### PR TITLE
Flask: add GET variant summary endpoint

### DIFF
--- a/flask/app/__init__.py
+++ b/flask/app/__init__.py
@@ -11,6 +11,7 @@ from app import (
     participants,
     tissue_samples,
     analyses,
+    gene_viewer,
     groups,
     users,
     manage,
@@ -45,6 +46,7 @@ def register_blueprints(app):
     app.register_blueprint(participants.participants_blueprint)
     app.register_blueprint(tissue_samples.tissue_blueprint)
     app.register_blueprint(analyses.analyses_blueprint)
+    app.register_blueprint(gene_viewer.gene_viewer_blueprint)
 
     app.register_blueprint(buckets.bucket_blueprint)
     app.register_blueprint(groups.groups_blueprint)

--- a/flask/app/gene_viewer.py
+++ b/flask/app/gene_viewer.py
@@ -1,0 +1,247 @@
+from dataclasses import asdict
+
+from flask import Blueprint, Response, abort, current_app as app, jsonify, request
+from flask_login import current_user, login_required
+from sqlalchemy.orm import contains_eager
+from sqlalchemy.sql import or_
+from sqlalchemy.sql.selectable import Select
+from sqlalchemy.engine.base import Engine
+
+import pandas as pd
+from . import models
+
+from .extensions import db
+
+from .utils import (
+    check_admin,
+    enum_validate,
+    filter_in_enum_or_abort,
+    filter_updated_or_abort,
+    mixin,
+    paged,
+    transaction_or_abort,
+)
+
+
+gene_viewer_blueprint = Blueprint(
+    "gene_viewer",
+    __name__,
+)
+
+
+def get_variant_wise_df(statement: Select, session: Engine):
+
+    df = pd.read_sql(statement, session)
+
+    app.logger.debug(df.head(3))
+
+    df = df[
+        [
+            "position",
+            "reference_allele",
+            "alt_allele",
+            "variation",
+            "refseq_change",
+            "depth",
+            "gene",
+            "conserved_in_20_mammals",
+            "sift_score",
+            "polyphen_score",
+            "cadd_score",
+            "gnomad_af",
+            "zygosity",
+            "burden",
+            "alt_depths",
+            "dataset_id",
+            "participant_id",
+            "participant_codename",
+            "family_id",
+            "family_codename",
+        ]
+    ]
+    df = df.loc[:, ~df.columns.duplicated()]
+    # some columns are duplicated eg. dataset_id, is there a way to query so that this doesn't happen?
+
+    df = df[~df["zygosity"].str.contains("-|Insufficient")]
+
+    df = df.astype(str)
+    df = df.groupby(["position", "reference_allele", "alt_allele"]).agg(
+        {
+            "variation": "first",
+            "refseq_change": "first",
+            "depth": list,
+            "gene": "first",
+            "conserved_in_20_mammals": "first",
+            "sift_score": "first",
+            "polyphen_score": "first",
+            "cadd_score": "first",
+            "gnomad_af": "first",
+            "zygosity": list,
+            "burden": list,
+            "alt_depths": list,
+            "dataset_id": list,
+            "participant_id": list,
+            "participant_codename": list,
+            "family_id": lambda x: set(x),
+            "family_codename": lambda x: set(x),
+        },
+        axis="columns",
+    )
+
+    df["frequency"] = df["participant_codename"].str.len()
+
+    for col in [
+        "zygosity",
+        "burden",
+        "alt_depths",
+        "depth",
+        "participant_codename",
+        "family_codename",
+        "dataset_id",
+        "participant_id",
+        "family_id",
+    ]:
+        df[col] = df[col].apply(lambda g: "; ".join(g))
+    return df
+
+
+@gene_viewer_blueprint.route("/api/summary/variants", methods=["GET"])
+@login_required
+def variant_summary():
+
+    app.logger.debug("Retrieving user id..")
+
+    if app.config.get("LOGIN_DISABLED") or current_user.is_admin:
+        user_id = request.args.get("user")
+        app.logger.debug("User is admin with ID '%s'", user_id)
+    else:
+        user_id = current_user.user_id
+        app.logger.debug("User is regular with ID '%s'", user_id)
+
+    if request.headers["Accept"] not in ["application/json", "text/csv"]:
+        app.logger.error("Unsupported HTTP accept")
+        abort(406, description="Unsupported HTTP accept")
+
+    app.logger.debug("Parsing query parameters..")
+
+    genes = request.args.getlist("genes")
+
+    app.logger.info("Requested genes are %s", genes)
+
+    if len(genes) == 0:
+
+        app.logger.error("No gene(s) provided in the request body")
+        abort(400, description="No gene(s) provided")
+
+    filters = [models.Gene.gene == gene for gene in genes]
+
+    if user_id:
+        app.logger.debug("Processing query - restricted based on user id.")
+        query = (
+            models.Gene.query.join(models.Gene.variants)
+            .join(models.Variant.genotype)
+            .join(models.Genotype.analysis, models.Genotype.dataset)
+            .join(models.Dataset.tissue_sample)
+            .join(models.TissueSample.participant)
+            .join(models.Participant.family)
+            .join(
+                models.groups_datasets_table,
+                models.Dataset.dataset_id
+                == models.groups_datasets_table.columns.dataset_id,
+            )
+            .join(
+                models.users_groups_table,
+                models.groups_datasets_table.columns.group_id
+                == models.users_groups_table.columns.group_id,
+            )
+            .options(
+                contains_eager(models.Gene.variants)
+                .contains_eager(models.Variant.genotype)
+                .contains_eager(models.Genotype.analysis)
+                .contains_eager(models.Analysis.datasets)
+                .contains_eager(models.Dataset.tissue_sample)
+                .contains_eager(models.TissueSample.participant)
+                .contains_eager(models.Participant.family),
+            )
+            .filter(or_(*filters), models.users_groups_table.columns.user_id == user_id)
+        )
+
+    else:
+        app.logger.debug("Processing query - unrestricted based on user id.")
+        query = (
+            models.Gene.query.join(models.Gene.variants)
+            .join(models.Variant.genotype)
+            .join(models.Genotype.analysis, models.Genotype.dataset)
+            .join(models.Dataset.tissue_sample)
+            .join(models.TissueSample.participant)
+            .join(models.Participant.family)
+            .options(
+                contains_eager(models.Gene.variants)
+                .contains_eager(models.Variant.genotype)
+                .contains_eager(models.Genotype.analysis)
+                .contains_eager(models.Analysis.datasets)
+                .contains_eager(models.Dataset.tissue_sample)
+                .contains_eager(models.TissueSample.participant)
+                .contains_eager(models.Participant.family),
+            )
+            .filter(or_(*filters))
+        )
+
+    q = query.all()
+
+    if len(q) == 0:
+        app.logger.error("No requested genes were found.")
+        abort(400, description="No requested genes were found.")
+    elif len(q) < len(genes):
+        app.logger.error("Not all requested genes were found.")
+        abort(400, description="Not all requested genes were found.")
+
+    if request.accept_mimetypes["application/json"]:
+
+        app.logger.info("Application/json Accept header requested")
+        return jsonify(
+            [
+                {
+                    **asdict(gene),
+                    "variants": [
+                        {
+                            **asdict(variant),
+                            "zygosity": [
+                                genotype.zygosity for genotype in variant.genotype
+                            ],
+                            "alt_depths": [
+                                genotype.alt_depths for genotype in variant.genotype
+                            ],
+                            "burden": [
+                                genotype.burden for genotype in variant.genotype
+                            ],
+                            "participant_codenames": [
+                                dataset.tissue_sample.participant.participant_codename
+                                for dataset in variant.analysis.datasets
+                            ],
+                        }
+                        for variant in gene.variants
+                    ],
+                }
+                for gene in q
+            ]
+        )
+
+    elif request.accept_mimetypes["text/csv"]:
+
+        app.logger.info("text/csv Accept header requested")
+
+        try:
+            agg_df = get_variant_wise_df(query.statement, query.session.bind)
+        except:
+            abort(500, "Unexpected error")
+
+        csv_data = agg_df.to_csv(encoding="utf-8")
+
+        response = Response(csv_data, mimetype="text/csv")
+
+        response.headers.set(
+            "Content-Disposition", "attachment", filename="variant_wise_report.csv"
+        )
+
+        return response

--- a/flask/app/gene_viewer.py
+++ b/flask/app/gene_viewer.py
@@ -124,9 +124,10 @@ def variant_summary():
 
     app.logger.debug("Parsing query parameters..")
 
-    genes = request.args.getlist("genes")
+    genes = request.args.get("panel")
+    genes = genes.split(";")
 
-    app.logger.info("Requested genes are %s", genes)
+    app.logger.info("Requested gene panel: %s", genes)
 
     if len(genes) == 0:
 

--- a/flask/app/gene_viewer.py
+++ b/flask/app/gene_viewer.py
@@ -248,3 +248,10 @@ def variant_summary():
         )
 
         return response
