### PR TITLE
Flask: /api/groups fix-up related to CodeQL warning

### DIFF
--- a/flask/app/groups.py
+++ b/flask/app/groups.py
@@ -103,7 +103,7 @@ def update_group(group_code) -> Response:
 
     group = models.Group.query.filter_by(group_code=group_code).first_or_404()
 
-    if request.json.get("group_name", type=str):
+    if request.json.get("group_name"):
         # Check if display name is in use, 422
         conflicting_group = models.Group.query.filter_by(
             group_name=request.json["group_name"]
@@ -155,8 +155,8 @@ def create_group():
 
     Potential problems: MinIO operations failing result in an inconsistent state.
     """
-    group_name = request.json.get("group_name", type=str)
-    group_code = request.json.get("group_code", type=str)
+    group_name = request.json.get("group_name")
+    group_code = request.json.get("group_code")
     strlist_users = (
         request.json.get("users")  # Ignores the empty list
         and type(request.json["users"]) is list

--- a/flask/app/groups.py
+++ b/flask/app/groups.py
@@ -98,7 +98,7 @@ def update_group(group_code) -> Response:
     )
     if type(request.json) is not dict:
         abort(400, description="Expected object")
-    if "users" in strlist_users and not strlist_users:
+    if "users" in request.json and not strlist_users:
         abort(400, description="users should be a string array")
 
     group = models.Group.query.filter_by(group_code=group_code).first_or_404()
@@ -164,7 +164,7 @@ def create_group():
     )
     if type(request.json) is not dict:
         abort(400, description="Expected object")
-    if "users" in strlist_users and not strlist_users:
+    if "users" in request.json and not strlist_users:
         abort(400, description="users should be a string array")
     if not group_name:
         abort(400, description="A group display name must be provided")

--- a/flask/app/groups.py
+++ b/flask/app/groups.py
@@ -1,12 +1,13 @@
-from flask import abort, jsonify, request, Response, Blueprint, current_app as app
-from flask_login import login_user, logout_user, current_user, login_required
-from .extensions import db, login
-from . import models
-from sqlalchemy.orm import contains_eager, joinedload
-from .utils import check_admin, transaction_or_abort, mixin, validate_json
+from urllib.parse import quote
 
+from flask import abort, jsonify, request, Response, Blueprint, current_app as app
+from flask_login import current_user, login_required
 from minio import Minio
+
+from . import models
+from .extensions import db
 from .madmin import MinioAdmin, stager_buckets_policy
+from .utils import check_admin, transaction_or_abort, validate_json
 
 
 groups_blueprint = Blueprint(
@@ -17,7 +18,11 @@ groups_blueprint = Blueprint(
 
 @groups_blueprint.route("/api/groups", methods=["GET"])
 @login_required
-def list_groups():
+def list_groups() -> Response:
+    """
+    Enumerates all permission groups visible to the current user. Administrators
+    can see all groups; regular users can see groups that they are a member of.
+    """
     if app.config.get("LOGIN_DISABLED") or current_user.is_admin:
         user_id = request.args.get("user")
     else:
@@ -42,7 +47,11 @@ def list_groups():
 
 @groups_blueprint.route("/api/groups/<string:group_code>", methods=["GET"])
 @login_required
-def get_group(group_code):
+def get_group(group_code) -> Response:
+    """
+    Enumerate all activated users in a group and retrieve group metadata. Administrators
+    can read all groups; regular users can only read groups that they are a member of.
+    """
     if app.config.get("LOGIN_DISABLED") or current_user.is_admin:
         user_id = request.args.get("user")
     else:
@@ -53,15 +62,12 @@ def get_group(group_code):
             models.Group.query.filter(models.Group.group_code == group_code)
             .join(models.Group.users)
             .filter(models.User.user_id == user_id)
-            .one_or_none()
+            .first_or_404()
         )
     else:
         group = models.Group.query.filter(
             models.Group.group_code == group_code
-        ).one_or_none()
-
-    if group is None:
-        abort(403, description="Forbidden")
+        ).first_or_404()
 
     return jsonify(
         {
@@ -78,19 +84,22 @@ def get_group(group_code):
 @login_required
 @check_admin
 @validate_json
-def update_group(group_code):
+def update_group(group_code) -> Response:
+    """
+    Change the display name or user membership of a group. Administrator-only.
 
+    Potential problems: MinIO operations failing result in an inconsistent state.
+    """
     group = models.Group.query.filter_by(group_code=group_code).first_or_404()
 
-    if "group_name" in request.json:
-        if request.json["group_name"]:
-            # Check if display name is in use, 422
-            conflicting_group = models.Group.query.filter_by(
-                group_name=request.json["group_name"]
-            ).one_or_none()
-            if (conflicting_group is not None) and (conflicting_group != group):
-                abort(422, description="Group name in use")
-            group.group_name = request.json["group_name"]
+    if request.json.get("group_name"):
+        # Check if display name is in use, 422
+        conflicting_group = models.Group.query.filter_by(
+            group_name=request.json["group_name"]
+        ).one_or_none()
+        if (conflicting_group is not None) and (conflicting_group != group):
+            abort(422, description="Group name in use")
+        group.group_name = request.json["group_name"]
 
     minio_admin = MinioAdmin(
         endpoint=app.config["MINIO_ENDPOINT"],
@@ -99,7 +108,11 @@ def update_group(group_code):
     )
 
     # Check if a user to be added doesn't exist, 404
-    if "users" in request.json:
+    if (
+        "users" in request.json
+        and type(request.json["users"]) is list
+        and all([type(user) is str for user in request.json["users"]])
+    ):
         users = models.User.query.filter(
             models.User.username.in_(request.json["users"])
         ).all()
@@ -121,12 +134,8 @@ def update_group(group_code):
         # Reset policy for group in case the group did not exist
         minio_admin.set_policy(group_code, group=group_code)
 
-    try:
-        db.session.commit()
-        return jsonify(group)
-    except:
-        db.session.rollback()
-        abort(500)
+    transaction_or_abort(db.session.commit)
+    return jsonify(group)
 
 
 @groups_blueprint.route("/api/groups", methods=["POST"])
@@ -134,7 +143,11 @@ def update_group(group_code):
 @check_admin
 @validate_json
 def create_group():
+    """
+    Create a new permission group. Administrator-only.
 
+    Potential problems: MinIO operations failing result in an inconsistent state.
+    """
     group_name = request.json.get("group_name")
     group_code = request.json.get("group_code")
 
@@ -143,10 +156,14 @@ def create_group():
     if not group_code:
         abort(400, description="A group codename must be provided")
 
-    if models.Group.query.filter(
-        (models.Group.group_code == group_code)
-        | (models.Group.group_name == group_name)
-    ).value("group_id"):
+    if (
+        db.session.query(models.Group.group_id)
+        .filter(
+            (models.Group.group_code == group_code)
+            | (models.Group.group_name == group_name)
+        )
+        .first()
+    ):
         abort(422, description="Group already exists")
 
     minio_client = Minio(
@@ -170,43 +187,48 @@ def create_group():
     except:
         abort(422, description="Invalid bucket name")
 
-    group_obj = models.Group(group_code=group_code, group_name=group_name)
+    group = models.Group(group_code=group_code, group_name=group_name)
 
     # Add users to the db if they were given
-    if request.json.get("users"):
+    have_users = (
+        request.json.get("users")  # Ignores the empty list
+        and type(request.json["users"]) is list
+        and all([type(user) is str for user in request.json["users"]])
+    )
+    if have_users:
         users = models.User.query.filter(
             models.User.username.in_(request.json["users"])
         ).all()
         # Make sure all users are valid
         if len(users) != len(request.json["users"]):
             abort(404, description="Invalid username provided")
-        group_obj.users += users
+        group.users += users
 
     # Make corresponding policy
     policy = stager_buckets_policy(group_code)
     minio_admin.add_policy(group_code, policy)
 
     # Add users to minio group if applicable, creating group as well
-    if request.json.get("users"):
+    if have_users:
         for user in users:
             minio_admin.group_add(group_code, user.minio_access_key)
 
         # Set group access policy to the bucket by the same name
         minio_admin.set_policy(group_code, group=group_code)
 
-    db.session.add(group_obj)
+    db.session.add(group)
     transaction_or_abort(db.session.commit)
-
-    location_header = "/api/groups/{}".format(group_obj.group_code)
-
-    return request.json, 201, {"location": location_header}
+    return request.json, 201, {"location": f"/api/groups/{quote(group.group_code)}"}
 
 
 @groups_blueprint.route("/api/groups/<string:group_code>", methods=["DELETE"])
 @login_required
 @check_admin
 def delete_group(group_code):
-
+    """
+    If the permission group is empty, removes the permission group, but retains
+    the MinIO bucket. Administrator-only.
+    """
     group = models.Group.query.filter_by(group_code=group_code).first_or_404()
 
     minio_admin = MinioAdmin(
@@ -223,6 +245,9 @@ def delete_group(group_code):
     if group_code in minio_admin.list_groups():
         group_info = minio_admin.get_group(group_code)
         if "members" in group_info:
+            app.logger.warn(
+                f"Group {group_code} has members in MinIO but not the database"
+            )
             abort(422, description="Group has users, cannot delete!")
 
     try:
@@ -230,10 +255,13 @@ def delete_group(group_code):
         db.session.delete(group)
         db.session.commit()
     except:
+        app.logger.exception(f"Could not delete permission group {group_code}!")
         db.session.rollback()
         abort(422, description="Deletion of entity failed!")
 
     try:
         minio_admin.group_remove(group_code)
+    except:
+        app.logger.exception(f"Removing MinIO group {group_code}")
     finally:
         return "Deletion successful", 204

--- a/flask/app/groups.py
+++ b/flask/app/groups.py
@@ -218,7 +218,11 @@ def create_group():
 
     db.session.add(group)
     transaction_or_abort(db.session.commit)
-    return request.json, 201, {"location": f"/api/groups/{quote(group.group_code)}"}
+    return (
+        jsonify(request.json),
+        201,
+        {"location": f"/api/groups/{quote(group.group_code)}"},
+    )
 
 
 @groups_blueprint.route("/api/groups/<string:group_code>", methods=["DELETE"])

--- a/flask/tests/test_groups.py
+++ b/flask/tests/test_groups.py
@@ -85,7 +85,7 @@ def test_list_groups_user_from_admin(test_database, client, login_as):
 def test_get_group(test_database, client, login_as):
     # Test invalid group_code
     login_as("admin")
-    assert client.get("/api/groups/hahah").status_code == 403
+    assert client.get("/api/groups/hahah").status_code == 404
 
     group_2 = models.Group(group_code="alas", group_name="...")
     db.session.add(group_2)
@@ -93,10 +93,9 @@ def test_get_group(test_database, client, login_as):
 
     # Test wrong permissions
     login_as("user")
-    assert client.get("/api/groups/alas").status_code == 403
+    assert client.get("/api/groups/alas").status_code == 404
 
     # Test and validate success based on user's permissions
-    login_as("user")
     response = client.get("/api/groups/ach")
     assert response.status_code == 200
     assert response.get_json()["group_name"] == "Alberta"


### PR DESCRIPTION
There is no XSS risk as responses are JSON, but the location header was not escaped (not a problem specifically for group code as it has to be a valid domain name).

- Add type hints and docstrings to all endpoints
- Change group not found error code, regardless of authorization, to 404
- Validate the typing of the users array for the create and update endpoints
- Update a query's syntax for SQLAlchemy 1.4
- Escape the group code in the location header anyway
- Log some exceptions