### PR TITLE
clear non-static query cache on logout

### DIFF
--- a/react/src/App.tsx
+++ b/react/src/App.tsx
@@ -8,6 +8,7 @@ import LoginForm from "./Login";
 import Navigation from "./Navigation";
 import { CurrentUser } from "./typings";
 import { UserContext, emptyUser, UserClient } from "./contexts";
+import { clearQueryCache } from "./hooks/utils";
 
 const notistackRef = React.createRef<SnackbarProvider>();
 const onClickDismiss = (key: SnackbarKey) => () => {
@@ -53,6 +54,7 @@ function BaseApp(props: { darkMode: boolean; toggleDarkMode: () => void }) {
         });
         if (result.ok) {
             setAuthenticated(false);
+            clearQueryCache(queryClient, ["enums", "metadatasettypes"]);
         }
     }
     // Check if already signed in

--- a/react/src/hooks/utils.tsx
+++ b/react/src/hooks/utils.tsx
@@ -215,3 +215,22 @@ export function useQueriesTyped<TQueries extends readonly UseQueryOptions[]>(
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     return useQueries(queries as UseQueryOptions<unknown, unknown, unknown>[]) as any;
 }
+
+/**
+ * Remove all queries from cache, with optional preservation whitelist
+ * @param queryClient The react-query client.
+ * @param preserve Optional array of string keys to preserve
+ */
+export function clearQueryCache(queryClient: QueryClient, preserve: string[] = []): void {
+    return queryClient
+        .getQueryCache()
+        .getAll()
+        .forEach(query => {
+            const key = Array.isArray(query.queryKey)
+                ? (query.queryKey[0] as string)
+                : (query.queryKey as string);
+            if (!preserve.includes(key)) {
+                queryClient.removeQueries(key);
+            }
+        });
+}


### PR DESCRIPTION
Remove queries from client on logout, preserving constants like enums.