+    else:
+        app.logger.error(
+            "Only 'text/csv' and 'application/json' HTTP accept headers supported"
+        )
+        abort(
+            406, "Only 'text/csv' and 'application/json' HTTP accept headers supported"
+        )


### PR DESCRIPTION
closes #481 

couple things to note
- pagination has not been implemented yet to keep review simple 

- tests are WIP

- the select statement from the query generates duplicate columns as a result of the eager joining, i subset the dataframe columns using a list, if someone knows of a more elegant solution through the orm please let me know

- for each variant, an array of participant codenames and genotypic information is also returned

- i’ve compared the output of the csv in this endpoint with one created directly from the reports and they are identical across all fields

- example json output from the example GET request above (if this should not be public let me know and I can paste in the dev chat instead)
```
# curl  -H "Accept: text/csv" localhost:5000/api/summary/variants\?panel=LOXL4\;RTEL1
curl  -i -H "Accept: application/json" localhost:5000/api/summary/variants\?panel=LOXL4\;RTEL1

[
  {
    "ensembl_id": null, 
    "gene": "LOXL4", 
    "gene_id": 7350, 
    "hgnc_gene_id": null, 
    "hgnc_gene_name": null, 
    "variants": [
      {
        "alt_allele": "T", 
        "analysis_id": 4089, 
        "cadd_score": 25.2, 
        "conserved_in_20_mammals": 0.935, 
        "depth": 377, 
        "gene_id": 7350, 
        "genotype": [
          {
            "alt_depths": 0, 
            "analysis_id": 4089, 
            "burden": 0, 
            "dataset_id": 6250, 
            "participant_codename": "HA0154", 
            "variant_id": 15569, 
            "zygosity": "-"
          }, 
          {
            "alt_depths": 0, 
            "analysis_id": 4089, 
            "burden": 0, 
            "dataset_id": 6251, 
            "participant_codename": "HA0155", 
            "variant_id": 15569, 
            "zygosity": "-"
          }, 
          {
            "alt_depths": 62, 
            "analysis_id": 4089, 
            "burden": 1, 
            "dataset_id": 6252, 
            "participant_codename": "HA0156", 
            "variant_id": 15569, 
            "zygosity": "Het"
          }
        ], 
        "gnomad_af": 0.00058463, 
        "polyphen_score": 0.73, 
        "position": "10:100010909", 
        "reference_allele": "C", 
        "sift_score": 0.16, 
        "variant_id": 15569, 
        "variation": "missense_variant"
      }, 
      {
        "alt_allele": "A", 
        "analysis_id": 6145, 
        "cadd_score": 34.0, 
        "conserved_in_20_mammals": 0.953, 
        "depth": 311, 
        "gene_id": 7350, 
        "genotype": [
          {
            "alt_depths": 0, 
            "analysis_id": 6145, 
            "burden": 0, 
            "dataset_id": 8309, 
            "participant_codename": "TR0181", 
            "variant_id": 48193, 
            "zygosity": "-"
          }, 
          {
            "alt_depths": 0, 
            "analysis_id": 6145, 
            "burden": 0, 
            "dataset_id": 8310, 
            "participant_codename": "TR0182", 
            "variant_id": 48193, 
            "zygosity": "-"
          }, 
          {
            "alt_depths": 57, 
            "analysis_id": 6145, 
            "burden": 1, 
            "dataset_id": 8311, 
            "participant_codename": "TR0183", 
            "variant_id": 48193, 
            "zygosity": "Het"
          }
        ], 
        "gnomad_af": 0.00028506, 
        "polyphen_score": 0.964, 
        "position": "10:100016632", 
        "reference_allele": "G", 
        "sift_score": 0.03, 
        "variant_id": 48193, 
        "variation": "missense_variant"
      }, 
      {
        "alt_allele": "C", 
        "analysis_id": 6266, 
        "cadd_score": 27.1, 
        "conserved_in_20_mammals": 0.953, 
        "depth": 634, 
        "gene_id": 7350, 
        "genotype": [
          {
            "alt_depths": 92, 
            "analysis_id": 6266, 
            "burden": 1, 
            "dataset_id": 8430, 
            "participant_codename": "CH0639", 
            "variant_id": 54939, 
            "zygosity": "Het"
          }, 
          {
            "alt_depths": 0, 
            "analysis_id": 6266, 
            "burden": 0, 
            "dataset_id": 8431, 
            "participant_codename": "CH0640", 
            "variant_id": 54939, 
            "zygosity": "-"
          }, 
          {
            "alt_depths": 69, 
            "analysis_id": 6266, 
            "burden": 1, 
            "dataset_id": 8432, 
            "participant_codename": "CH3095", 
            "variant_id": 54939, 
            "zygosity": "Het"
          }
        ], 
        "gnomad_af": 0.00021667, 
        "polyphen_score": 0.998, 
        "position": "10:100016572", 
        "reference_allele": "G", 
        "sift_score": 0.02, 
        "variant_id": 54939, 
        "variation": "missense_variant"
      }, 
      {
        "alt_allele": "C", 
        "analysis_id": 7421, 
        "cadd_score": 27.1, 
        "conserved_in_20_mammals": 0.953, 
        "depth": 295, 
        "gene_id": 7350, 
        "genotype": [
          {
            "alt_depths": 54, 
            "analysis_id": 7421, 
            "burden": 1, 
            "dataset_id": 6654, 
            "participant_codename": "SK0201", 
            "variant_id": 73305, 
            "zygosity": "Het"
          }, 
          {
            "alt_depths": 34, 
            "analysis_id": 7421, 
            "burden": 1, 
            "dataset_id": 6655, 
            "participant_codename": "SK0202", 
            "variant_id": 73305, 
            "zygosity": "Het"
          }, 
          {
            "alt_depths": 0, 
            "analysis_id": 7421, 
            "burden": 0, 
            "dataset_id": 6656, 
            "participant_codename": "SK0203", 
            "variant_id": 73305, 
            "zygosity": "-"
          }
    
  ....
]
 ```
 ```
curl  -i  localhost:5000/api/summary/variants\?genes=LOXL4\&genes=RTEL1
HTTP/1.0 406 NOT ACCEPTABLE
Content-Type: application/json
Content-Length: 41
Server: Werkzeug/1.0.1 Python/3.7.9
Date: Mon, 12 Apr 2021 17:06:25 GMT

{
  "error": "Unsupported HTTP accept"
}
```