### PR TITLE
Docker: lock MinIO to previous version to fix CI failures

### DIFF
--- a/.github/workflows/flask.yml
+++ b/.github/workflows/flask.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Check version
         run: |
           docker-compose up -d mysql minio
-          docker-compose exec minio minio --version
+          docker-compose exec -T minio minio --version
       - name: Pytest
         run: docker-compose run --rm app
       - name: Black

--- a/.github/workflows/flask.yml
+++ b/.github/workflows/flask.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Check version
         run: |
           docker-compose up -d mysql minio
-          docker-compose exec -T minio minio --version
+          docker-compose exec minio minio --version
       - name: Pytest
         run: docker-compose run --rm app
       - name: Black

--- a/.github/workflows/flask.yml
+++ b/.github/workflows/flask.yml
@@ -48,6 +48,10 @@ jobs:
         if: ${{ github.event_name == 'push' }}
         run: docker push ghcr.io/ccmbioinfo/stager:dev
       - run: cp sample.env .env
+      - name: Check version
+        run: |
+          docker-compose up -d mysql minio
+          docker-compose exec minio minio --version
       - name: Pytest
         run: docker-compose run --rm app
       - name: Black

--- a/.github/workflows/flask.yml
+++ b/.github/workflows/flask.yml
@@ -48,10 +48,6 @@ jobs:
         if: ${{ github.event_name == 'push' }}
         run: docker push ghcr.io/ccmbioinfo/stager:dev
       - run: cp sample.env .env
-      - name: Check version
-        run: |
-          docker-compose up -d mysql minio
-          docker-compose exec minio minio --version
       - name: Pytest
         run: docker-compose run --rm app
       - name: Black

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Production image. Runs a Guicorn WSGI server.
-FROM minio/mc:latest AS mc
+FROM minio/mc:RELEASE.2021-02-07T02-02-05Z AS mc
 FROM python:3.7-slim
 WORKDIR /usr/src/stager
 # Install PyPI prod-only packages first and then copy the MinIO client as the latter updates more frequently

--- a/docker-compose.prod.yaml
+++ b/docker-compose.prod.yaml
@@ -22,7 +22,7 @@ services:
       test: ["CMD", "mysqladmin", "ping", "-uroot", "-p${MYSQL_ROOT_PASSWORD}"]
     <<: *common
   minio:
-    image: minio/minio
+    image: minio/minio:RELEASE.2021-02-11T08-23-43Z
     user: "${MINIO_UIDGID}"
     environment:
       MINIO_ACCESS_KEY: "${MINIO_ACCESS_KEY}"

--- a/docker-compose.test.yaml
+++ b/docker-compose.test.yaml
@@ -10,7 +10,7 @@ services:
       MYSQL_PASSWORD: "${TEST_MYSQL_PASSWORD}"
       MYSQL_ROOT_PASSWORD: "${TEST_MYSQL_ROOT_PASSWORD}"
   minio:
-    image: minio/minio
+    image: minio/minio:RELEASE.2021-02-11T08-23-43Z
     environment:
       MINIO_ACCESS_KEY: "${TEST_MINIO_ACCESS_KEY}"
       MINIO_SECRET_KEY: "${TEST_MINIO_SECRET_KEY}"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -15,7 +15,7 @@ services:
     volumes:
       - ${MYSQL_VOLUME}:/var/lib/mysql
   minio:
-    image: minio/minio
+    image: minio/minio:RELEASE.2021-02-11T08-23-43Z
     user: "${MINIO_UIDGID:-}"
     restart: on-failure
     environment:

--- a/flask/Dockerfile
+++ b/flask/Dockerfile
@@ -1,5 +1,5 @@
 # Development image only. Runs a Flask development server.
-FROM minio/mc:latest AS mc
+FROM minio/mc:RELEASE.2021-02-07T02-02-05Z AS mc
 FROM python:3.7-slim
 WORKDIR /usr/src/stager
 # Install PyPI packages first and then copy the MinIO client as the latter updates more frequently


### PR DESCRIPTION
minio/minio#11544

Should unblock all backend PRs
