### PR TITLE
React: Add pipeline filter for analyses page

### DIFF
--- a/react/src/Analyses/components/PipelineFilter.tsx
+++ b/react/src/Analyses/components/PipelineFilter.tsx
@@ -17,7 +17,7 @@ function pipelineName(p: Pipeline) {
  */
 export default function PipelineFilter(props: FilterProps) {
     const pipelinesQuery = usePipelinesQuery();
-    const pipelines = useMemo(() => {
+    const pipelinesObj = useMemo(() => {
         if (pipelinesQuery.isSuccess) {
             const obj: { [key: number]: Pipeline } = {};
             pipelinesQuery.data.forEach(p => {
@@ -27,6 +27,11 @@ export default function PipelineFilter(props: FilterProps) {
         }
         return undefined;
     }, [pipelinesQuery]);
+
+    const pipelineList = useMemo(() => (pipelinesQuery.isSuccess ? pipelinesQuery.data : []), [
+        pipelinesQuery,
+    ]);
+
     // Selected pipeline_ids
     const [selected, setSelected] = useState<number[]>([]);
 
@@ -41,17 +46,17 @@ export default function PipelineFilter(props: FilterProps) {
 
     return (
         <>
-            {pipelines && (
+            {pipelinesObj && pipelineList && (
                 <Select
                     multiple
                     value={selected}
                     onChange={onFilterChange}
                     onClose={onClose}
                     renderValue={selected =>
-                        (selected as number[]).map(id => pipelineName(pipelines[id])).join(", ")
+                        (selected as number[]).map(id => pipelineName(pipelinesObj[id])).join(", ")
                     }
                 >
-                    {Object.values(pipelines).map(p => (
+                    {pipelineList.map(p => (
                         <MenuItem key={p.pipeline_id} value={p.pipeline_id}>
                             <Checkbox checked={selected.indexOf(p.pipeline_id) > -1} />
                             <ListItemText primary={pipelineName(p)} />

--- a/react/src/Analyses/components/PipelineFilter.tsx
+++ b/react/src/Analyses/components/PipelineFilter.tsx
@@ -1,0 +1,40 @@
+import React, { useMemo, useState } from "react";
+import { Column } from "material-table";
+import { Analysis } from "../../typings";
+import { Checkbox, ListItemText, MenuItem, Select } from "@material-ui/core";
+import { usePipelinesQuery } from "../../hooks";
+
+type FilterProps = Parameters<Required<Column<Analysis>>["filterComponent"]>[0];
+
+/**
+ * Dropdown filter for pipeline ids. Displays name + version.
+ *
+ * Copies parameters from material-table filterComponent
+ */
+export default function PipelineFilter(props: FilterProps) {
+    const pipelinesQuery = usePipelinesQuery();
+    const pipelines = useMemo(() => (pipelinesQuery.isSuccess ? pipelinesQuery.data : []), [
+        pipelinesQuery,
+    ]);
+    // Selected pipeline_ids
+    const [selected, setSelected] = useState<number[]>([]);
+
+    function onFilterChange(event: React.ChangeEvent<{ value: unknown }>) {
+        console.log(event.target.value);
+        const newIds = event.target.value as number[];
+        setSelected(newIds);
+        const rowId = (props.columnDef as any).tableData.id;
+        props.onFilterChanged(rowId, newIds.join(","));
+    }
+
+    return (
+        <Select multiple value={selected} onChange={onFilterChange}>
+            {pipelines.map(p => (
+                <MenuItem key={p.pipeline_id} value={p.pipeline_id}>
+                    <Checkbox checked={selected.indexOf(p.pipeline_id) > -1} />
+                    <ListItemText primary={`${p.pipeline_name} ${p.pipeline_version}`} />
+                </MenuItem>
+            ))}
+        </Select>
+    );
+}

--- a/react/src/components/NotificationPopover.tsx
+++ b/react/src/components/NotificationPopover.tsx
@@ -51,7 +51,8 @@ export default function NotificationPopover({ lastLoginTime }: NotificationPopov
     const classes = useStyles();
     const [anchorEl, setAnchorEl] = useState<HTMLButtonElement | null>(null);
     const lastLoginDate = useMemo(() => new Date(lastLoginTime), [lastLoginTime]);
-    const { data: analyses } = useAnalysesQuery(lastLoginDate);
+    const { data: analysisQuery } = useAnalysesQuery(lastLoginDate);
+    const analyses = useMemo(() => analysisQuery?.data || [], [analysisQuery]);
     const popoverOpen = Boolean(anchorEl);
     const [clickedAnalysis, setClickedAnalysis] = useState<Analysis | null>(null);
     const [openDialog, setOpenDialog] = useState<boolean>(false);

--- a/react/src/hooks/analyses/useAnalysesPage.tsx
+++ b/react/src/hooks/analyses/useAnalysesPage.tsx
@@ -1,7 +1,8 @@
+import { useCallback } from "react";
 import { Query, QueryResult } from "material-table";
 import { useQueryClient } from "react-query";
-import { queryTableData } from "../utils";
-import { Analysis } from "../../typings";
+import { basicFetch, queryTableData } from "../utils";
+import { Analysis, AnalysisDetailed } from "../../typings";
 
 async function fetchAnalyses(query: Query<Analysis>) {
     const queryResult = await queryTableData<Analysis>(query, "/api/analyses");
@@ -14,9 +15,40 @@ async function fetchAnalyses(query: Query<Analysis>) {
 export function useAnalysesPage() {
     const queryClient = useQueryClient();
 
-    return async (query: Query<Analysis>) => {
-        return await queryClient.fetchQuery<QueryResult<Analysis>, Error>(["analyses", query], () =>
-            fetchAnalyses(query)
-        );
-    };
+    const func = useCallback(
+        async (query: Query<Analysis>) => {
+            // If analysis_id is specified, we'll use the individual GET endpoint
+            const idFilter = query.filters.find(
+                filter => filter.column.field === "analysis_id" && filter.value
+            );
+            if (idFilter && typeof idFilter.value === "string") {
+                try {
+                    const result = await queryClient.fetchQuery<string, Response, AnalysisDetailed>(
+                        ["analyses", idFilter.value],
+                        () => basicFetch("/api/analyses/" + idFilter.value)
+                    );
+
+                    return {
+                        data: [result],
+                        page: 0,
+                        totalCount: 1,
+                    };
+                } catch {
+                    return {
+                        data: [],
+                        page: 0,
+                        totalCount: 0,
+                    };
+                }
+            }
+
+            return await queryClient.fetchQuery<QueryResult<Analysis>, Error>(
+                ["analyses", query],
+                () => fetchAnalyses(query)
+            );
+        },
+        [queryClient]
+    );
+
+    return func;
 }

--- a/react/src/hooks/analyses/useAnalysesQuery.tsx
+++ b/react/src/hooks/analyses/useAnalysesQuery.tsx
@@ -1,4 +1,5 @@
 import dayjs from "dayjs";
+import { QueryResult } from "material-table";
 import { QueryObserverResult, useQuery } from "react-query";
 import { jsonToAnalyses } from "../../functions";
 import { Analysis } from "../../typings";
@@ -6,7 +7,7 @@ import { basicFetch } from "../utils";
 
 async function fetchAnalyses(since?: string) {
     let params = "";
-    if (since) params = "?since=" + since;
+    if (since) params = "?updated=after," + since;
     return await basicFetch("/api/analyses" + params);
 }
 
@@ -28,7 +29,13 @@ export function useAnalysesQuery(since?: Date) {
     }
     if (queryKey.length === 1) queryKey = queryKey[0];
 
-    const result = useQuery<any[], Response>(queryKey, () => fetchAnalyses(dateString));
-    if (result.isSuccess) result.data = jsonToAnalyses(result.data);
-    return result as QueryObserverResult<Analysis[], Response>;
+    const result = useQuery<QueryResult<Analysis>, Response>(queryKey, () =>
+        fetchAnalyses(dateString)
+    );
+    if (result.isSuccess)
+        result.data = {
+            ...result.data,
+            data: jsonToAnalyses(result.data.data),
+        };
+    return result as QueryObserverResult<QueryResult<Analysis>, Response>;
 }

--- a/react/src/hooks/index.tsx
+++ b/react/src/hooks/index.tsx
@@ -9,6 +9,7 @@ export { useBulkCreateMutation } from "./bulk/useBulkCreateMutation";
 
 export { useAnalysisQuery } from "./analyses/useAnalysisQuery";
 export { useAnalysesQuery } from "./analyses/useAnalysesQuery";
+export { useAnalysesPage } from "./analyses/useAnalysesPage";
 export { useAnalysisCreateMutation } from "./analyses/useAnalysisCreateMutation";
 export { useAnalysisUpdateMutation } from "./analyses/useAnalysisUpdateMutation";
 export type { AnalysisOptions } from "./analyses/useAnalysisUpdateMutation";


### PR DESCRIPTION
Related to #406

Also fixes an issue with useAnalysesQuery, and updates the notification popover to use `updated=after,{date}` parameter format.

EDIT: Added analysis_id filter changes here because front-end on `master` is broken, so this branch is easier to test on.