### PR TITLE
Flask: pip-compile --upgrade

### DIFF
--- a/flask/requirements-dev.txt
+++ b/flask/requirements-dev.txt
@@ -4,130 +4,58 @@
 #
 #    pip-compile requirements-dev.in
 #
-alembic==1.4.3
-    # via flask-migrate
-appdirs==1.4.4
-    # via black
-astroid==2.5.1
-    # via pylint
-attrs==20.3.0
-    # via pytest
-black==20.8b1
-    # via -r requirements-dev.in
-certifi==2020.12.5
-    # via minio
-cffi==1.14.4
-    # via cryptography
-click==7.1.2
-    # via
-    #   black
-    #   flask
-cryptography==3.3.2
-    # via pymysql
-flask-login==0.5.0
-    # via -r requirements.in
-flask-migrate==2.7.0
-    # via -r requirements.in
-flask-sqlalchemy==2.5.1
-    # via
-    #   -r requirements.in
-    #   flask-migrate
-flask-wtf==0.14.3
-    # via -r requirements.in
-flask==1.1.2
-    # via
-    #   -r requirements.in
-    #   flask-login
-    #   flask-migrate
-    #   flask-sqlalchemy
-    #   flask-wtf
-gunicorn==20.1.0
-    # via -r requirements.in
-iniconfig==1.1.1
-    # via pytest
-isort==5.6.4
-    # via pylint
-itsdangerous==1.1.0
-    # via
-    #   flask
-    #   flask-wtf
-jinja2==2.11.3
-    # via flask
-lazy-object-proxy==1.4.3
-    # via astroid
-mako==1.1.3
-    # via alembic
-markupsafe==1.1.1
-    # via
-    #   jinja2
-    #   mako
-    #   wtforms
-mccabe==0.6.1
-    # via pylint
-minio==7.0.2
-    # via -r requirements.in
-mypy-extensions==0.4.3
-    # via black
-numpy==1.19.4
-    # via pandas
-packaging==20.8
-    # via pytest
-pandas==1.2.3
-    # via -r requirements.in
-pathspec==0.8.1
-    # via black
-pluggy==0.13.1
-    # via pytest
-py==1.10.0
-    # via pytest
-pycparser==2.20
-    # via cffi
-pylint==2.7.2
-    # via -r requirements-dev.in
-pymysql[rsa]==0.10.1
-    # via -r requirements.in
-pyparsing==2.4.7
-    # via packaging
-pytest==6.2.2
-    # via -r requirements-dev.in
-python-dateutil==2.8.1
-    # via
-    #   alembic
-    #   pandas
-python-editor==1.0.4
-    # via alembic
-pytz==2020.4
-    # via pandas
-regex==2020.11.13
-    # via black
-six==1.15.0
-    # via
-    #   cryptography
-    #   python-dateutil
-sqlalchemy==1.3.23
-    # via
-    #   -r requirements.in
-    #   alembic
-    #   flask-sqlalchemy
-toml==0.10.2
-    # via
-    #   black
-    #   pylint
-    #   pytest
-typed-ast==1.4.1
-    # via black
-typing-extensions==3.7.4.3
-    # via black
-urllib3==1.26.4
-    # via minio
-werkzeug==1.0.1
-    # via
-    #   -r requirements.in
-    #   flask
-wrapt==1.12.1
-    # via astroid
-wtforms==2.3.3
-    # via flask-wtf
+alembic==1.5.8            # via flask-migrate
+appdirs==1.4.4            # via black
+astroid==2.5.2            # via pylint
+attrs==20.3.0             # via pytest
+black==20.8b1             # via -r requirements-dev.in
+certifi==2020.12.5        # via minio
+cffi==1.14.5              # via cryptography
+click==7.1.2              # via black, flask
+cryptography==3.4.7       # via pymysql
+flask-login==0.5.0        # via -r requirements.in
+flask-migrate==2.7.0      # via -r requirements.in
+flask-sqlalchemy==2.5.1   # via -r requirements.in, flask-migrate
+flask-wtf==0.14.3         # via -r requirements.in
+flask==1.1.2              # via -r requirements.in, flask-login, flask-migrate, flask-sqlalchemy, flask-wtf
+greenlet==1.0.0           # via sqlalchemy
+gunicorn==20.1.0          # via -r requirements.in
+importlib-metadata==3.10.0  # via pluggy, pytest, sqlalchemy
+iniconfig==1.1.1          # via pytest
+isort==5.8.0              # via pylint
+itsdangerous==1.1.0       # via flask, flask-wtf
+jinja2==2.11.3            # via flask
+lazy-object-proxy==1.6.0  # via astroid
+mako==1.1.4               # via alembic
+markupsafe==1.1.1         # via jinja2, mako, wtforms
+mccabe==0.6.1             # via pylint
+minio==7.0.3              # via -r requirements.in
+mypy-extensions==0.4.3    # via black
+numpy==1.20.2             # via pandas
+packaging==20.9           # via pytest
+pandas==1.2.3             # via -r requirements.in
+pathspec==0.8.1           # via black
+pluggy==0.13.1            # via pytest
+py==1.10.0                # via pytest
+pycparser==2.20           # via cffi
+pylint==2.7.4             # via -r requirements-dev.in
+pymysql[rsa]==1.0.2       # via -r requirements.in
+pyparsing==2.4.7          # via packaging
+pytest==6.2.3             # via -r requirements-dev.in
+python-dateutil==2.8.1    # via alembic, pandas
+python-editor==1.0.4      # via alembic
+pytz==2021.1              # via pandas
+regex==2021.4.4           # via black
+six==1.15.0               # via python-dateutil
+sqlalchemy==1.4.6         # via -r requirements.in, alembic, flask-sqlalchemy
+toml==0.10.2              # via black, pylint, pytest
+typed-ast==1.4.2          # via astroid, black
+typing-extensions==3.7.4.3  # via black, importlib-metadata
+urllib3==1.26.4           # via minio
+werkzeug==1.0.1           # via -r requirements.in, flask
+wrapt==1.12.1             # via astroid
+wtforms==2.3.3            # via flask-wtf
+zipp==3.4.1               # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/flask/requirements-dev.txt
+++ b/flask/requirements-dev.txt
@@ -47,7 +47,7 @@ python-editor==1.0.4      # via alembic
 pytz==2021.1              # via pandas
 regex==2021.4.4           # via black
 six==1.15.0               # via python-dateutil
