### PR TITLE
React: Fix groups mutations to only update group list

### DIFF
--- a/react/src/hooks/groups/useGroupCreateMutation.tsx
+++ b/react/src/hooks/groups/useGroupCreateMutation.tsx
@@ -21,7 +21,11 @@ export function useGroupCreateMutation() {
             queryClient.setQueryData(["groups", sentGroup.group_code.toLowerCase()], receivedGroup);
             // destructuring to keep consistent with GET /api/groups format
             const { users, ...listableGroup } = receivedGroup;
-            addToCachedList<Group>("groups", queryClient, listableGroup);
+            addToCachedList<Group>("groups", queryClient, listableGroup, {
+                invalidateQueryFilters: {
+                    exact: true,
+                },
+            });
         },
     });
     return mutation;

--- a/react/src/hooks/groups/useGroupDeleteMutation.tsx
+++ b/react/src/hooks/groups/useGroupDeleteMutation.tsx
@@ -22,7 +22,12 @@ export function useGroupDeleteMutation() {
                 "groups",
                 queryClient,
                 group_code.toLowerCase(),
-                "group_code"
+                "group_code",
+                {
+                    invalidateQueryFilters: {
+                        exact: true,
+                    },
+                }
             );
         },
     });

--- a/react/src/hooks/groups/useGroupUpdateMutation.tsx
+++ b/react/src/hooks/groups/useGroupUpdateMutation.tsx
@@ -22,7 +22,11 @@ export function useGroupUpdateMutation() {
                 ["groups", updatedGroup.group_code.toLowerCase()],
                 updatedGroup
             );
-            updateInCachedList<Group>("groups", queryClient, updatedGroup, "group_code");
+            updateInCachedList<Group>("groups", queryClient, updatedGroup, "group_code", {
+                invalidateQueryFilters: {
+                    exact: true,
+                },
+            });
         },
     });
     return mutation;


### PR DESCRIPTION
Invalidating queries with option `{ exact: true }` ensures that only queries that exactly match the given key will be invalidated, instead of all queries that contain it. The group create, update, delete hooks now use this option so that only the /api/groups query is invalidated, and not other /api/groups/:id queries that aren't affected by the action.