### PR TITLE
Cklamann/material table fixes

### DIFF
--- a/react/src/Analyses/index.tsx
+++ b/react/src/Analyses/index.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { useHistory, useParams } from "react-router";
 import { makeStyles } from "@material-ui/core/styles";
 import { Chip, IconButton, TextField, Container } from "@material-ui/core";
@@ -14,7 +14,7 @@ import {
 import MaterialTable, { MTableToolbar } from "material-table";
 import { useSnackbar } from "notistack";
 import { UseMutationResult } from "react-query";
-import { isRowSelected, exportCSV } from "../functions";
+import { isRowSelected, exportCSV, updateTableFilter, toTitleCase } from "../functions";
 import { Analysis, PipelineStatus } from "../typings";
 import { AnalysisInfoDialog, Note, DateTimeText, DateFilterComponent } from "../components";
 import { AnalysisOptions, useAnalysesPage, useAnalysisUpdateMutation } from "../hooks";
@@ -159,6 +159,8 @@ export default function Analyses() {
     const { enqueueSnackbar } = useSnackbar();
     const { id: paramID } = useParams<{ id: string }>();
 
+    const tableRef = useRef<any>();
+
     function changeAnalysisState(filter: (row: Analysis) => boolean, newState: PipelineStatus) {
         return _changeStateForSelectedRows(activeRows, filter, analysisUpdateMutation, newState);
     }
@@ -275,6 +277,7 @@ export default function Analyses() {
 
             <Container maxWidth={false} className={classes.container}>
                 <MaterialTable
+                    tableRef={tableRef}
                     columns={[
                         {
                             title: "Analysis ID",
@@ -526,37 +529,22 @@ export default function Analyses() {
                             <div>
                                 <MTableToolbar {...props} />
                                 <div style={{ marginLeft: "24px" }}>
-                                    <Chip
-                                        label="Completed"
-                                        clickable
-                                        className={classes.chip}
-                                        onClick={() => setChipFilter(PipelineStatus.COMPLETED)}
-                                    />
-                                    <Chip
-                                        label="Running"
-                                        clickable
-                                        className={classes.chip}
-                                        onClick={() => setChipFilter(PipelineStatus.RUNNING)}
-                                    />
-                                    <Chip
-                                        label="Pending"
-                                        clickable
-                                        className={classes.chip}
-                                        onClick={() => setChipFilter(PipelineStatus.PENDING)}
-                                    />
-                                    <Chip
-                                        label="Error"
-                                        clickable
-                                        className={classes.chip}
-                                        onClick={() => setChipFilter(PipelineStatus.ERROR)}
-                                    />
-                                    <Chip
-                                        label="Cancelled"
-                                        clickable
-                                        className={classes.chip}
-                                        onClick={() => setChipFilter(PipelineStatus.CANCELLED)}
-                                    />
-                                    <IconButton onClick={() => setChipFilter("")}>
+                                    {Object.entries(PipelineStatus).map(([k, v]) => (
+                                        <Chip
+                                            key={k}
+                                            label={toTitleCase(k)}
+                                            clickable
+                                            className={classes.chip}
+                                            onClick={() =>
+                                                updateTableFilter(tableRef, "analysis_state", v)
+                                            }
+                                        />
+                                    ))}
+                                    <IconButton
+                                        onClick={() =>
+                                            updateTableFilter(tableRef, "analysis_state", "")
+                                        }
+                                    >
                                         <Cancel />
                                     </IconButton>
                                 </div>

--- a/react/src/Analyses/index.tsx
+++ b/react/src/Analyses/index.tsx
@@ -152,8 +152,6 @@ export default function Analyses() {
 
     const [activeRows, setActiveRows] = useState<Analysis[]>([]);
 
-    const [chipFilter, setChipFilter] = useState<string>(""); // filter by state
-
     const history = useHistory();
 
     const { enqueueSnackbar } = useSnackbar();
@@ -328,7 +326,6 @@ export default function Analyses() {
                             field: "analysis_state",
                             type: "string",
                             editable: "never",
-                            defaultFilter: chipFilter,
                         },
                         {
                             title: "Notes",

--- a/react/src/Datasets/components/DatasetTable.tsx
+++ b/react/src/Datasets/components/DatasetTable.tsx
@@ -164,14 +164,12 @@ export default function DatasetTable() {
                     {
                         title: "Notes",
                         field: "notes",
-                        grouping: false,
                         render: RenderNotes,
                         editComponent: EditNotesComponent,
                     },
                     {
                         title: "Files",
                         field: "linked_files",
-                        grouping: false,
                         // can search by number of files, or by file name
                         customFilterAndSearch: customFileFilterAndSearch,
                         customSort: linkedFileSort,
@@ -202,7 +200,6 @@ export default function DatasetTable() {
                     filtering: true,
                     search: false,
                     padding: "dense",
-                    grouping: true,
                     exportAllData: true,
                     exportButton: { csv: true, pdf: false },
                     exportCsv: wrappedExportCsv,

--- a/react/src/Datasets/components/DatasetTable.tsx
+++ b/react/src/Datasets/components/DatasetTable.tsx
@@ -5,7 +5,7 @@ import { PlayArrow, Delete, Cancel, Visibility } from "@material-ui/icons";
 import MaterialTable, { EditComponentProps, MTableToolbar } from "material-table";
 import { useSnackbar } from "notistack";
 import { useQueryClient } from "react-query";
-import { toKeyValue, exportCSV, rowDiff } from "../../functions";
+import { toKeyValue, exportCSV, rowDiff, updateTableFilter } from "../../functions";
 import { Dataset } from "../../typings";
 import AnalysisRunnerDialog from "./AnalysisRunnerDialog";
 import DatasetInfoDialog from "./DatasetInfoDialog";
@@ -105,24 +105,6 @@ export default function DatasetTable() {
 
     //setting to `any` b/c MTable typing doesn't include dataManager
     const MTRef = useRef<any>();
-
-    /**
-     * Update a table filter from outside the table
-     * MaterialTable holds its own state, so to avoid a rerender and state flush we need to get a handle \
-     * on the instance, make imperative updates, and force an internal state change
-     */
-    const updateFilter = (column: string, filterVal: string | string[]) => {
-        if (MTRef.current) {
-            const col = MTRef.current.dataManager.columns.find((c: any) => c.field === column);
-            if (col) {
-                col.tableData.filterValue = filterVal;
-                MTRef.current.dataManager.changeApplyFilters(true);
-                MTRef.current.dataManager.filterData();
-                MTRef.current.onFilterChangeDebounce();
-                MTRef.current.onQueryChange();
-            }
-        }
-    };
 
     return (
         <div>
@@ -256,14 +238,18 @@ export default function DatasetTable() {
                                             key={metatype}
                                             label={metatype}
                                             onClick={() =>
-                                                updateFilter("dataset_type", datasetTypes)
+                                                updateTableFilter(
+                                                    MTRef,
+                                                    "dataset_type",
+                                                    datasetTypes
+                                                )
                                             }
                                             clickable
                                             className={classes.chip}
                                         />
                                     ))}
                                 <IconButton
-                                    onClick={() => updateFilter("dataset_type", "")}
+                                    onClick={() => updateTableFilter(MTRef, "dataset_type", "")}
                                     className={classes.chip}
                                 >
                                     <Cancel />

--- a/react/src/Participants/components/ParticipantTable.tsx
+++ b/react/src/Participants/components/ParticipantTable.tsx
@@ -111,7 +111,6 @@ export default function ParticipantTable() {
                     {
                         title: "Notes",
                         field: "notes",
-                        grouping: false,
                         render: rowData => <Note>{rowData.notes}</Note>,
                         editComponent: props => (
                             <TextField
@@ -129,7 +128,6 @@ export default function ParticipantTable() {
                         editable: "never",
                         lookup: datasetTypes,
                         filtering: false,
-                        grouping: false,
                         render: rowData => (
                             <DatasetTypes datasetTypes={countArray(rowData.dataset_types)} />
                         ),
@@ -143,7 +141,6 @@ export default function ParticipantTable() {
                     filtering: true,
                     search: false,
                     padding: "dense",
-                    grouping: true,
                     exportAllData: true,
                     exportButton: { csv: true, pdf: false },
                     exportCsv: (columns, data) => exportCSV(columns, data, "Participants"),

--- a/react/src/functions.tsx
+++ b/react/src/functions.tsx
@@ -218,10 +218,14 @@ export function getDataEntryHeaders() {
  * Assume that input string is alphanumeric with underscores.
  */
 export function snakeCaseToTitle(str: string): string {
-    return str
-        .split("_")
-        .join(" ")
-        .replace(/\w\S*/g, txt => txt.charAt(0).toUpperCase() + txt.substr(1));
+    return str.split("_").map(toTitleCase).join(" ");
+}
+
+/**
+ * Given a string, returns the string with first word capitalized
+ */
+export function toTitleCase(str: string): string {
+    return str.replace(/\w\S*/g, txt => txt.charAt(0).toUpperCase() + txt.substr(1).toLowerCase());
 }
 
 export function createFieldObj(
@@ -350,3 +354,25 @@ export function strIsEmpty(str?: string): boolean {
     const testRegex = /\S/g;
     return str ? !testRegex.test(str) : true;
 }
+
+/**
+ * Update a material-table filter from outside the table
+ * MaterialTable holds its own state, so to avoid a rerender and state flush we need to get a handle \
+ * on the instance, make imperative updates, and force an internal state change
+ */
+export const updateTableFilter = (
+    tableRef: React.MutableRefObject<any>,
+    column: string,
+    filterVal: string | string[]
+) => {
+    if (tableRef.current) {
+        const col = tableRef.current.dataManager.columns.find((c: any) => c.field === column);
+        if (col) {
+            col.tableData.filterValue = filterVal;
+            tableRef.current.dataManager.changeApplyFilters(true);
+            tableRef.current.dataManager.filterData();
+            tableRef.current.onFilterChangeDebounce();
+            tableRef.current.onQueryChange();
+        }
+    }
+};


### PR DESCRIPTION
- remove grouping functionality from dataset and analysis tables b/c material-table doesn't support progressive loading on grouped data
- fix the chip filters on the analysis table, which was overlooked (by me) in [PR 478](https://github.com/ccmbioinfo/stager/pull/478) and update code for better sharing/reuse.