### PR TITLE
Flask: deny MinIO delete actions

### DIFF
--- a/flask/app/groups.py
+++ b/flask/app/groups.py
@@ -6,7 +6,7 @@ from sqlalchemy.orm import contains_eager, joinedload
 from .utils import check_admin, transaction_or_abort, mixin
 
 from minio import Minio
-from .madmin import MinioAdmin, readwrite_buckets_policy
+from .madmin import MinioAdmin, stager_buckets_policy
 
 
 groups_blueprint = Blueprint(
@@ -186,7 +186,7 @@ def create_group():
         group_obj.users += users
 
     # Make corresponding policy
-    policy = readwrite_buckets_policy(group_code)
+    policy = stager_buckets_policy(group_code)
     minio_admin.add_policy(group_code, policy)
 
     # Add users to minio group if applicable, creating group as well

--- a/flask/app/madmin.py
+++ b/flask/app/madmin.py
@@ -137,3 +137,27 @@ def readwrite_buckets_policy(*buckets: str) -> Dict[str, Any]:
             }
         ],
     }
+
+
+# This is Stager-specific and probably not to be included if this module is made independent
+def stager_buckets_policy(*buckets: str) -> Dict[str, Any]:
+    return {
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Effect": "Allow",
+                "Action": ["s3:*"],
+                "Resource": [f"arn:aws:s3:::{bucket}/*" for bucket in buckets],
+            },
+            {
+                "Effect": "Deny",
+                "Action": [
+                    "s3:DeleteBucket",
+                    "s3:ForceDeleteBucket",
+                    "s3:DeleteObject",
+                    "s3:DeleteObjectVersion",
+                ],
+                "Resource": [f"arn:aws:s3:::{bucket}/*" for bucket in buckets],
+            },
+        ],
+    }

--- a/flask/app/manage.py
+++ b/flask/app/manage.py
@@ -9,7 +9,7 @@ from minio import Minio
 
 from .models import *
 from .extensions import db
-from .madmin import MinioAdmin, readwrite_buckets_policy
+from .madmin import MinioAdmin, stager_buckets_policy
 
 
 @click.command("add-default-admin")
@@ -57,7 +57,7 @@ def add_groups():
     }
 
     for default_code, default_name in default_groups.items():
-        policy = readwrite_buckets_policy(default_code)
+        policy = stager_buckets_policy(default_code)
         minio_admin.add_policy(default_code, policy)
         try:
             minio_client.make_bucket(default_code)

--- a/flask/tests/test_groups.py
+++ b/flask/tests/test_groups.py
@@ -2,7 +2,7 @@ import pytest
 from app import db, models
 from sqlalchemy.orm import joinedload
 from conftest import TestConfig
-from app.madmin import MinioAdmin, readwrite_buckets_policy
+from app.madmin import MinioAdmin, stager_buckets_policy
 from minio import Minio
 
 
@@ -17,7 +17,7 @@ def minio_admin():
     madmin.add_user("user", "useruser")
     madmin.add_user("admin", "adminadmin")
     madmin.group_add("ach", "user")
-    madmin.add_policy("ach", readwrite_buckets_policy("ach"))
+    madmin.add_policy("ach", stager_buckets_policy("ach"))
     madmin.set_policy("ach", group="ach")
     yield madmin
     # Teardown

--- a/flask/tests/test_users.py
+++ b/flask/tests/test_users.py
@@ -2,7 +2,7 @@ import json
 
 import pytest
 from app import db
-from app.madmin import MinioAdmin, readwrite_buckets_policy
+from app.madmin import MinioAdmin, stager_buckets_policy
 from app.models import User
 from conftest import TestConfig
 
@@ -48,7 +48,7 @@ def minio_policy():
         access_key=TestConfig.MINIO_ACCESS_KEY,
         secret_key=TestConfig.MINIO_SECRET_KEY,
     )
-    madmin.add_policy("ach", readwrite_buckets_policy("ach"))
+    madmin.add_policy("ach", stager_buckets_policy("ach"))
     yield madmin
     try:
         madmin.remove_policy("ach")


### PR DESCRIPTION
Closes #314

This doesn't prevent overwriting the object with a blank file because that's the same permission in S3. At most we could enable [object versioning](https://stackoverflow.com/questions/10592541/amazon-s3-acl-for-read-only-and-write-once-access on the [instance](https://docs.minio.io/docs/minio-bucket-versioning-guide.html). We should revisit the subject with our collaborators.

To test this, you probably need to reset your db and local minio so it can recreate the policies correctly and not make assumptions based on the current state.