### PR TITLE
React: Fix material-table filters being deleted upon first typing

### DIFF
--- a/react/src/Analyses/index.tsx
+++ b/react/src/Analyses/index.tsx
@@ -157,7 +157,6 @@ export default function Analyses() {
 
     const { enqueueSnackbar } = useSnackbar();
     const { id: paramID } = useParams<{ id: string }>();
-    const [paramFilter, setParamFilter] = useState(paramID);
 
     useEffect(() => {
         document.title = `Analyses | ${process.env.REACT_APP_NAME}`;
@@ -306,7 +305,7 @@ export default function Analyses() {
                             type: "string",
                             editable: "never",
                             width: "8%",
-                            defaultFilter: paramFilter,
+                            defaultFilter: paramID,
                         },
                         {
                             title: "Pipeline",
@@ -609,12 +608,6 @@ export default function Analyses() {
                         header: {
                             actions: "", //remove action buttons' header
                         },
-                    }}
-                    onFilterChange={filters => {
-                        const newValue = filters.find(
-                            filter => filter.column.field === "analysis_id"
-                        )?.value;
-                        setParamFilter(newValue ? newValue : "");
                     }}
                 />
             </Container>

--- a/react/src/Datasets/components/DatasetTable.tsx
+++ b/react/src/Datasets/components/DatasetTable.tsx
@@ -55,7 +55,6 @@ export default function DatasetTable({ isAdmin }: DatasetTableProps) {
     const { enqueueSnackbar } = useSnackbar();
 
     const { id: paramID } = useParams<{ id?: string }>();
-    const [paramFilter, setParamFilter] = useState(paramID);
 
     useEffect(() => {
         fetch("/api/datasets").then(async response => {
@@ -183,7 +182,7 @@ export default function DatasetTable({ isAdmin }: DatasetTableProps) {
                         title: "ID",
                         field: "dataset_id",
                         editable: "never",
-                        defaultFilter: paramFilter,
+                        defaultFilter: paramID,
                     },
                 ]}
                 data={datasets}
@@ -309,11 +308,6 @@ export default function DatasetTable({ isAdmin }: DatasetTableProps) {
                     header: {
                         actions: "", //remove action buttons' header
                     },
-                }}
-                onFilterChange={filters => {
-                    const newValue = filters.find(filter => filter.column.field === "analysis_id")
-                        ?.value;
-                    setParamFilter(newValue ? newValue : "");
                 }}
             />
         </div>


### PR DESCRIPTION
Quick fix for this weird behaviour. 

There is still a bug where the page re-renders when you open/close the Drawer, or when you click the dark mode switch on the AppBar. My guess is it's related to how the routes are rendered or something, but I haven't figured it out.