### PR TITLE
React: Refactor /api/groups hookup to use react-query

### DIFF
--- a/react/src/AddDatasets/components/DataEntryTable.tsx
+++ b/react/src/AddDatasets/components/DataEntryTable.tsx
@@ -34,7 +34,7 @@ import { DataEntryActionCell, DataEntryCell, HeaderCell } from "./TableCells";
 import UploadDialog from "./UploadDialog";
 import { getDataEntryHeaders, createEmptyRows, setProp } from "../../functions";
 import { GroupDropdownSelect } from "../../components";
-import { useEnums } from "../../hooks";
+import { useEnums, useFamilies } from "../../hooks";
 
 export interface DataEntryTableProps {
     data: DataEntryRow[];
@@ -122,22 +122,13 @@ export default function DataEntryTable(props: DataEntryTableProps) {
 
     const [optionals, setOptionals] = useState<DataEntryHeader[]>(getOptionalHeaders());
 
-    const [families, setFamilies] = useState<Family[]>([]);
     const [files, setFiles] = useState<string[]>([]);
+    const families = useFamilies();
     const enums = useEnums();
 
     const [showRNA, setShowRNA] = useState<boolean>(false);
 
     useEffect(() => {
-        fetch("/api/families")
-            .then(response => response.json())
-            .then(data => {
-                setFamilies(data as Family[]);
-            })
-            .catch(error => {
-                console.error(error);
-            });
-
         fetch("/api/unlinked")
             .then(response => response.json())
             .then(files => setFiles(files.sort()))

--- a/react/src/App.tsx
+++ b/react/src/App.tsx
@@ -12,7 +12,13 @@ const onClickDismiss = (key: SnackbarKey) => () => {
     notistackRef.current!.closeSnackbar(key);
 };
 
-const queryClient = new QueryClient();
+const queryClient = new QueryClient({
+    defaultOptions: {
+        queries: {
+            staleTime: 1000 * 60, // 1 minute
+        },
+    },
+});
 
 function BaseApp(props: { darkMode: boolean; toggleDarkMode: () => void }) {
     const [authenticated, setAuthenticated] = useState<boolean | null>(null);

--- a/react/src/Groups/components/Group.tsx
+++ b/react/src/Groups/components/Group.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React, { useState } from "react";
 import {
     makeStyles,
     Theme,
@@ -12,6 +12,7 @@ import {
 import { Group as GroupIcon, Edit, Check, Close, Delete } from "@material-ui/icons";
 import ConfirmModal from "../../components/ConfirmModal";
 import { Group as GroupType } from "../../typings";
+import { useGroup } from "../../hooks";
 
 const useStyles = makeStyles((theme: Theme) => ({
     paper: {
@@ -53,14 +54,10 @@ export function Group({ group, onNameChange, onDelete }: GroupProps) {
     const classes = useStyles();
     const [editing, setEditing] = useState<boolean>(false);
     const [groupName, setGroupName] = useState<string>(group.group_name);
-    const [numUsers, setNumUsers] = useState<number>(0);
+    const tempGroup = useGroup(group.group_code);
+    let numUsers = 0;
+    if (tempGroup && tempGroup.users) numUsers = tempGroup.users.length;
     const [confirmDelete, setConfirmDelete] = useState<boolean>(false);
-
-    useEffect(() => {
-        fetch(`/api/groups/${group.group_code}`)
-            .then(response => response.json())
-            .then(data => setNumUsers(data.users.length));
-    }, [group]);
 
     return (
         <Grid item xs={12} sm={6} md={4} xl={3}>

--- a/react/src/Groups/index.tsx
+++ b/react/src/Groups/index.tsx
@@ -4,7 +4,7 @@ import { GroupAdd } from "@material-ui/icons";
 import { useSnackbar } from "notistack";
 import { Group as GroupCard } from "./components/Group";
 import CreateGroupModal from "./components/CreateGroupModal";
-import { Group } from "../typings";
+import { useGroups, useGroupsPatch, useGroupsDelete } from "../hooks";
 
 const useStyles = makeStyles((theme: Theme) => ({
     root: {
@@ -31,17 +31,16 @@ const useStyles = makeStyles((theme: Theme) => ({
 
 export default function Groups() {
     const classes = useStyles();
-    const [groups, setGroups] = useState<Group[]>([]);
-    const [openNewGroup, setOpenNewGroup] = useState<boolean>(false);
+    const groups = useGroups();
+    const groupPatch = useGroupsPatch();
+    const groupDelete = useGroupsDelete();
+    const [openNewGroup, setOpenNewGroup] = useState(false);
     const { enqueueSnackbar } = useSnackbar();
 
     useEffect(() => {
         document.title = `Groups | ${process.env.REACT_APP_NAME}`;
+    }, []);
 
-        fetch("/api/groups")
-            .then(response => response.json())
-            .then(data => setGroups(data as Group[]));
-    }, [openNewGroup]);
     return (
         <Box className={classes.root}>
             <div className={classes.appBarSpacer} />
@@ -52,56 +51,40 @@ export default function Groups() {
                         <GroupCard
                             key={group.group_code}
                             group={group}
-                            onNameChange={async (newName: string) => {
-                                const response = await fetch(`/api/groups/${group.group_code}`, {
-                                    method: "PATCH",
-                                    headers: { "Content-Type": "application/json" },
-                                    body: JSON.stringify({
-                                        ...group,
-                                        group_name: newName,
-                                    }),
-                                });
-                                if (response.ok) {
-                                    const responseData = (await response.json()) as Group;
-                                    setGroups(
-                                        groups.map(currGroup =>
-                                            currGroup.group_code === group.group_code
-                                                ? { ...group, group_name: responseData.group_name }
-                                                : currGroup
-                                        )
-                                    );
-                                    enqueueSnackbar(
-                                        `Group ${group.group_name} renamed to ${responseData.group_name} successfully.`,
-                                        { variant: "success" }
-                                    );
-                                } else {
-                                    enqueueSnackbar(
-                                        `Failed to edit group ${group.group_name}. Error: ${response.status} - ${response.statusText}`,
-                                        { variant: "error" }
-                                    );
-                                }
+                            onNameChange={(newName: string) => {
+                                groupPatch.mutate(
+                                    { ...group, group_name: newName },
+                                    {
+                                        onSuccess: patchedGroup => {
+                                            enqueueSnackbar(
+                                                `Group ${group.group_name} renamed to ${patchedGroup.group_name} successfully.`,
+                                                { variant: "success" }
+                                            );
+                                        },
+                                        onError: response => {
+                                            enqueueSnackbar(
+                                                `Failed to edit group ${group.group_name}. Error: ${response.status} - ${response.statusText}`,
+                                                { variant: "error" }
+                                            );
+                                        },
+                                    }
+                                );
                             }}
-                            onDelete={async () => {
-                                const response = await fetch(`/api/groups/${group.group_code}`, {
-                                    method: "DELETE",
-                                    credentials: "same-origin",
+                            onDelete={() => {
+                                groupDelete.mutate(group.group_code, {
+                                    onSuccess: () => {
+                                        enqueueSnackbar(
+                                            `Group ${group.group_name} deleted successfully.`,
+                                            { variant: "success" }
+                                        );
+                                    },
+                                    onError: response => {
+                                        enqueueSnackbar(
+                                            `Group ${group.group_name} deletion failed. Error: ${response.status} - ${response.statusText}`,
+                                            { variant: "error" }
+                                        );
+                                    },
                                 });
-                                if (response.ok) {
-                                    setGroups(
-                                        groups.filter(
-                                            currGroup => currGroup.group_code !== group.group_code
-                                        )
-                                    );
-                                    enqueueSnackbar(
-                                        `Group ${group.group_name} deleted successfully.`,
-                                        { variant: "success" }
-                                    );
-                                } else {
-                                    enqueueSnackbar(
-                                        `Group ${group.group_name} deletion failed. Error: ${response.status} - ${response.statusText}`,
-                                        { variant: "error" }
-                                    );
-                                }
                             }}
                         />
                     ))}

--- a/react/src/hooks/groups/useGroup.tsx
+++ b/react/src/hooks/groups/useGroup.tsx
@@ -3,7 +3,7 @@ import { Group } from "../../typings";
 import { basicFetch } from "../utils";
 
 async function fetchGroup(group_code: string) {
-    return await basicFetch("/api/groups/" + group_code);
+    return await basicFetch("/api/groups/" + group_code.toLowerCase());
 }
 
 /**
@@ -13,7 +13,9 @@ async function fetchGroup(group_code: string) {
  * the list of users who belong to it.
  */
 export function useGroup(group_code: string) {
-    const result = useQuery<Group, Response>(["groups", group_code], () => fetchGroup(group_code));
+    const result = useQuery<Group, Response>(["groups", group_code.toLowerCase()], () =>
+        fetchGroup(group_code)
+    );
     if (result.isSuccess) return result.data;
     return undefined;
 }

--- a/react/src/hooks/groups/useGroup.tsx
+++ b/react/src/hooks/groups/useGroup.tsx
@@ -1,0 +1,19 @@
+import { useQuery } from "react-query";
+import { Group } from "../../typings";
+import { basicFetch } from "../utils";
+
+async function fetchGroup(group_code: string) {
+    return await basicFetch("/api/groups/" + group_code);
+}
+
+/**
+ * Return result of GET /api/groups/:id.
+ *
+ * That is, return the specified group object which includes
+ * the list of users who belong to it.
+ */
+export function useGroup(group_code: string) {
+    const result = useQuery<Group, Response>(["groups", group_code], () => fetchGroup(group_code));
+    if (result.isSuccess) return result.data;
+    return undefined;
+}

--- a/react/src/hooks/groups/useGroups.tsx
+++ b/react/src/hooks/groups/useGroups.tsx
@@ -1,13 +1,15 @@
 import { useQuery } from "react-query";
-import { Group } from "../typings";
-import { basicFetch } from "./utils";
+import { Group } from "../../typings";
+import { basicFetch } from "../utils";
 
 async function fetchGroups() {
     return await basicFetch("/api/groups");
 }
 
 /**
- * Return all permission groups.
+ * Return result of GET /api/groups.
+ *
+ * That is, return an array of all permission groups as name-code pairs.
  */
 export function useGroups(): Group[] {
     // all groups

--- a/react/src/hooks/groups/useGroups.tsx
+++ b/react/src/hooks/groups/useGroups.tsx
@@ -13,9 +13,7 @@ async function fetchGroups() {
  */
 export function useGroups(): Group[] {
     // all groups
-    const result = useQuery<Group[], Response>("groups", fetchGroups, {
-        staleTime: 1000 * 60, // 1 minute
-    });
+    const result = useQuery<Group[], Response>("groups", fetchGroups);
     if (result.isSuccess) return result.data;
     return [];
 }

--- a/react/src/hooks/groups/useGroupsDelete.tsx
+++ b/react/src/hooks/groups/useGroupsDelete.tsx
@@ -1,0 +1,29 @@
+import { useMutation, useQueryClient } from "react-query";
+
+async function deleteGroup(group_code: string) {
+    const response = await fetch("/api/groups/" + group_code, {
+        method: "DELETE",
+        credentials: "same-origin",
+    });
+    if (response.ok) {
+        return response.text();
+    } else {
+        throw response;
+    }
+}
+
+/**
+ * Return a mutation object for DELETE /api/groups/:id
+ *
+ * Used for deleting a group.
+ */
+export function useGroupsDelete() {
+    const queryClient = useQueryClient();
+    const mutation = useMutation<string, Response, string>(deleteGroup, {
+        onSuccess: group_code => {
+            queryClient.removeQueries(["groups", group_code]);
+            queryClient.invalidateQueries("groups");
+        },
+    });
+    return mutation;
+}

--- a/react/src/hooks/groups/useGroupsDelete.tsx
+++ b/react/src/hooks/groups/useGroupsDelete.tsx
@@ -21,7 +21,7 @@ export function useGroupsDelete() {
     const queryClient = useQueryClient();
     const mutation = useMutation<string, Response, string>(deleteGroup, {
         onSuccess: group_code => {
-            queryClient.removeQueries(["groups", group_code]);
+            queryClient.removeQueries(["groups", group_code.toLowerCase()]);
             queryClient.invalidateQueries("groups");
         },
     });

--- a/react/src/hooks/groups/useGroupsDelete.tsx
+++ b/react/src/hooks/groups/useGroupsDelete.tsx
@@ -1,4 +1,5 @@
 import { useMutation, useQueryClient } from "react-query";
+import { Group } from "../../typings";
 
 async function deleteGroup(group_code: string) {
     const response = await fetch("/api/groups/" + group_code, {
@@ -22,7 +23,16 @@ export function useGroupsDelete() {
     const mutation = useMutation<string, Response, string>(deleteGroup, {
         onSuccess: group_code => {
             queryClient.removeQueries(["groups", group_code.toLowerCase()]);
-            queryClient.invalidateQueries("groups");
+
+            const existingGroups: Group[] | undefined = queryClient.getQueryData("groups");
+            if (existingGroups !== undefined) {
+                queryClient.setQueryData(
+                    "groups",
+                    existingGroups.filter(group => group.group_code !== group_code)
+                );
+            } else {
+                queryClient.invalidateQueries("groups");
+            }
         },
     });
     return mutation;

--- a/react/src/hooks/groups/useGroupsPatch.tsx
+++ b/react/src/hooks/groups/useGroupsPatch.tsx
@@ -27,7 +27,10 @@ export function useGroupsPatch() {
         onSuccess: updatedGroup => {
             queryClient.invalidateQueries("groups");
             // successfully patched, so we can update cache immediately
-            queryClient.setQueryData(["groups", updatedGroup.group_code], updatedGroup);
+            queryClient.setQueryData(
+                ["groups", updatedGroup.group_code.toLowerCase()],
+                updatedGroup
+            );
         },
     });
     return mutation;

--- a/react/src/hooks/groups/useGroupsPatch.tsx
+++ b/react/src/hooks/groups/useGroupsPatch.tsx
@@ -1,0 +1,34 @@
+import { useMutation, useQueryClient } from "react-query";
+import { Group } from "../../typings";
+
+async function patchGroup(newGroup: Group) {
+    // group_code is immutable
+    const { group_code, ...group } = newGroup;
+    const response = await fetch("/api/groups/" + group_code, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(group),
+    });
+    if (response.ok) {
+        return response.json();
+    } else {
+        throw response;
+    }
+}
+
+/**
+ * Return a mutation object for PATCH /api/groups/:id.
+ *
+ * Used for updating fields for an existing group.
+ */
+export function useGroupsPatch() {
+    const queryClient = useQueryClient();
+    const mutation = useMutation<Group, Response, Group>(patchGroup, {
+        onSuccess: updatedGroup => {
+            queryClient.invalidateQueries("groups");
+            // successfully patched, so we can update cache immediately
+            queryClient.setQueryData(["groups", updatedGroup.group_code], updatedGroup);
+        },
+    });
+    return mutation;
+}

--- a/react/src/hooks/groups/useGroupsPatch.tsx
+++ b/react/src/hooks/groups/useGroupsPatch.tsx
@@ -25,12 +25,23 @@ export function useGroupsPatch() {
     const queryClient = useQueryClient();
     const mutation = useMutation<Group, Response, Group>(patchGroup, {
         onSuccess: updatedGroup => {
-            queryClient.invalidateQueries("groups");
             // successfully patched, so we can update cache immediately
             queryClient.setQueryData(
                 ["groups", updatedGroup.group_code.toLowerCase()],
                 updatedGroup
             );
+
+            const existingGroups: Group[] | undefined = queryClient.getQueryData("groups");
+            if (existingGroups !== undefined) {
+                queryClient.setQueryData(
+                    "groups",
+                    existingGroups.map(group =>
+                        group.group_code === updatedGroup.group_code ? updatedGroup : group
+                    )
+                );
+            } else {
+                queryClient.invalidateQueries("groups");
+            }
         },
     });
     return mutation;

--- a/react/src/hooks/groups/useGroupsPost.tsx
+++ b/react/src/hooks/groups/useGroupsPost.tsx
@@ -1,0 +1,40 @@
+import { useMutation, useQueryClient } from "react-query";
+import { Group } from "../../typings";
+
+async function postNewGroup(newGroup: Group) {
+    const response = await fetch("/api/groups", {
+        method: "POST",
+        credentials: "same-origin",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ ...newGroup, group_code: newGroup.group_code.toLowerCase() }),
+    });
+    if (response.ok) {
+        return response.json();
+    } else {
+        throw response;
+    }
+}
+
+/**
+ * Return a mutation object for POST /api/groups.
+ *
+ * Used for creating a new group.
+ */
+export function useGroupsPost() {
+    const queryClient = useQueryClient();
+    const mutation = useMutation<Group, Response, Group>(postNewGroup, {
+        onSuccess: newGroup => {
+            queryClient.invalidateQueries("groups");
+            // we know that this group is brand new so we can cache it
+            queryClient.setQueryData(["groups", newGroup.group_code], newGroup);
+
+            const cachedGroups = queryClient.getQueryData<Group[]>("groups");
+            if (cachedGroups !== undefined) {
+                // destructuring to keep consistent with GET /api/groups format
+                const { users, ...listableGroup } = newGroup;
+                queryClient.setQueryData("groups", [...cachedGroups, listableGroup]);
+            }
+        },
+    });
+    return mutation;
+}

--- a/react/src/hooks/groups/useGroupsPost.tsx
+++ b/react/src/hooks/groups/useGroupsPost.tsx
@@ -24,7 +24,6 @@ export function useGroupsPost() {
     const queryClient = useQueryClient();
     const mutation = useMutation<Group, Response, Group>(postNewGroup, {
         onSuccess: (receivedGroup, sentGroup) => {
-            queryClient.invalidateQueries("groups");
             // we know that this group is brand new so we can cache it
             queryClient.setQueryData(["groups", sentGroup.group_code.toLowerCase()], receivedGroup);
 
@@ -33,6 +32,8 @@ export function useGroupsPost() {
                 // destructuring to keep consistent with GET /api/groups format
                 const { users, ...listableGroup } = receivedGroup;
                 queryClient.setQueryData("groups", [...cachedGroups, listableGroup]);
+            } else {
+                queryClient.invalidateQueries("groups");
             }
         },
     });

--- a/react/src/hooks/groups/useGroupsPost.tsx
+++ b/react/src/hooks/groups/useGroupsPost.tsx
@@ -23,15 +23,15 @@ async function postNewGroup(newGroup: Group) {
 export function useGroupsPost() {
     const queryClient = useQueryClient();
     const mutation = useMutation<Group, Response, Group>(postNewGroup, {
-        onSuccess: newGroup => {
+        onSuccess: (receivedGroup, sentGroup) => {
             queryClient.invalidateQueries("groups");
             // we know that this group is brand new so we can cache it
-            queryClient.setQueryData(["groups", newGroup.group_code], newGroup);
+            queryClient.setQueryData(["groups", sentGroup.group_code.toLowerCase()], receivedGroup);
 
             const cachedGroups = queryClient.getQueryData<Group[]>("groups");
             if (cachedGroups !== undefined) {
                 // destructuring to keep consistent with GET /api/groups format
-                const { users, ...listableGroup } = newGroup;
+                const { users, ...listableGroup } = receivedGroup;
                 queryClient.setQueryData("groups", [...cachedGroups, listableGroup]);
             }
         },

--- a/react/src/hooks/index.tsx
+++ b/react/src/hooks/index.tsx
@@ -1,3 +1,7 @@
 export { useEnums } from "./useEnums";
-export { useGroups } from "./useGroups";
 export { useFamilies } from "./useFamilies";
+export { useGroup } from "./groups/useGroup";
+export { useGroups } from "./groups/useGroups";
+export { useGroupsPost } from "./groups/useGroupsPost";
+export { useGroupsPatch } from "./groups/useGroupsPatch";
+export { useGroupsDelete } from "./groups/useGroupsDelete";

--- a/react/src/hooks/index.tsx
+++ b/react/src/hooks/index.tsx
@@ -1,2 +1,3 @@
 export { useEnums } from "./useEnums";
 export { useGroups } from "./useGroups";
+export { useFamilies } from "./useFamilies";

--- a/react/src/hooks/useEnums.tsx
+++ b/react/src/hooks/useEnums.tsx
@@ -13,7 +13,7 @@ async function fetchEnums() {
  * Return undefined if fetch is unsuccessful.
  */
 export function useEnums() {
-    const result = useQuery<EnumResult, Error>("enums", fetchEnums, {
+    const result = useQuery<EnumResult, Response>("enums", fetchEnums, {
         staleTime: Infinity, // for now, it never gets stale
     });
     if (result.isSuccess) return result.data;

--- a/react/src/hooks/useFamilies.tsx
+++ b/react/src/hooks/useFamilies.tsx
@@ -7,7 +7,9 @@ async function fetchFamilies() {
 }
 
 /**
- * Return an array of all family objects.
+ * Return result of GET /api/families.
+ *
+ * That is, return an array of all families.
  */
 export function useFamilies() {
     const result = useQuery<Family[], Response>("families", fetchFamilies);

--- a/react/src/hooks/useFamilies.tsx
+++ b/react/src/hooks/useFamilies.tsx
@@ -1,0 +1,16 @@
+import { useQuery } from "react-query";
+import { Family } from "../typings";
+import { basicFetch } from "./utils";
+
+async function fetchFamilies() {
+    return await basicFetch("/api/families");
+}
+
+/**
+ * Return an array of all family objects.
+ */
+export function useFamilies() {
+    const result = useQuery<Family[], Response>("families", fetchFamilies);
+    if (result.isSuccess) return result.data;
+    return [];
+}

--- a/react/src/hooks/useGroups.tsx
+++ b/react/src/hooks/useGroups.tsx
@@ -11,7 +11,7 @@ async function fetchGroups() {
  */
 export function useGroups(): Group[] {
     // all groups
-    const result = useQuery<Group[], Error>("groups", fetchGroups, {
+    const result = useQuery<Group[], Response>("groups", fetchGroups, {
         staleTime: 1000 * 60, // 1 minute
     });
     if (result.isSuccess) return result.data;


### PR DESCRIPTION
These custom hooks each correspond to the 'groups' endpoints, and help for managing fetching behaviour in one place.