### PR TITLE
React: useFetchCache hook for caching any api call for session duration

### DIFF
--- a/react/src/AddDatasets/components/DataEntryTable.tsx
+++ b/react/src/AddDatasets/components/DataEntryTable.tsx
@@ -33,7 +33,7 @@ import { Option, getOptions as _getOptions, getColumns, participantColumns } fro
 import { DataEntryActionCell, DataEntryCell, HeaderCell } from "./TableCells";
 import UploadDialog from "./UploadDialog";
 import { getDataEntryHeaders, createEmptyRows, setProp } from "../../functions";
-import { useEnums } from "../../contexts/enums";
+import { useFetchCache } from "../../contexts/fetchCache/FetchCacheProvider";
 
 export interface DataEntryTableProps {
     data: DataEntryRow[];
@@ -120,7 +120,7 @@ export default function DataEntryTable(props: DataEntryTableProps) {
 
     const [families, setFamilies] = useState<Family[]>([]);
     const [files, setFiles] = useState<string[]>([]);
-    const enums = useEnums();
+    const enums = useFetchCache("/api/enums");
 
     const [showRNA, setShowRNA] = useState<boolean>(false);
 

--- a/react/src/AddDatasets/components/DataEntryTable.tsx
+++ b/react/src/AddDatasets/components/DataEntryTable.tsx
@@ -33,7 +33,7 @@ import { Option, getOptions as _getOptions, getColumns, participantColumns } fro
 import { DataEntryActionCell, DataEntryCell, HeaderCell } from "./TableCells";
 import UploadDialog from "./UploadDialog";
 import { getDataEntryHeaders, createEmptyRows, setProp } from "../../functions";
-import { useFetchCache } from "../../contexts/fetchCache/FetchCacheProvider";
+import { useFetchCache } from "../../contexts/fetchCache";
 
 export interface DataEntryTableProps {
     data: DataEntryRow[];

--- a/react/src/Admin/components/CreateUserModal.tsx
+++ b/react/src/Admin/components/CreateUserModal.tsx
@@ -13,6 +13,7 @@ import {
 } from "@material-ui/core";
 import { Group, NewUser } from "../../typings";
 import GroupSelect from "./GroupSelect";
+import { useFetchCache } from "../../contexts/fetchCache";
 
 interface CreateUserState {
     username: string;
@@ -52,7 +53,6 @@ export interface CreateUserModalProps {
     open: boolean;
     onClose: () => void;
     onSuccess: (state: NewUser) => void;
-    groups: Group[];
 }
 
 const useStyles = makeStyles(theme => ({
@@ -104,6 +104,7 @@ export default function CreateUserModal(props: CreateUserModalProps) {
     const [submitting, setSubmitting] = useState(false);
     const [errorCode, setErrorCode] = useState(0);
     const [errorDetails, setErrorDetails] = useState({ error: "", message: "" });
+    const groups = (useFetchCache("/api/groups") || []) as Group[];
 
     // Reset on open/close as side effect
     useEffect(() => {
@@ -216,7 +217,7 @@ export default function CreateUserModal(props: CreateUserModalProps) {
                     helperText={passwordErrorText}
                 />
                 <GroupSelect
-                    groups={props.groups}
+                    groups={groups}
                     selected={state.groups}
                     onSelectionChange={selectedGroups =>
                         dispatch({ type: "set", groups: selectedGroups })

--- a/react/src/Admin/components/UserList.tsx
+++ b/react/src/Admin/components/UserList.tsx
@@ -12,10 +12,9 @@ import {
 } from "@material-ui/core";
 import { PersonAdd } from "@material-ui/icons";
 import { useSnackbar } from "notistack";
-import { User, NewUser, Group } from "../../typings";
+import { User, NewUser } from "../../typings";
 import UserRow from "./UserRow";
 import CreateUserModal from "./CreateUserModal";
-import { useFetchCache } from "../../contexts/fetchCache";
 
 async function updateUser(user: User) {
     return fetch("/api/users", {
@@ -88,7 +87,6 @@ function reducer(state: User[], action: AddUserAction | ChangeUserAction | SetUs
 export default function UserList() {
     const classes = useStyles();
     const [users, dispatch] = useReducer(reducer, []);
-    const groups = useFetchCache("/api/groups") as Group[];
     const [openNewUser, setOpenNewUser] = useState(false);
     const { enqueueSnackbar } = useSnackbar();
 
@@ -117,7 +115,6 @@ export default function UserList() {
                         variant: "success",
                     });
                 }}
-                groups={groups}
             />
             <Toolbar component={Paper} className={classes.toolbar}>
                 <Typography variant="h6">Users</Typography>
@@ -134,7 +131,6 @@ export default function UserList() {
                         <UserRow
                             key={user.username}
                             user={user}
-                            groups={groups}
                             onSave={newUser => {
                                 updateUser(newUser).then(async response => {
                                     const message = await response.text();

--- a/react/src/Admin/components/UserList.tsx
+++ b/react/src/Admin/components/UserList.tsx
@@ -15,6 +15,7 @@ import { useSnackbar } from "notistack";
 import { User, NewUser, Group } from "../../typings";
 import UserRow from "./UserRow";
 import CreateUserModal from "./CreateUserModal";
+import { useFetchCache } from "../../contexts/fetchCache";
 
 async function updateUser(user: User) {
     return fetch("/api/users", {
@@ -87,7 +88,7 @@ function reducer(state: User[], action: AddUserAction | ChangeUserAction | SetUs
 export default function UserList() {
     const classes = useStyles();
     const [users, dispatch] = useReducer(reducer, []);
-    const [groups, setGroups] = useState<Group[]>([]);
+    const groups = useFetchCache("/api/groups") as Group[];
     const [openNewUser, setOpenNewUser] = useState(false);
     const { enqueueSnackbar } = useSnackbar();
 
@@ -101,9 +102,6 @@ export default function UserList() {
                     payload: data,
                 })
             ); // No safety check on JSON structure
-        fetch("/api/groups")
-            .then(response => response.json())
-            .then(data => setGroups(data as Group[]));
     }, []);
 
     return (

--- a/react/src/Admin/components/UserRow.tsx
+++ b/react/src/Admin/components/UserRow.tsx
@@ -17,6 +17,7 @@ import { ExpandLess, ExpandMore, Person, PersonOutline, Security } from "@materi
 import { Group, User } from "../../typings";
 import UserDetails from "./UserDetails";
 import { LastLoginDisplay, ChipGroup, MinioKeys } from "../../components";
+import { useFetchCache } from "../../contexts/fetchCache";
 
 const useRowStyles = makeStyles<Theme, Boolean>(theme => ({
     button: {
@@ -37,7 +38,6 @@ const useRowStyles = makeStyles<Theme, Boolean>(theme => ({
  */
 export default function UserRow(props: {
     user: User;
-    groups: Group[];
     onSave: (newUser: User) => void;
     onDelete: (deleteUser: User) => void;
 }) {
@@ -46,6 +46,7 @@ export default function UserRow(props: {
     const [date, time] = new Date(props.user.last_login).toISOString().split(/[T|.]/);
     const [open, setOpen] = useState(false);
     const [loading, setLoading] = useState(false);
+    const groups = useFetchCache("/api/groups") || ([] as Group[]);
 
     // MinIO keys get fetched once when the user opens the dropdown
     useEffect(() => {
@@ -126,7 +127,7 @@ export default function UserRow(props: {
                     <Divider />
                     <UserDetails
                         user={user}
-                        groups={props.groups}
+                        groups={groups}
                         onSave={props.onSave}
                         onDelete={props.onDelete}
                         loading={loading}

--- a/react/src/App.tsx
+++ b/react/src/App.tsx
@@ -5,7 +5,7 @@ import { SnackbarKey, SnackbarProvider } from "notistack";
 
 import LoginForm from "./Login";
 import Navigation from "./Navigation";
-import FetchCacheProvider from "./contexts/fetchCache/FetchCacheProvider";
+import { FetchCacheProvider } from "./contexts/fetchCache";
 
 const notistackRef = React.createRef<SnackbarProvider>();
 const onClickDismiss = (key: SnackbarKey) => () => {

--- a/react/src/App.tsx
+++ b/react/src/App.tsx
@@ -5,7 +5,7 @@ import { SnackbarKey, SnackbarProvider } from "notistack";
 
 import LoginForm from "./Login";
 import Navigation from "./Navigation";
-import { EnumProvider } from "./contexts/enums";
+import FetchCacheProvider from "./contexts/fetchCache/FetchCacheProvider";
 
 const notistackRef = React.createRef<SnackbarProvider>();
 const onClickDismiss = (key: SnackbarKey) => () => {
@@ -45,7 +45,7 @@ function BaseApp(props: { darkMode: boolean; toggleDarkMode: () => void }) {
         return <></>;
     } else if (authenticated) {
         return (
-            <EnumProvider>
+            <FetchCacheProvider>
                 <SnackbarProvider
                     ref={notistackRef}
                     action={key => (
@@ -72,7 +72,7 @@ function BaseApp(props: { darkMode: boolean; toggleDarkMode: () => void }) {
                         isAdmin={isAdmin}
                     />
                 </SnackbarProvider>
-            </EnumProvider>
+            </FetchCacheProvider>
         );
     } else {
         return (

--- a/react/src/Datasets/components/DatasetInfoDialog.tsx
+++ b/react/src/Datasets/components/DatasetInfoDialog.tsx
@@ -11,7 +11,7 @@ import {
     getSecDatasetFields,
     createFieldObj,
 } from "../../functions";
-import { useFetchCache } from "../../contexts/fetchCache/FetchCacheProvider";
+import { useFetchCache } from "../../contexts/fetchCache";
 
 const useStyles = makeStyles(theme => ({
     datasetInfo: {

--- a/react/src/Datasets/components/DatasetInfoDialog.tsx
+++ b/react/src/Datasets/components/DatasetInfoDialog.tsx
@@ -11,7 +11,7 @@ import {
     getSecDatasetFields,
     createFieldObj,
 } from "../../functions";
-import { useEnums } from "../../contexts/enums";
+import { useFetchCache } from "../../contexts/fetchCache/FetchCacheProvider";
 
 const useStyles = makeStyles(theme => ({
     datasetInfo: {
@@ -51,7 +51,7 @@ export default function DatasetInfoDialog(props: DialogProp) {
     const [analyses, setAnalyses] = useState<Analysis[]>([]);
     const [sample, setSample] = useState<Sample>();
 
-    const enums = useEnums();
+    const enums = useFetchCache("/api/enums");
 
     useEffect(() => {
         fetch("/api/datasets/" + props.dataset.dataset_id)

--- a/react/src/Datasets/components/DatasetTable.tsx
+++ b/react/src/Datasets/components/DatasetTable.tsx
@@ -10,7 +10,7 @@ import { KeyValue, Dataset, Pipeline } from "../../typings";
 import AnalysisRunnerDialog from "./AnalysisRunnerDialog";
 import DatasetInfoDialog from "./DatasetInfoDialog";
 import { Note } from "../../components";
-import { useEnums } from "../../contexts/enums";
+import { useFetchCache } from "../../contexts/fetchCache/FetchCacheProvider";
 
 const useStyles = makeStyles(theme => ({
     chip: {
@@ -37,7 +37,7 @@ export default function DatasetTable({ isAdmin }: DatasetTableProps) {
     const [datasets, setDatasets] = useState<Dataset[]>([]);
     const [pipelines, setPipelines] = useState<Pipeline[]>([]);
 
-    const enums = useEnums();
+    const enums = useFetchCache("/api/enums");
     let tissueSampleTypes: KeyValue = {};
     let datasetTypes: KeyValue = {};
     let conditions: KeyValue = {};

--- a/react/src/Datasets/components/DatasetTable.tsx
+++ b/react/src/Datasets/components/DatasetTable.tsx
@@ -10,7 +10,7 @@ import { KeyValue, Dataset, Pipeline } from "../../typings";
 import AnalysisRunnerDialog from "./AnalysisRunnerDialog";
 import DatasetInfoDialog from "./DatasetInfoDialog";
 import { Note } from "../../components";
-import { useFetchCache } from "../../contexts/fetchCache/FetchCacheProvider";
+import { useFetchCache } from "../../contexts/fetchCache";
 
 const useStyles = makeStyles(theme => ({
     chip: {

--- a/react/src/Participants/components/ParticipantInfoDialog.tsx
+++ b/react/src/Participants/components/ParticipantInfoDialog.tsx
@@ -11,7 +11,7 @@ import {
 import { Participant, Analysis, Field } from "../../typings";
 import { DialogHeader, DetailSection, InfoList } from "../../components";
 import SampleTable from "./SampleTable";
-import { useEnums } from "../../contexts/enums";
+import { useFetchCache } from "../../contexts/fetchCache/FetchCacheProvider";
 
 const useStyles = makeStyles(theme => ({
     dialogContent: {
@@ -51,7 +51,7 @@ export default function ParticipantInfoDialog(props: DialogProp) {
     const labeledBy = "participant-info-dialog-slide-title";
     const [analyses, setAnalyses] = useState<Analysis[]>([]);
     const { enqueueSnackbar } = useSnackbar();
-    const enums = useEnums();
+    const enums = useFetchCache("/api/enums");
 
     useEffect(() => {
         (async () => {

--- a/react/src/Participants/components/ParticipantInfoDialog.tsx
+++ b/react/src/Participants/components/ParticipantInfoDialog.tsx
@@ -11,7 +11,7 @@ import {
 import { Participant, Analysis, Field } from "../../typings";
 import { DialogHeader, DetailSection, InfoList } from "../../components";
 import SampleTable from "./SampleTable";
-import { useFetchCache } from "../../contexts/fetchCache/FetchCacheProvider";
+import { useFetchCache } from "../../contexts/fetchCache";
 
 const useStyles = makeStyles(theme => ({
     dialogContent: {

--- a/react/src/Participants/components/ParticipantTable.tsx
+++ b/react/src/Participants/components/ParticipantTable.tsx
@@ -9,7 +9,7 @@ import { KeyValue, Participant } from "../../typings";
 import DatasetTypes from "./DatasetTypes";
 import ParticipantInfoDialog from "./ParticipantInfoDialog";
 import { Note, BooleanDisplay, BooleanEditComponent, BooleanFilter } from "../../components";
-import { useFetchCache } from "../../contexts/fetchCache/FetchCacheProvider";
+import { useFetchCache } from "../../contexts/fetchCache";
 
 export default function ParticipantTable() {
     const [participants, setParticipants] = useState<Participant[]>([]);

--- a/react/src/Participants/components/ParticipantTable.tsx
+++ b/react/src/Participants/components/ParticipantTable.tsx
@@ -9,13 +9,13 @@ import { KeyValue, Participant } from "../../typings";
 import DatasetTypes from "./DatasetTypes";
 import ParticipantInfoDialog from "./ParticipantInfoDialog";
 import { Note, BooleanDisplay, BooleanEditComponent, BooleanFilter } from "../../components";
-import { useEnums } from "../../contexts/enums";
+import { useFetchCache } from "../../contexts/fetchCache/FetchCacheProvider";
 
 export default function ParticipantTable() {
     const [participants, setParticipants] = useState<Participant[]>([]);
     const [detail, setDetail] = useState(false);
     const [activeRow, setActiveRow] = useState<Participant | undefined>(undefined);
-    const enums = useEnums();
+    const enums = useFetchCache("/api/enums");
     let sexTypes: KeyValue = {};
     let datasetTypes: KeyValue = {};
     let participantTypes: KeyValue = {};

--- a/react/src/components/AnalysisInfoDialog.tsx
+++ b/react/src/components/AnalysisInfoDialog.tsx
@@ -7,7 +7,7 @@ import { Analysis, Dataset, Pipeline } from "../typings";
 import DialogHeader from "./DialogHeader";
 import DetailSection from "./DetailSection";
 import InfoList from "./InfoList";
-import { useFetchCache } from "../contexts/fetchCache/FetchCacheProvider";
+import { useFetchCache } from "../contexts/fetchCache";
 
 const useStyles = makeStyles(theme => ({
     dialogContent: {

--- a/react/src/components/AnalysisInfoDialog.tsx
+++ b/react/src/components/AnalysisInfoDialog.tsx
@@ -7,7 +7,7 @@ import { Analysis, Dataset, Pipeline } from "../typings";
 import DialogHeader from "./DialogHeader";
 import DetailSection from "./DetailSection";
 import InfoList from "./InfoList";
-import { useEnums } from "../contexts/enums";
+import { useFetchCache } from "../contexts/fetchCache/FetchCacheProvider";
 
 const useStyles = makeStyles(theme => ({
     dialogContent: {
@@ -46,7 +46,7 @@ export default function AnalysisInfoDialog(props: AlertInfoDialogProp) {
     const [datasets, setDatasets] = useState<Dataset[]>([]);
     const [pipeline, setPipeline] = useState<Pipeline>();
     const labeledBy = "analysis-info-dialog-slide-title";
-    const enums = useEnums();
+    const enums = useFetchCache("/api/enums");
 
     useEffect(() => {
         fetch("/api/analyses/" + props.analysis.analysis_id)

--- a/react/src/contexts/EnumContext.tsx
+++ b/react/src/contexts/EnumContext.tsx
@@ -1,0 +1,6 @@
+import { createContext } from "react";
+import { KeyValue } from "../typings";
+
+type Enum = KeyValue | undefined;
+
+export default createContext<Enum>(undefined);

--- a/react/src/contexts/EnumProvider.tsx
+++ b/react/src/contexts/EnumProvider.tsx
@@ -1,0 +1,23 @@
+import React, { useEffect, useState } from "react";
+import { KeyValue } from "../typings";
+import EnumContext from "./EnumContext";
+
+export function EnumProvider(props: { children: React.ReactNode }) {
+    // The enum cache is a react state kept here
+    const [enums, setEnums] = useState<KeyValue>();
+
+    useEffect(() => {
+        fetch("/api/enums").then(async response => {
+            if (response.ok) {
+                const data = await response.json();
+                setEnums(data as KeyValue);
+            } else {
+                console.error(
+                    `GET /api/enums failed with ${response.status}: ${response.statusText}`
+                );
+            }
+        });
+    }, []);
+
+    return <EnumContext.Provider value={enums}>{props.children}</EnumContext.Provider>;
+}

--- a/react/src/contexts/fetchCache/FetchCacheContext.tsx
+++ b/react/src/contexts/fetchCache/FetchCacheContext.tsx
@@ -1,0 +1,11 @@
+import { createContext } from "react";
+
+type ClientContextType = (url: string) => void;
+
+// Value is a function that updates the url to fetch/page cache for
+const ClientContext = createContext<ClientContextType>(() => {});
+
+// Value is the result of a fetch or cache page for a url
+const ResultContext = createContext<any>({});
+
+export { ClientContext, ResultContext };

--- a/react/src/contexts/fetchCache/FetchCacheProvider.tsx
+++ b/react/src/contexts/fetchCache/FetchCacheProvider.tsx
@@ -6,21 +6,32 @@ import { ClientContext, ResultContext } from "./FetchCacheContext";
  */
 export function FetchCacheProvider(props: { children: React.ReactNode }) {
     const [url, setURL] = useState("");
-    const [cachedResult, setCachedResult] = useState<any>();
+    const [cache, setCache] = useState<{ [url: string]: any }>({});
 
+    // Problem: If you ask for resource B when you already asked for resource A,
+    // the hook gives resource A back for a split-second while resource B gets
+    // fetched.
     useEffect(() => {
+        function updateCache(key: string, value: any) {
+            setCache(oldCache => {
+                const newCache = { ...oldCache };
+                newCache[key] = value;
+                return newCache;
+            });
+        }
+
         // use url as cache key
         const stored = sessionStorage.getItem(url);
         if (stored) {
             // hit, no fetch
-            setCachedResult(JSON.parse(stored));
+            updateCache(url, JSON.parse(stored));
         } else {
             // miss, refetch
             fetch(url).then(async response => {
                 if (response.ok) {
                     const data = await response.json();
                     sessionStorage.setItem(url, JSON.stringify(data));
-                    setCachedResult(data);
+                    updateCache(url, data);
                 } else {
                     console.error(
                         `GET ${url} failed with response ${response.status} - ${response.statusText}`
@@ -34,7 +45,7 @@ export function FetchCacheProvider(props: { children: React.ReactNode }) {
     // and retrieve result via ResultContext
     return (
         <ClientContext.Provider value={setURL}>
-            <ResultContext.Provider value={cachedResult}>{props.children}</ResultContext.Provider>
+            <ResultContext.Provider value={cache}>{props.children}</ResultContext.Provider>
         </ClientContext.Provider>
     );
 }

--- a/react/src/contexts/fetchCache/FetchCacheProvider.tsx
+++ b/react/src/contexts/fetchCache/FetchCacheProvider.tsx
@@ -1,0 +1,43 @@
+import React, { createContext, useContext, useEffect, useState } from "react";
+
+type ClientContextType = (url: string) => void;
+
+const ClientContext = createContext<ClientContextType>(() => {});
+const ResultContext = createContext<any>({});
+
+export default function FetchCacheProvider(props: { children: React.ReactNode }) {
+    const [url, setURL] = useState("");
+    const [cachedResult, setCachedResult] = useState<any>();
+
+    useEffect(() => {
+        const stored = sessionStorage.getItem(url);
+        if (stored) {
+            // hit, no fetch
+            setCachedResult(JSON.parse(stored));
+        } else {
+            // miss, refetch
+            fetch(url).then(async response => {
+                if (response.ok) {
+                    const data = await response.json();
+                    sessionStorage.setItem(url, JSON.stringify(data));
+                    setCachedResult(data);
+                } else {
+                    console.error(
+                        `GET ${url} failed with response ${response.status} - ${response.statusText}`
+                    );
+                }
+            });
+        }
+    }, [url]);
+
+    return (
+        <ClientContext.Provider value={setURL}>
+            <ResultContext.Provider value={cachedResult}>{props.children}</ResultContext.Provider>
+        </ClientContext.Provider>
+    );
+}
+
+export function useFetchCache(url: string) {
+    useContext(ClientContext)(url);
+    return useContext(ResultContext);
+}

--- a/react/src/contexts/fetchCache/FetchCacheProvider.tsx
+++ b/react/src/contexts/fetchCache/FetchCacheProvider.tsx
@@ -5,11 +5,15 @@ type ClientContextType = (url: string) => void;
 const ClientContext = createContext<ClientContextType>(() => {});
 const ResultContext = createContext<any>({});
 
+/**
+ * Provider for useFetchCache hook.
+ */
 export default function FetchCacheProvider(props: { children: React.ReactNode }) {
     const [url, setURL] = useState("");
     const [cachedResult, setCachedResult] = useState<any>();
 
     useEffect(() => {
+        // use url as cache key
         const stored = sessionStorage.getItem(url);
         if (stored) {
             // hit, no fetch
@@ -30,6 +34,8 @@ export default function FetchCacheProvider(props: { children: React.ReactNode })
         }
     }, [url]);
 
+    // Nested providers so that we can pass in URL via ClientContext,
+    // and retrieve result via ResultContext
     return (
         <ClientContext.Provider value={setURL}>
             <ResultContext.Provider value={cachedResult}>{props.children}</ResultContext.Provider>
@@ -37,6 +43,10 @@ export default function FetchCacheProvider(props: { children: React.ReactNode })
     );
 }
 
+/**
+ * Given an API url, caches and returns the result of
+ * that API call. Cached result expires when the session ends.
+ */
 export function useFetchCache(url: string) {
     useContext(ClientContext)(url);
     return useContext(ResultContext);

--- a/react/src/contexts/fetchCache/FetchCacheProvider.tsx
+++ b/react/src/contexts/fetchCache/FetchCacheProvider.tsx
@@ -1,14 +1,10 @@
-import React, { createContext, useContext, useEffect, useState } from "react";
-
-type ClientContextType = (url: string) => void;
-
-const ClientContext = createContext<ClientContextType>(() => {});
-const ResultContext = createContext<any>({});
+import React, { useEffect, useState } from "react";
+import { ClientContext, ResultContext } from "./FetchCacheContext";
 
 /**
  * Provider for useFetchCache hook.
  */
-export default function FetchCacheProvider(props: { children: React.ReactNode }) {
+export function FetchCacheProvider(props: { children: React.ReactNode }) {
     const [url, setURL] = useState("");
     const [cachedResult, setCachedResult] = useState<any>();
 
@@ -41,13 +37,4 @@ export default function FetchCacheProvider(props: { children: React.ReactNode })
             <ResultContext.Provider value={cachedResult}>{props.children}</ResultContext.Provider>
         </ClientContext.Provider>
     );
-}
-
-/**
- * Given an API url, caches and returns the result of
- * that API call. Cached result expires when the session ends.
- */
-export function useFetchCache(url: string) {
-    useContext(ClientContext)(url);
-    return useContext(ResultContext);
 }

--- a/react/src/contexts/fetchCache/index.tsx
+++ b/react/src/contexts/fetchCache/index.tsx
@@ -1,0 +1,2 @@
+export { useFetchCache } from "./useFetchCache";
+export { FetchCacheProvider } from "./FetchCacheProvider";

--- a/react/src/contexts/fetchCache/useFetchCache.tsx
+++ b/react/src/contexts/fetchCache/useFetchCache.tsx
@@ -9,5 +9,5 @@ import { ClientContext, ResultContext } from "./FetchCacheContext";
 export function useFetchCache(url: string) {
     useContext(ClientContext)(url);
     const result = useContext(ResultContext);
-    return result ? (result[url] ? result[url] : undefined) : undefined;
+    return result && result[url];
 }

--- a/react/src/contexts/fetchCache/useFetchCache.tsx
+++ b/react/src/contexts/fetchCache/useFetchCache.tsx
@@ -1,0 +1,12 @@
+import { useContext } from "react";
+import { ClientContext, ResultContext } from "./FetchCacheContext";
+
+/**
+ * Hook that returns the JSON response from
+ * GET-ing the provided url. Result is cached and
+ * reused. Cache expires on session end.
+ */
+export function useFetchCache(url: string) {
+    useContext(ClientContext)(url);
+    return useContext(ResultContext);
+}

--- a/react/src/contexts/fetchCache/useFetchCache.tsx
+++ b/react/src/contexts/fetchCache/useFetchCache.tsx
@@ -8,5 +8,6 @@ import { ClientContext, ResultContext } from "./FetchCacheContext";
  */
 export function useFetchCache(url: string) {
     useContext(ClientContext)(url);
-    return useContext(ResultContext);
+    const result = useContext(ResultContext);
+    return result ? (result[url] ? result[url] : undefined) : undefined;
 }

--- a/react/src/contexts/useEnums.tsx
+++ b/react/src/contexts/useEnums.tsx
@@ -1,0 +1,4 @@
+import { useContext } from "react";
+import EnumContext from "./EnumContext";
+
+export default () => useContext(EnumContext);


### PR DESCRIPTION
Closes #277. 
API calls made through `useFetchCache` are only fetched once, and taken from cache for every subsequent call. This may cause issues later for calls like `/api/groups` which can be updated during a session, so we should revisit this later and use a library like react-query to save the hassle of setting up refetch policies from scratch.