### PR TITLE
Flask: /api/users fix-up related to CodeQL warning

### DIFF
--- a/flask/app/groups.py
+++ b/flask/app/groups.py
@@ -6,8 +6,8 @@ from minio import Minio
 
 from . import models
 from .extensions import db
-from .madmin import MinioAdmin, stager_buckets_policy
-from .utils import check_admin, transaction_or_abort, validate_json
+from .madmin import stager_buckets_policy
+from .utils import check_admin, get_minio_admin, transaction_or_abort, validate_json
 
 
 groups_blueprint = Blueprint(
@@ -112,11 +112,7 @@ def update_group(group_code) -> Response:
             abort(422, description="Group name in use")
         group.group_name = request.json["group_name"]
 
-    minio_admin = MinioAdmin(
-        endpoint=app.config["MINIO_ENDPOINT"],
-        access_key=app.config["MINIO_ACCESS_KEY"],
-        secret_key=app.config["MINIO_SECRET_KEY"],
-    )
+    minio_admin = get_minio_admin()
 
     # Check if a user to be added doesn't exist, 404
     if strlist_users:
@@ -188,11 +184,7 @@ def create_group():
         secure=False,
     )
 
-    minio_admin = MinioAdmin(
-        endpoint=app.config["MINIO_ENDPOINT"],
-        access_key=app.config["MINIO_ACCESS_KEY"],
-        secret_key=app.config["MINIO_SECRET_KEY"],
-    )
+    minio_admin = get_minio_admin()
 
     try:
         # Create minio bucket via mc, 422 if it already exists
@@ -245,11 +237,7 @@ def delete_group(group_code):
     """
     group = models.Group.query.filter_by(group_code=group_code).first_or_404()
 
-    minio_admin = MinioAdmin(
-        endpoint=app.config["MINIO_ENDPOINT"],
-        access_key=app.config["MINIO_ACCESS_KEY"],
-        secret_key=app.config["MINIO_SECRET_KEY"],
-    )
+    minio_admin = get_minio_admin()
 
     # Check group users in db
     if len(group.users) != 0:

--- a/flask/app/users.py
+++ b/flask/app/users.py
@@ -9,7 +9,7 @@ from sqlalchemy.orm import joinedload
 from . import models
 from .extensions import db
 from .madmin import MinioAdmin
-from .utils import check_admin, transaction_or_abort, validate_json
+from .utils import check_admin, get_minio_admin, transaction_or_abort, validate_json
 
 
 users_blueprint = Blueprint(
@@ -84,14 +84,6 @@ def get_user(username: str) -> Response:
     )
     app.logger.debug("Success, returning JSON")
     return jsonify_user(user)
-
-
-def get_minio_admin() -> MinioAdmin:
-    return MinioAdmin(
-        endpoint=app.config["MINIO_ENDPOINT"],
-        access_key=app.config["MINIO_ACCESS_KEY"],
-        secret_key=app.config["MINIO_SECRET_KEY"],
-    )
 
 
 def safe_remove(user: models.User, minio_admin: MinioAdmin = None) -> None:

--- a/flask/app/utils.py
+++ b/flask/app/utils.py
@@ -10,6 +10,7 @@ from sqlalchemy import exc
 from werkzeug.exceptions import HTTPException
 
 from .extensions import db
+from .madmin import MinioAdmin
 
 
 def handle_error(e):
@@ -141,6 +142,14 @@ def filter_updated_or_abort(column: db.Column, value: str):
         return column >= updated[1]
     else:
         abort(400, description=description)
+
+
+def get_minio_admin() -> MinioAdmin:
+    return MinioAdmin(
+        endpoint=app.config["MINIO_ENDPOINT"],
+        access_key=app.config["MINIO_ACCESS_KEY"],
+        secret_key=app.config["MINIO_SECRET_KEY"],
+    )
 
 
 class DateTimeEncoder(JSONEncoder):

--- a/flask/tests/test_users.py
+++ b/flask/tests/test_users.py
@@ -127,8 +127,8 @@ def test_get_user_user(test_database, client, login_as):
     assert client.get("/api/users/user").status_code == 401
 
     login_as("user")
-    assert client.get("/api/users/foo").status_code == 401
-    assert client.get("/api/users/admin").status_code == 401
+    assert client.get("/api/users/foo").status_code == 403
+    assert client.get("/api/users/admin").status_code == 403
 
     response = client.get("/api/users/user")
     assert response.status_code == 200
@@ -180,13 +180,13 @@ def test_reset_minio_user(test_database, minio_policy, client, login_as):
         client.post(
             "/api/users/foo", headers={"Content-Type": "application/json"}
         ).status_code
-        == 401
+        == 403
     )
     assert (
         client.post(
             "/api/users/admin", headers={"Content-Type": "application/json"}
         ).status_code
-        == 401
+        == 403
     )
 
     assert_reset("user", client)


### PR DESCRIPTION
There is no XSS risk as responses are JSON, but the location header was not escaped, and usernames may contain arbitrary characters. This fixes that so the resulting location header is always usable, and also addresses usernames with slashes.

- Add type hints and docstrings to all endpoints
- Refactor: move get_minio_admin to utils
- Log some exceptions
- Add a simple assertion for request body typing
- Fix create_user not returning the Location header for the actual conflicting user