### PR TITLE
Flask: add GET /api/metadatasettypes

### DIFF
--- a/flask/app/routes.py
+++ b/flask/app/routes.py
@@ -113,6 +113,20 @@ def pipelines_list():
     return jsonify(db_pipelines)
 
 
+@routes.route("/api/metadatasettypes", methods=["GET"])
+@login_required
+def get_metadataset_types():
+
+    metadataset_dataset_types = models.MetaDatasetType_DatasetType.query.all()
+
+    d = {e.metadataset_type: [] for e in metadataset_dataset_types}
+
+    for k in metadataset_dataset_types:
+        d[k.metadataset_type].append(k.dataset_type)
+
+    return jsonify(d)
+
+
 @routes.route("/api/enums", methods=["GET"])
 @login_required
 def get_enums():

--- a/flask/tests/conftest.py
+++ b/flask/tests/conftest.py
@@ -60,6 +60,48 @@ def client(application):
 
 @pytest.fixture
 def test_database(client):
+
+    dataset_types = [
+        "RES",
+        "CES",
+        "WES",
+        "CPS",
+        "RCS",
+        "RDC",
+        "RDE",
+        "RGS",
+        "CGS",
+        "WGS",
+        "RRS",
+        "RLM",
+        "RMM",
+        "RTA",
+    ]
+
+    for d in dataset_types:
+        db.session.add(DatasetType(dataset_type=d))
+    db.session.flush()
+
+    metadataset_types = ["Genome", "Exome", "RNA", "Other"]
+
+    for m in metadataset_types:
+        db.session.add(MetaDatasetType(metadataset_type=m))
+    db.session.flush()
+
+    md_d = {
+        "Exome": ["RES", "CES", "WES", "CPS", "RCS", "RDC", "RDE"],
+        "Genome": ["RGS", "CGS", "WGS"],
+        "Other": ["RLM", "RMM", "RTA"],
+        "RNA": ["RRS"],
+    }
+
+    for k in md_d:
+        for dataset in md_d[k]:
+            db.session.add(
+                MetaDatasetType_DatasetType(metadataset_type=k, dataset_type=dataset)
+            )
+    db.session.flush()
+
     group = Group(group_code="ach", group_name="Alberta")
     db.session.add(group)
     db.session.flush()
@@ -97,9 +139,6 @@ def test_database(client):
 
     wes = DatasetType(dataset_type="WES")
     wgs = DatasetType(dataset_type="WGS")
-    db.session.add(wes)
-    db.session.add(wgs)
-    db.session.flush()
 
     pipeline_1 = Pipeline(pipeline_name="CRG", pipeline_version="1.2")
     db.session.add(pipeline_1)

--- a/flask/tests/conftest.py
+++ b/flask/tests/conftest.py
@@ -137,9 +137,6 @@ def test_database(client):
     db.session.add(user_b)
     db.session.flush()
 
-    wes = DatasetType(dataset_type="WES")
-    wgs = DatasetType(dataset_type="WGS")
-
     pipeline_1 = Pipeline(pipeline_name="CRG", pipeline_version="1.2")
     db.session.add(pipeline_1)
     db.session.flush()
@@ -172,7 +169,7 @@ def test_database(client):
     participant_1.tissue_samples.append(sample_1)
 
     dataset_1 = Dataset(
-        dataset_type=wes.dataset_type,
+        dataset_type="WES",
         condition=DatasetCondition.Somatic,
         created_by_id=admin.user_id,
         updated_by_id=admin.user_id,
@@ -180,7 +177,7 @@ def test_database(client):
     sample_1.datasets.append(dataset_1)
 
     dataset_2 = Dataset(
-        dataset_type=wgs.dataset_type,
+        dataset_type="WGS",
         condition=DatasetCondition.Somatic,
         created_by_id=admin.user_id,
         updated_by_id=admin.user_id,
@@ -206,7 +203,7 @@ def test_database(client):
     participant_2.tissue_samples.append(sample_2)
 
     dataset_3 = Dataset(
-        dataset_type=wes.dataset_type,
+        dataset_type="WES",
         condition=DatasetCondition.Somatic,
         created_by_id=admin.user_id,
         updated_by_id=admin.user_id,
@@ -265,7 +262,7 @@ def test_database(client):
     participant_3.tissue_samples.append(sample_3)
 
     dataset_4 = Dataset(
-        dataset_type=wgs.dataset_type,
+        dataset_type="WGS",
         condition=DatasetCondition.Somatic,
         created_by_id=admin.user_id,
         updated_by_id=admin.user_id,

--- a/flask/tests/test_misc.py
+++ b/flask/tests/test_misc.py
@@ -27,6 +27,16 @@ def test_get_enums(test_database, client, login_as):
         assert enumType is not None
 
 
+# GET /api/metadatasettypes
+def test_get_metadatasettypes(test_database, client, login_as):
+    login_as("admin")
+    response = client.get("/api/metadatasettypes")
+    assert response.status_code == 200
+    assert len(response.get_json()) == 4
+    for metadataset_type, _ in response.get_json().items():
+        assert metadataset_type is not None
+
+
 # POST /api/_bulk
 
 

--- a/flask/tests/test_misc.py
+++ b/flask/tests/test_misc.py
@@ -33,13 +33,11 @@ def test_get_metadatasettypes(test_database, client, login_as):
     response = client.get("/api/metadatasettypes")
     assert response.status_code == 200
     assert len(response.get_json()) == 4
-    for metadataset_type, _ in response.get_json().items():
-        assert metadataset_type is not None
+    for _, dataset_types in response.get_json().items():
+        assert dataset_types is not None and isinstance(dataset_types, list)
 
 
 # POST /api/_bulk
-
-
 def test_post_bulk(test_database, client, login_as):
     login_as("admin")
     # Test invalid csv


### PR DESCRIPTION
closes #317
curl localhost:5000/api/metadatasettypes 

```
{
  "Exome": [
    "CES", 
    "CPS", 
    "RCS", 
    "RDC", 
    "RDE", 
    "RES", 
    "WES"
  ], 
  "Genome": [
    "CGS", 
    "RGS", 
    "WGS"
  ], 
  "Other": [
    "RLM", 
    "RMM", 
    "RTA"
  ], 
  "RNA": [
    "RRS"
  ]
}
```