-sqlalchemy==1.4.6         # via -r requirements.in, alembic, flask-sqlalchemy
+sqlalchemy==1.3.24        # via -r requirements.in, alembic, flask-sqlalchemy
 toml==0.10.2              # via black, pylint, pytest
 typed-ast==1.4.2          # via astroid, black
 typing-extensions==3.7.4.3  # via black, importlib-metadata

--- a/flask/requirements.txt
+++ b/flask/requirements.txt
@@ -4,83 +4,38 @@
 #
 #    pip-compile
 #
-alembic==1.4.3
-    # via flask-migrate
-certifi==2020.12.5
-    # via minio
-cffi==1.14.4
-    # via cryptography
-click==7.1.2
-    # via flask
-cryptography==3.3.2
-    # via pymysql
-flask-login==0.5.0
-    # via -r requirements.in
-flask-migrate==2.7.0
-    # via -r requirements.in
-flask-sqlalchemy==2.5.1
-    # via
-    #   -r requirements.in
-    #   flask-migrate
-flask-wtf==0.14.3
-    # via -r requirements.in
-flask==1.1.2
-    # via
-    #   -r requirements.in
-    #   flask-login
-    #   flask-migrate
-    #   flask-sqlalchemy
-    #   flask-wtf
-gunicorn==20.1.0
-    # via -r requirements.in
-itsdangerous==1.1.0
-    # via
-    #   flask
-    #   flask-wtf
-jinja2==2.11.3
-    # via flask
-mako==1.1.3
-    # via alembic
-markupsafe==1.1.1
-    # via
-    #   jinja2
-    #   mako
-    #   wtforms
-minio==7.0.2
-    # via -r requirements.in
-numpy==1.19.4
-    # via pandas
-pandas==1.2.3
-    # via -r requirements.in
-pycparser==2.20
-    # via cffi
-pymysql[rsa]==0.10.1
-    # via -r requirements.in
-python-dateutil==2.8.1
-    # via
-    #   alembic
-    #   pandas
-python-editor==1.0.4
-    # via alembic
-pytz==2020.4
-    # via pandas
-six==1.15.0
-    # via
-    #   cryptography
-    #   python-dateutil
-sqlalchemy==1.3.23
-    # via
-    #   -r requirements.in
-    #   alembic
-    #   flask-sqlalchemy
-urllib3==1.26.4
-    # via minio
-werkzeug==1.0.1
-    # via
-    #   -r requirements.in
-    #   flask
-wtforms==2.3.3
-    # via flask-wtf
+alembic==1.5.8            # via flask-migrate
+certifi==2020.12.5        # via minio
+cffi==1.14.5              # via cryptography
+click==7.1.2              # via flask
+cryptography==3.4.7       # via pymysql
+flask-login==0.5.0        # via -r requirements.in
+flask-migrate==2.7.0      # via -r requirements.in
+flask-sqlalchemy==2.5.1   # via -r requirements.in, flask-migrate
+flask-wtf==0.14.3         # via -r requirements.in
+flask==1.1.2              # via -r requirements.in, flask-login, flask-migrate, flask-sqlalchemy, flask-wtf
+greenlet==1.0.0           # via sqlalchemy
+gunicorn==20.1.0          # via -r requirements.in
+importlib-metadata==3.10.0  # via sqlalchemy
+itsdangerous==1.1.0       # via flask, flask-wtf
+jinja2==2.11.3            # via flask
+mako==1.1.4               # via alembic
+markupsafe==1.1.1         # via jinja2, mako, wtforms
+minio==7.0.3              # via -r requirements.in
+numpy==1.20.2             # via pandas
+pandas==1.2.3             # via -r requirements.in
+pycparser==2.20           # via cffi
+pymysql[rsa]==1.0.2       # via -r requirements.in
+python-dateutil==2.8.1    # via alembic, pandas
+python-editor==1.0.4      # via alembic
+pytz==2021.1              # via pandas
+six==1.15.0               # via python-dateutil
+sqlalchemy==1.4.6         # via -r requirements.in, alembic, flask-sqlalchemy
+typing-extensions==3.7.4.3  # via importlib-metadata
+urllib3==1.26.4           # via minio
+werkzeug==1.0.1           # via -r requirements.in, flask
+wtforms==2.3.3            # via flask-wtf
+zipp==3.4.1               # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/flask/requirements.txt
+++ b/flask/requirements.txt
@@ -30,7 +30,7 @@ python-dateutil==2.8.1    # via alembic, pandas
 python-editor==1.0.4      # via alembic
 pytz==2021.1              # via pandas
 six==1.15.0               # via python-dateutil
-sqlalchemy==1.4.6         # via -r requirements.in, alembic, flask-sqlalchemy
+sqlalchemy==1.3.24        # via -r requirements.in, alembic, flask-sqlalchemy
 typing-extensions==3.7.4.3  # via importlib-metadata
 urllib3==1.26.4           # via minio
 werkzeug==1.0.1           # via -r requirements.in, flask


### PR DESCRIPTION
pymysql[rsa] 1.0.2 is required for the database seed to work correctly. The rest seems to be a shortcoming of dependabot, maybe related to dependabot/dependabot-core#3447. If this continues to be an issue we can create a workflow to do this on a sprint cycle for pip and yarn instead.