### PR TITLE
Flask: restrict analysis requests based on dataset type and pipeline …

### DIFF
--- a/flask/app/analyses.py
+++ b/flask/app/analyses.py
@@ -173,29 +173,6 @@ def create_analysis():
     else:
         requester_id = updated_by_id = user_id = current_user.user_id
 
-    # assumed to supersede user_id/admin check
-    compatible_datasets_pipelines_query = (
-        db.session.query(
-            models.Dataset, models.MetaDatasetType_DatasetType, models.PipelineDatasets
-        )
-        .filter(models.Dataset.dataset_id.in_(datasets))
-        .join(
-            models.MetaDatasetType_DatasetType,
-            models.Dataset.dataset_type
-            == models.MetaDatasetType_DatasetType.dataset_type,
-        )
-        .join(
-            models.PipelineDatasets,
-            models.PipelineDatasets.supported_metadataset_type
-            == models.MetaDatasetType_DatasetType.metadataset_type,
-        )
-        .filter(models.PipelineDatasets.pipeline_id == pipeline_id)
-        .all()
-    )
-
-    if len(compatible_datasets_pipelines_query) != len(datasets):
-        return "Requested pipelines are incompatible with datasets", 404
-
     if user_id:
         found_datasets_query = (
             models.Dataset.query.join(
@@ -219,6 +196,30 @@ def create_analysis():
 
     if len(found_datasets) != len(datasets):
         return "Some datasets were not found", 404
+
+    compatible_datasets_pipelines_query = (
+        db.session.query(
+            models.Dataset,
+            models.MetaDatasetType_DatasetType,
+            models.PipelineDatasets,
+        )
+        .filter(models.Dataset.dataset_id.in_(datasets))
+        .join(
+            models.MetaDatasetType_DatasetType,
+            models.Dataset.dataset_type
+            == models.MetaDatasetType_DatasetType.dataset_type,
+        )
+        .join(
+            models.PipelineDatasets,
+            models.PipelineDatasets.supported_metadataset_type
+            == models.MetaDatasetType_DatasetType.metadataset_type,
+        )
+        .filter(models.PipelineDatasets.pipeline_id == pipeline_id)
+        .all()
+    )
+
+    if len(compatible_datasets_pipelines_query) != len(datasets):
+        return "Requested pipelines are incompatible with datasets", 404
 
     now = datetime.now()
     analysis = models.Analysis(

--- a/flask/tests/conftest.py
+++ b/flask/tests/conftest.py
@@ -167,6 +167,20 @@ def test_database(client):
 
     pipeline_1 = Pipeline(pipeline_name="CRG", pipeline_version="1.2")
     db.session.add(pipeline_1)
+    pipeline_2 = Pipeline(pipeline_name="CRE", pipeline_version="1.1")
+    db.session.add(pipeline_2)
+    db.session.flush()
+
+    db.session.add(
+        PipelineDatasets(
+            pipeline_id=pipeline_1.pipeline_id, supported_metadataset_type="Genome"
+        )
+    )
+    db.session.add(
+        PipelineDatasets(
+            pipeline_id=pipeline_2.pipeline_id, supported_metadataset_type="Exome"
+        )
+    )
     db.session.flush()
 
     family_a = Family(

--- a/flask/tests/test_analyses.py
+++ b/flask/tests/test_analyses.py
@@ -221,7 +221,7 @@ def test_create_analysis(test_database, client, login_as):
 
     # test compatible metadataset types - may need to expand on these after more pipelines are introduced
 
-    test_compataible_dict = {
+    test_compatible_dict = {
         "wes_crg": ([3], 1, 404),  # Fail
         "wes_cre": ([3], 2, 201),  # Pass
         "wgs_crg": ([4], 1, 201),  # Pass
@@ -230,8 +230,8 @@ def test_create_analysis(test_database, client, login_as):
         "multi_cre_good": ([2, 3], 2, 201),  # Pass
     }
 
-    for key in test_compataible_dict:
-        dataset_ids, pipeline_id, expected_error_code = combination_d[key]
+    for key in test_compatible_dict:
+        dataset_ids, pipeline_id, expected_error_code = test_compatible_dict[key]
         assert (
             client.post(
                 "/api/analyses",

--- a/flask/tests/test_analyses.py
+++ b/flask/tests/test_analyses.py
@@ -195,10 +195,10 @@ def test_create_analysis(test_database, client, login_as):
         == 404
     )
 
-    # Test success and check db
+    # Test success and check db (switched from dataset 1 to dataset 3 as 1 is WES and incompatible with pipeline_id 2)
     assert (
         client.post(
-            "/api/analyses", json={"datasets": [1], "pipeline_id": 1}
+            "/api/analyses", json={"datasets": [3], "pipeline_id": 2}
         ).status_code
         == 201
     )
@@ -207,14 +207,35 @@ def test_create_analysis(test_database, client, login_as):
         .filter(models.Analysis.analysis_id == 4)
         .one_or_none()
     )
-    dataset_1 = (
+    dataset_3 = (
         models.Dataset.query.options(joinedload(models.Dataset.analyses))
-        .filter(models.Dataset.dataset_id == 1)
+        .filter(models.Dataset.dataset_id == 3)
         .one_or_none()
     )
     assert analysis is not None
     assert len(analysis.datasets) == 1
-    assert len(dataset_1.analyses) == 2
+    assert len(dataset_3.analyses) == 3
 
     login_as("admin")
     assert len(client.get("/api/analyses").get_json()) == 4
+
+    # test compatible metadataset types - may need to expand on these after more pipelines are introduced
+
+    test_compataible_dict = {
+        "wes_crg": ([3], 1, 404),  # Fail
+        "wes_cre": ([3], 2, 201),  # Pass
+        "wgs_crg": ([4], 1, 201),  # Pass
+        "wgs_cre": ([4], 2, 404),  # Fail
+        "multi_cre_bad": ([3, 4], 1, 404),  # Fail
+        "multi_cre_good": ([2, 3], 2, 201),  # Pass
+    }
+
+    for key in test_compataible_dict:
+        dataset_ids, pipeline_id, expected_error_code = combination_d[key]
+        assert (
+            client.post(
+                "/api/analyses",
+                json={"datasets": dataset_ids, "pipeline_id": pipeline_id},
+            ).status_code
+            == expected_error_code
+        )

--- a/flask/tests/test_misc.py
+++ b/flask/tests/test_misc.py
@@ -11,7 +11,7 @@ def test_get_pipelines(test_database, client, login_as):
     login_as("admin")
     response = client.get("/api/pipelines")
     assert response.status_code == 200
-    assert len(response.get_json()) == 1
+    assert len(response.get_json()) == 2
 
 
 # GET /api/enums


### PR DESCRIPTION
…compatability

I'll update the tests if the logic seems sound. 

To test:

```
# add a few datasets that are not strictly RGS (since all the datasets added to the db in manage.py are RGS)
# in a fresh db this adds the following dataset ids: 
# 13, 15 - WGS/RGS (Genome)
# 14, 16 - WES/CES (Exome)

curl -D - -X POST -H "Content-Type: application/json"  --data '[
                 {
                     "family_codename": "HOOD",
                     "participant_codename": "HERO",
                     "participant_type": "Proband",
                     "tissue_sample_type": "Saliva",
                     "sequencing_date" : "20200101", 
                     "dataset_type": "WGS",
                     "sex": "Female",
                     "condition": "GermLine",
                     "linked_files": ["/hello/world2"]
                 },
                 {
                     "family_codename": "HOOD",
                     "participant_codename": "HERO",
                     "participant_type": "Proband",
                     "tissue_sample_type": "Saliva",
                     "sequencing_date" : "20200101", 
                     "dataset_type": "WES",
                     "sex": "Female",
                     "condition": "GermLine",
                     "linked_files": [ "/bye/"]
                 },
                 {
                     "family_codename": "HOOD",
                     "participant_codename": "HERO",
                     "participant_type": "Proband",
                     "tissue_sample_type": "Saliva",
                     "sequencing_date" : "20200101", 
                     "dataset_type": "RGS",
                     "sex": "Female",
                     "condition": "GermLine",
                     "linked_files": ["/bye2/"]
                 },
                                  {
                     "family_codename": "HOOD",
                     "participant_codename": "HERO",
                     "participant_type": "Proband",
                     "tissue_sample_type": "Saliva",
                     "sequencing_date" : "20200101", 
                     "dataset_type": "CES",
                     "sex": "Female",
                     "condition": "GermLine",
                     "linked_files": ["/bye3/"]
                 }
]' \localhost:5000/api/_bulk\?groups=CHEO


# examples 
# pipeline_id = 1 is CRG (genome) and pipeline_id = 2 is CRE (exome)

# compatible dataset and pipelines, eg. WGS with CRG and WES with CRE - succeeds
curl -X POST -H "Content-Type: application/json" -d '{"datasets" : [13], "pipeline_id" : 1}' localhost:5000/api/analyses
curl -X POST -H "Content-Type: application/json" -d '{"datasets" : [14], "pipeline_id" : 2}' localhost:5000/api/analyses

# incompatible dataset and pipelines eg. WGS with CRE and WES with CRG - fails
curl -X POST -H "Content-Type: application/json" -d '{"datasets" : [13], "pipeline_id" : 2}' localhost:5000/api/analyses
curl -X POST -H "Content-Type: application/json" -d '{"datasets" : [14], "pipeline_id" : 1}' localhost:5000/api/analyses

# fails if you mix and match (eg. exome with genome)
curl -X POST -H "Content-Type: application/json" -d '{"datasets" : [13, 14], "pipeline_id" : 2}' localhost:5000/api/analyses
curl -X POST -H "Content-Type: application/json" -d '{"datasets" : [13, 14], "pipeline_id" : 1}' localhost:5000/api/analyses

# succeeds if all datasets have the same metadata set type and pipeline supports 
curl -X POST -H "Content-Type: application/json" -d '{"datasets" : [15, 13], "pipeline_id" : 1}' localhost:5000/api/analyses
curl -X POST -H "Content-Type: application/json" -d '{"datasets" : [14, 16], "pipeline_id" : 2}' localhost:5000/api/analyses
```

Closes #316 