### PR TITLE
React: Fix permission group dropdown defaults in Add Datasets

### DIFF
--- a/react/src/AddDatasets/index.tsx
+++ b/react/src/AddDatasets/index.tsx
@@ -45,7 +45,7 @@ export default function AddParticipants(props: {
     }, []);
 
     useEffect(() => {
-        if (props.groups.length > 0) {
+        if (props.groups.length === 1) {
             setAsGroups(props.groups);
         }
     }, [props.groups]);


### PR DESCRIPTION
Closes #310 

- Users in only one group will be automatically filled in
- Users in multiple groups will start with no group selected to prevent mistakes