### PR TITLE
CI: only login to registry on push workflows

### DIFF
--- a/.github/workflows/flask.yml
+++ b/.github/workflows/flask.yml
@@ -31,6 +31,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-buildx-
       - uses: docker/login-action@v1
+        if: github.event_name == 'push'
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}


### PR DESCRIPTION
ghcr.io/ccmbioinfo/stager is now public
Works around dependabot/dependabot-core#3253