### PR TITLE
connect autocomplete to variant csv endpoint

### DIFF
--- a/react/src/SearchVariants/components/SearchVariantsPage.tsx
+++ b/react/src/SearchVariants/components/SearchVariantsPage.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from "react";
 import { Box, Container, Grid, makeStyles, Typography } from "@material-ui/core";
+import { useSnackbar } from "notistack";
 import GeneAutocomplete from "./Autocomplete";
 import { Gene } from "../../typings";
 import { useVariantsQuery } from "../../hooks/variants";
@@ -24,14 +25,17 @@ const SearchVariantsPage: React.FC<SearchVariantsPageProps> = () => {
     const [selectedGene, setSelectedGene] = useState<Gene>();
     const [error, setError] = useState(false);
 
+    const { enqueueSnackbar } = useSnackbar();
+
     const { data: blob } = useVariantsQuery({ panel: selectedGene?.hgnc_gene_name }, "csv", {
         enabled: !!selectedGene,
-        onError: e => {
+        onError: response => {
             //I'm not sure how common this scenario will be
-            if (e.status === 400) {
+            if (response.status === 400) {
                 setError(true);
             } else {
-                throw e;
+                const errorText = response.statusText;
+                enqueueSnackbar(`Query Failed. Error: ${errorText}`, { variant: "error" });
             }
         },
     });

--- a/react/src/SearchVariants/components/SearchVariantsPage.tsx
+++ b/react/src/SearchVariants/components/SearchVariantsPage.tsx
@@ -1,8 +1,7 @@
 import React, { useEffect, useState } from "react";
-import { Box, Container, Grid, makeStyles, Typography } from "@material-ui/core";
+import { Box, Button, Chip, Container, Grid, makeStyles, Typography } from "@material-ui/core";
 import { useSnackbar } from "notistack";
 import GeneAutocomplete from "./Autocomplete";
-import { Gene } from "../../typings";
 import { useVariantsQuery } from "../../hooks/variants";
 import { downloadCsvResponse } from "../../hooks/utils";
 
@@ -22,15 +21,22 @@ const useStyles = makeStyles(theme => ({
 }));
 
 const SearchVariantsPage: React.FC<SearchVariantsPageProps> = () => {
-    const [selectedGene, setSelectedGene] = useState<Gene>();
+    const [selectedGenes, setSelectedGenes] = useState<string[]>([]);
     const [error, setError] = useState(false);
 
     const { enqueueSnackbar } = useSnackbar();
 
-    const { data: blob } = useVariantsQuery({ panel: selectedGene?.hgnc_gene_name }, "csv", {
-        enabled: !!selectedGene,
+    const updateSelectedGenes = (gene: string) => {
+        if (gene && !selectedGenes.includes(gene)) {
+            setSelectedGenes(selectedGenes.concat(gene));
+        } else {
+            setSelectedGenes(selectedGenes.filter(g => g !== gene));
+        }
+    };
+
+    const { data: blob, refetch } = useVariantsQuery({ panel: selectedGenes.join(";") }, "csv", {
+        enabled: false,
         onError: response => {
-            //I'm not sure how common this scenario will be
             if (response.status === 400) {
                 setError(true);
             } else {
@@ -43,15 +49,16 @@ const SearchVariantsPage: React.FC<SearchVariantsPageProps> = () => {
     const clearError = () => {
         if (error) {
             setError(false);
+            setSelectedGenes([]);
         }
     };
 
     useEffect(() => {
-        if (blob && selectedGene) {
+        if (blob && selectedGenes) {
             downloadCsvResponse(blob);
-            setSelectedGene(undefined);
+            setSelectedGenes([]);
         }
-    }, [selectedGene, blob]);
+    }, [selectedGenes, blob]);
 
     useEffect(() => {
         document.title = `Search Variants | ${process.env.REACT_APP_NAME}`;
@@ -63,25 +70,70 @@ const SearchVariantsPage: React.FC<SearchVariantsPageProps> = () => {
         <main className={classes.content}>
             <div className={classes.appBarSpacer} />
             <Container className={classes.container} maxWidth={false}>
-                <Grid container justify="center">
+                <Grid spacing={3} direction="column" container alignItems="center">
                     <Grid item xs={12}>
                         <Typography align="center" variant="h3">
                             Search for Variants by Gene
                         </Typography>
                     </Grid>
-                    <Grid item xs={12} md={6}>
-                        <Box padding={4}>
+                    <Grid
+                        container
+                        justify="center"
+                        alignItems="center"
+                        spacing={1}
+                        item
+                        xs={12}
+                        md={6}
+                        wrap="nowrap"
+                    >
+                        <Grid item xs={12}>
                             <GeneAutocomplete
                                 fullWidth={true}
                                 onSearch={clearError}
-                                onSelect={gene => setSelectedGene(gene)}
+                                onSelect={gene =>
+                                    gene.hgnc_gene_name
+                                        ? updateSelectedGenes(gene.hgnc_gene_name)
+                                        : /* this shouldn't happen since we're querying on this field in the first place */
+                                          console.error(`Gene id ${gene.gene_id} has no gene name`)
+                                }
                             />
-                        </Box>
+                        </Grid>
+                        <Grid item>
+                            <Button
+                                disabled={!selectedGenes.length}
+                                onClick={() => refetch()}
+                                size="large"
+                                variant="contained"
+                            >
+                                Submit
+                            </Button>
+                        </Grid>
+                    </Grid>
+                    <Grid container item xs={12} md={6} wrap="nowrap">
+                        <Grid item>
+                            {!!selectedGenes.length && (
+                                <Box padding={1} margin={1}>
+                                    <Typography>Selected Genes</Typography>
+                                </Box>
+                            )}
+                        </Grid>
+                        <Grid item container xs={12}>
+                            {selectedGenes.map(g => (
+                                <Grid item key={g}>
+                                    <Box key={g} padding={1} margin={1}>
+                                        <Chip label={g} onDelete={() => updateSelectedGenes(g)} />
+                                    </Box>
+                                </Grid>
+                            ))}
+                        </Grid>
                     </Grid>
                     <Grid item xs={12}>
                         {error && (
                             <Typography align="center" color="error">
-                                No variants found for {selectedGene?.hgnc_gene_name}
+                                No variants found for{" "}
+                                {selectedGenes.length === 1
+                                    ? selectedGenes[0]
+                                    : selectedGenes.join(", ")}
                             </Typography>
                         )}
                     </Grid>

--- a/react/src/hooks/utils.tsx
+++ b/react/src/hooks/utils.tsx
@@ -34,10 +34,10 @@ export async function basicFetch(
 }
 
 /**
- * Fetch csv from provided url. Download csv if successful.
+ * Fetch csv from provided url. Return blob and filename if successful (both should be included in cached response).
  * Throw the response if unsuccessful.
  */
-export async function fetchAndDownloadCsv(
+export async function fetchCsv(
     url: string,
     params: Record<string, any> = {},
     options: RequestInit | undefined = {}
@@ -51,20 +51,26 @@ export async function fetchAndDownloadCsv(
     const response = await fetch(`${url}${paramString}`, { ...options, headers });
 
     if (response.ok) {
-        const csvBlob = await response.blob();
-        const downloadLink = document.createElement("a");
-        const filename = (
-            response.headers.get("content-disposition") || "filename=report.csv"
-        ).replace(/.+=/, "");
-        const url = URL.createObjectURL(csvBlob);
-        downloadLink.href = url;
-        downloadLink.download = filename;
-        downloadLink.click();
-        URL.revokeObjectURL(url);
+        return {
+            blob: await response.blob(),
+            filename: (
+                response.headers.get("content-disposition") || "filename=report.csv"
+            ).replace(/.+=/, ""),
+        };
     } else {
         throw response;
     }
 }
+
+export const downloadCsvResponse = (args: { filename: string; blob: Blob }) => {
+    const { filename, blob } = args;
+    const downloadLink = document.createElement("a");
+    const url = URL.createObjectURL(blob);
+    downloadLink.href = url;
+    downloadLink.download = filename;
+    downloadLink.click();
+    URL.revokeObjectURL(url);
+};
 
 /**
  * Builds a data fetch request and returns a promise that resolves

--- a/react/src/hooks/variants/useVariantsQuery.ts
+++ b/react/src/hooks/variants/useVariantsQuery.ts
@@ -1,27 +1,38 @@
-import { useQuery } from "react-query";
-import { Variant } from "../../typings";
-import { basicFetch, fetchAndDownloadCsv } from "../utils";
+import { Variant } from "@material-ui/core/styles/createTypography";
+import { QueryObserverOptions, useQuery } from "react-query";
+import { basicFetch, fetchCsv } from "../utils";
 
 async function fetchVariants(params: Record<string, any>, returnType: "csv" | "json" = "csv") {
     const headers = { Accept: returnType === "csv" ? "text/csv" : "application/json" };
     if (returnType === "csv") {
-        return fetchAndDownloadCsv("/api/summary/variants", {}, { headers });
+        return fetchCsv("/api/summary/variants", params, { headers });
     } else {
         return await basicFetch("/api/summary/variants", params, { headers });
     }
 }
 
 /**
- * Return result of GET /api/variants
- *
+ * Return response of GET /api/variants
  */
-export const useVariantsQuery = (
+
+type BlobResponse = { filename: string; blob: Blob };
+
+export const useVariantsQuery = <T extends "csv" | "json">(
     params: Record<string, any>,
-    returnType: "csv" | "json",
-    enabled: boolean
-) =>
-    useQuery<Variant[], Response>(
+    returnType: T,
+    options: QueryObserverOptions<T extends "csv" ? BlobResponse : Variant[], Response>
+) => {
+    if (returnType === "csv") {
+        //never refetch csv
+        options.staleTime = Infinity;
+        options.retry = false;
+        options.refetchInterval = false;
+        options.refetchOnMount = false;
+    }
+
+    return useQuery<T extends "csv" ? BlobResponse : Variant[], Response>(
         ["variants", returnType, params],
         fetchVariants.bind(null, params, returnType),
-        { enabled }
+        options
     );
+};


### PR DESCRIPTION
* Connect variant/csv endpoint to front-end variant viewer
* return csv and automatically download when user selects gene from autocomplete list
* cache csv as blob/filename in browser via react-query
* handle 400 errors if no variants returned for selected gene