### PR TITLE
use tableRef to update dataset type filter on dataset page

### DIFF
--- a/react/src/Datasets/components/DatasetTable.tsx
+++ b/react/src/Datasets/components/DatasetTable.tsx
@@ -118,6 +118,7 @@ export default function DatasetTable() {
                 col.tableData.filterValue = filterVal;
                 MTRef.current.dataManager.changeApplyFilters(true);
                 MTRef.current.dataManager.filterData();
+                MTRef.current.onFilterChangeDebounce();
                 MTRef.current.onQueryChange();
             }
         }


### PR DESCRIPTION
Changing `defaultFilter` prop on column config causes a rerender of dataset table, wiping out filters that are already set. By using a ref to get the table instance, we can make the filter change imperatively and then force a state change by calling `onQueryChange`.