### PR TITLE
Flask: update start and finish times based on analysis state changes

### DIFF
--- a/flask/app/analyses.py
+++ b/flask/app/analyses.py
@@ -338,6 +338,7 @@ def update_analysis(id: int):
         "finished",
         "notes",
     ]
+
     if "assignee" in request.json:
         if not request.json["assignee"]:
             analysis.assignee = None
@@ -354,6 +355,12 @@ def update_analysis(id: int):
 
     if enum_error:
         return enum_error, 400
+
+    if request.json.get("analysis_state") == "Running":
+        analysis.started = datetime.now()
+    elif request.json.get("analysis_state") == "Done":
+        analysis.finished = datetime.now()
+    # Error and Cancelled defaults to time set in 'updated'
 
     if user_id:
         analysis.updated_by_id = user_id


### PR DESCRIPTION
closes #307 

To test:

Start (Running)
```
curl -X PATCH \
    -H "Content-Type: application/json"  \
    --data '{
         "notes": "hello",
         "analysis_state": "Running"
        }' \
    localhost:5000/api/analyses/1
{
  "analysis_id": 1, 
  "analysis_state": "Running", 
  "assignee": "admin", 
  "finished": "2021-02-01T20:08:49", 
  "notes": "hello", 
  "pipeline_id": 1, 
  "qsub_id": null, 
  "requested": "2021-02-01T00:00:00", 
  "requester": "admin", 
  "result_path": null, 
  "started": "2021-02-01T20:09:04", 
  "updated": "2021-02-01T20:09:04", 
  "updated_by_id": "admin"
}
```
End (Done)
```
curl -X PATCH \
    -H "Content-Type: application/json"  \
    --data '{
         "notes": "hello",
         "analysis_state": "Done"
        }' \
    localhost:5000/api/analyses/1

{
  "analysis_id": 1, 
  "analysis_state": "Done", 
  "assignee": "admin", 
  "finished": "2021-02-01T20:09:19", 
  "notes": "hello", 
  "pipeline_id": 1, 
  "qsub_id": null, 
  "requested": "2021-02-01T00:00:00", 
  "requester": "admin", 
  "result_path": null, 
  "started": "2021-02-01T20:09:04", 
  "updated": "2021-02-01T20:09:19", 
  "updated_by_id": "admin"
}

```