### PR TITLE
React: Fix empty string check in Add Datasets

### DIFF
--- a/react/src/AddDatasets/components/DataEntryTable.tsx
+++ b/react/src/AddDatasets/components/DataEntryTable.tsx
@@ -29,12 +29,7 @@ import {
     OpenInNew,
 } from "@material-ui/icons";
 import { DataEntryHeader, DataEntryRow, DataEntryRowOptional, Family, Option } from "../../typings";
-import {
-    getOptions as _getOptions,
-    getColumns,
-    participantColumns,
-    checkParticipant,
-} from "./utils";
+import { getOptions as _getOptions, getColumns, participantColumns } from "./utils";
 import { DataEntryActionCell, DataEntryCell, HeaderCell } from "./TableCells";
 import UploadDialog from "./UploadDialog";
 import { getDataEntryHeaders, createEmptyRows, setProp } from "../../functions";
@@ -175,9 +170,9 @@ export default function DataEntryTable(props: DataEntryTableProps) {
         const newRows = props.data.map((value, index) => {
             if (autopopulate && index === rowIndex) {
                 // autopopulate row
+                // pre-existing rows are disabled, even if the values are wrong
                 const participant = findParticipant(newValue as string, col.field, value, families);
-                const isValid = participant ? checkParticipant(participant, enums) : false;
-                if (participant && isValid) {
+                if (participant) {
                     // pre-existing participant
                     return setProp(
                         participantColumns.reduce(
@@ -301,12 +296,10 @@ export default function DataEntryTable(props: DataEntryTableProps) {
                                             onEdit(newValue, rowIndex, col, autocomplete)
                                         }
                                         key={col.field}
-                                        required
+                                        required={!row.participantColDisabled} // not required if pre-filled
                                         disabled={
                                             row.participantColDisabled &&
-                                            !!participantColumns.find(
-                                                currCol => currCol === col.field
-                                            )
+                                            (participantColumns as string[]).includes(col.field)
                                         }
                                     />
                                 ))}

--- a/react/src/AddDatasets/components/DataEntryTable.tsx
+++ b/react/src/AddDatasets/components/DataEntryTable.tsx
@@ -29,7 +29,12 @@ import {
     OpenInNew,
 } from "@material-ui/icons";
 import { DataEntryHeader, DataEntryRow, DataEntryRowOptional, Family, Option } from "../../typings";
-import { getOptions as _getOptions, getColumns, participantColumns } from "./utils";
+import {
+    getOptions as _getOptions,
+    getColumns,
+    participantColumns,
+    checkParticipant,
+} from "./utils";
 import { DataEntryActionCell, DataEntryCell, HeaderCell } from "./TableCells";
 import UploadDialog from "./UploadDialog";
 import { getDataEntryHeaders, createEmptyRows, setProp } from "../../functions";
@@ -169,17 +174,21 @@ export default function DataEntryTable(props: DataEntryTableProps) {
         }
         const newRows = props.data.map((value, index) => {
             if (autopopulate && index === rowIndex) {
+                // autopopulate row
                 const participant = findParticipant(newValue as string, col.field, value, families);
-                if (participant) {
+                const isValid = participant ? checkParticipant(participant, enums) : false;
+                if (participant && isValid) {
+                    // pre-existing participant
                     return setProp(
                         participantColumns.reduce(
-                            (row, currCol) => setProp(row, currCol, participant[currCol]),
-                            setProp({ ...value }, "participantColDisabled", true)
+                            (row, currCol) => setProp(row, currCol, participant[currCol]), // reducer
+                            setProp({ ...value }, "participantColDisabled", true) // init
                         ),
                         col.field,
                         newValue
                     );
                 } else {
+                    // No participant found
                     return setProp(
                         setProp({ ...value }, "participantColDisabled", false),
                         col.field,

--- a/react/src/AddDatasets/components/TableCells.tsx
+++ b/react/src/AddDatasets/components/TableCells.tsx
@@ -13,6 +13,7 @@ import { Resizable } from "re-resizable";
 import { DataEntryHeader, DataEntryRow, Option } from "../../typings";
 import FileLinkingComponent from "../../components/FileLinkingComponent";
 import { toOption, booleanColumns, dateColumns, enumerableColumns } from "./utils";
+import { strIsEmpty } from "../../functions";
 
 const useCellStyles = makeStyles(theme => ({
     textField: {
@@ -111,8 +112,7 @@ export function AutocompleteCell(
             arr.findIndex((opt, i) => opt.inputValue === val.inputValue) === index &&
             val.inputValue !== props.value.inputValue
     );
-
-    const isError = props.required && props.value.inputValue.trim() === "";
+    const isError = props.required && strIsEmpty(props.value.inputValue);
 
     return (
         <TableCell>

--- a/react/src/AddDatasets/components/utils.tsx
+++ b/react/src/AddDatasets/components/utils.tsx
@@ -1,5 +1,5 @@
-import { DataEntryHeader, DataEntryRow, Family, Option } from "../../typings";
-import { getDataEntryHeaders, snakeCaseToTitle } from "../../functions";
+import { DataEntryHeader, DataEntryRow, Family, Option, Participant } from "../../typings";
+import { getDataEntryHeaders, snakeCaseToTitle, strIsEmpty } from "../../functions";
 
 export const booleanColumns: Array<keyof DataEntryRow> = ["affected", "solved"];
 export const dateColumns: Array<keyof DataEntryRow> = ["sequencing_date"];
@@ -175,4 +175,43 @@ export function getOptions(
         default:
             return rowOptions;
     }
+}
+
+/**
+ * Checks if a pre-existing participant has valid values, and should be disabled.
+ * Return true if valid, false otherwise.
+ * @param participant The pre-existing participant in question.
+ * @param enums The result from /api/enums
+ */
+export function checkParticipant(participant: Participant, enums: any): boolean {
+    const required: string[] = getDataEntryHeaders().required;
+
+    return participantColumns.every(column => {
+        if (required.includes(column)) {
+            // required columns should be checked to be valid
+
+            const index = snakeToTitle(column);
+            // must be defined
+            if (!participant[column]) return false;
+
+            if (enumerableColumns.includes(column)) {
+                // if enumerable, must be valid value
+                return enums[index].includes(participant[column]);
+            } else if (booleanColumns.includes(column)) {
+                return ["true", "false"].includes(participant[column]);
+            } else {
+                return !strIsEmpty(participant[column]);
+            }
+        } else {
+            // optional columns are fine
+            return true;
+        }
+    });
+}
+
+function snakeToTitle(str: string): string {
+    return str
+        .split("_")
+        .map(word => word.substring(0, 1).toUpperCase() + word.substring(1))
+        .join("");
 }

--- a/react/src/AddDatasets/index.tsx
+++ b/react/src/AddDatasets/index.tsx
@@ -6,7 +6,7 @@ import { useSnackbar } from "notistack";
 import DataEntryTable from "./components/DataEntryTable";
 import { DataEntryRow, DataEntryRowBase } from "../typings";
 import { ConfirmModal } from "../components";
-import { createEmptyRows, getDataEntryHeaders } from "../functions";
+import { createEmptyRows, getDataEntryHeaders, strIsEmpty } from "../functions";
 
 const useStyles = makeStyles(theme => ({
     appBarSpacer: theme.mixins.toolbar,
@@ -76,7 +76,7 @@ export default function AddParticipants(props: {
             let row = data[i];
             for (const field of headers.required) {
                 // Condition for a row being 'problematic'
-                if (row[field].trim() === "") {
+                if (strIsEmpty(row[field])) {
                     if (problemRows.get(i)) problemRows.set(i, problemRows.get(i)!.concat(field));
                     else problemRows.set(i, [field]);
                 }

--- a/react/src/AddDatasets/index.tsx
+++ b/react/src/AddDatasets/index.tsx
@@ -7,6 +7,7 @@ import DataEntryTable from "./components/DataEntryTable";
 import { DataEntryRow, DataEntryRowBase } from "../typings";
 import { ConfirmModal } from "../components";
 import { createEmptyRows, getDataEntryHeaders, strIsEmpty } from "../functions";
+import { participantColumns } from "./components/utils";
 
 const useStyles = makeStyles(theme => ({
     appBarSpacer: theme.mixins.toolbar,
@@ -76,6 +77,11 @@ export default function AddParticipants(props: {
             let row = data[i];
             for (const field of headers.required) {
                 // Condition for a row being 'problematic'
+
+                // required rows that are pre-filled are allowed to be wrong
+                if (row.participantColDisabled && (participantColumns as string[]).includes(field))
+                    continue;
+
                 if (strIsEmpty(row[field])) {
                     if (problemRows.get(i)) problemRows.set(i, problemRows.get(i)!.concat(field));
                     else problemRows.set(i, [field]);

--- a/react/src/functions.tsx
+++ b/react/src/functions.tsx
@@ -344,9 +344,9 @@ export function formatFieldValue(value: FieldDisplayValueType, nullUnknown: bool
 }
 
 /**
- * Return true if the string contains non-whitespace characters, false otherwise.
+ * Return true if the string is empty or contains only whitespace, false otherwise.
  */
 export function strIsEmpty(str?: string): boolean {
     const testRegex = /\S/g;
-    return str ? testRegex.test(str) : false;
+    return str ? !testRegex.test(str) : true;
 }

--- a/react/src/functions.tsx
+++ b/react/src/functions.tsx
@@ -342,3 +342,11 @@ export function formatFieldValue(value: FieldDisplayValueType, nullUnknown: bool
         val = PseudoBooleanReadableMap[("" + value) as PseudoBoolean];
     return val;
 }
+
+/**
+ * Return true if the string contains non-whitespace characters, false otherwise.
+ */
+export function strIsEmpty(str?: string): boolean {
+    const testRegex = /\S/g;
+    return str ? testRegex.test(str) : false;
+}


### PR DESCRIPTION
I was not able to reproduce the bug, but seeing as calling `.trim(...)` requires the string to be defined, I replaced it with a helper function that checks if undefined and tests the string using `RegEx.test`.