### PR TITLE
Add analysis priority flag to fe components and process attribute in backend routes

### DIFF
--- a/flask/app/analyses.py
+++ b/flask/app/analyses.py
@@ -319,6 +319,9 @@ def create_analysis():
         datasets=found_datasets,
     )
 
+    if request.json.get("priority"):
+        analysis.priority = request.json.get("priority")
+
     db.session.add(analysis)
     transaction_or_abort(db.session.commit)
 

--- a/flask/app/utils.py
+++ b/flask/app/utils.py
@@ -28,10 +28,10 @@ def mixin(
             column = getattr(entity, field)  # will be None if no value for field in db
             value = json_mixin[field]
             if isinstance(column, Enum):
-                is_valid_null = (
+                is_null_valid = (
                     entity.__table__.columns[field].nullable and value is None
                 )
-                if not hasattr(type(column), str(value)) and not is_valid_null:
+                if not hasattr(type(column), str(value)) and not is_null_valid:
                     allowed = [e.value for e in type(column)]
                     return f'"{field}" must be one of {allowed}'
             setattr(entity, field, value)

--- a/flask/tests/test_analyses.py
+++ b/flask/tests/test_analyses.py
@@ -95,7 +95,7 @@ def test_delete_analysis(test_database, client, login_as):
 # PATCH /api/analyses/:id
 
 
-def test_update_participant(test_database, client, login_as):
+def test_update_analysis(test_database, client, login_as):
     login_as("user")
     # Test existence
     assert (
@@ -109,12 +109,11 @@ def test_update_participant(test_database, client, login_as):
     )
     # Test assignee does not exist
     assert client.patch("/api/analyses/1", json={"assignee": "nope"}).status_code == 400
+
     # Test enum error - doesn't really apply anymore if we get check for valid enums separately
     assert (
-        client.patch(
-            "/api/analyses/1", json={"analysis_state": "not_an_enum"}
-        ).status_code
-        == 403
+        client.patch("/api/analyses/1", json={"priority": "not_an_enum"}).status_code
+        == 400
     )
     # test analysis state restriction for users
     for state in ["Requested", "Running", "Done", "Error"]:
@@ -183,6 +182,15 @@ def test_create_analysis(test_database, client, login_as):
     assert (
         client.post(
             "/api/analyses", json={"datasets": [1, 2], "pipeline_id": "lol nah"}
+        ).status_code
+        == 400
+    )
+
+    # Test invalid invalid priority given
+    assert (
+        client.post(
+            "/api/analyses",
+            json={"datasets": [3], "pipeline_id": 2, "priority": "FOO"},
         ).status_code
         == 400
     )

--- a/react/src/Analyses/index.tsx
+++ b/react/src/Analyses/index.tsx
@@ -338,9 +338,9 @@ export default function Analyses() {
                             type: "string",
                             width: "8%",
                             lookup: priorityLookup,
-                            editComponent: ({ onChange }) => (
+                            editComponent: ({ onChange, value }) => (
                                 <Select
-                                    value={props.value || "None"}
+                                    value={value || "None"}
                                     onChange={event => onChange(event.target.value)}
                                     fullWidth
                                 >

--- a/react/src/Analyses/index.tsx
+++ b/react/src/Analyses/index.tsx
@@ -338,20 +338,30 @@ export default function Analyses() {
                             type: "string",
                             width: "8%",
                             lookup: priorityLookup,
-                            editComponent: ({ onChange, value }) => (
-                                <Select
-                                    value={value || "None"}
-                                    onChange={event => onChange(event.target.value)}
-                                    fullWidth
-                                >
-                                    {enums?.PriorityType.map(p => (
-                                        <MenuItem key={p} value={p}>
-                                            {p}
-                                        </MenuItem>
-                                    ))}
-                                    <MenuItem value="None">None</MenuItem>
-                                </Select>
-                            ),
+                            editComponent: ({ onChange, value }) => {
+                                //react doesn't like default null values in forms so we have to workaround
+                                const cast = value ? value : "None";
+                                return (
+                                    <Select
+                                        value={cast}
+                                        onChange={event =>
+                                            onChange(
+                                                event.target.value === "None"
+                                                    ? null
+                                                    : event.target.value
+                                            )
+                                        }
+                                        fullWidth
+                                    >
+                                        {enums?.PriorityType.map(p => (
+                                            <MenuItem key={p} value={p}>
+                                                {p}
+                                            </MenuItem>
+                                        ))}
+                                        <MenuItem value={"None"}>None</MenuItem>
+                                    </Select>
+                                );
+                            },
                         },
                         {
                             title: "Requester",
@@ -558,7 +568,7 @@ export default function Analyses() {
                             analysisUpdateMutation.mutate(
                                 { ...newData, source: "row-edit" },
                                 {
-                                    onSuccess: newRow => {
+                                    onSuccess: () => {
                                         enqueueSnackbar(
                                             `Analysis ID ${oldData?.analysis_id} edited successfully`,
                                             { variant: "success" }

--- a/react/src/Analyses/index.tsx
+++ b/react/src/Analyses/index.tsx
@@ -339,11 +339,9 @@ export default function Analyses() {
                             width: "8%",
                             lookup: priorityLookup,
                             editComponent: ({ onChange, value }) => {
-                                //react doesn't like default null values in forms so we have to workaround
-                                const cast = value ? value : "None";
                                 return (
                                     <Select
-                                        value={cast}
+                                        value={value || "None"}
                                         onChange={event =>
                                             onChange(
                                                 event.target.value === "None"
@@ -358,7 +356,7 @@ export default function Analyses() {
                                                 {p}
                                             </MenuItem>
                                         ))}
-                                        <MenuItem value={"None"}>None</MenuItem>
+                                        <MenuItem value="None">None</MenuItem>
                                     </Select>
                                 );
                             },

--- a/react/src/Datasets/components/AnalysisRunnerDialog.tsx
+++ b/react/src/Datasets/components/AnalysisRunnerDialog.tsx
@@ -114,9 +114,7 @@ export default function AnalysisRunnerDialog({
                                 name="priorities"
                                 value={analysisPriority}
                                 onChange={(event: React.ChangeEvent<HTMLInputElement>) =>
-                                    setAnalysisPriority(
-                                        event.target.value as AnalysisPriority | "None"
-                                    )
+                                    setAnalysisPriority(event.target.value as AnalysisPriority)
                                 }
                             >
                                 {enums?.PriorityType.concat("None").map(priorityName => (

--- a/react/src/Datasets/components/AnalysisRunnerDialog.tsx
+++ b/react/src/Datasets/components/AnalysisRunnerDialog.tsx
@@ -74,7 +74,7 @@ export default function AnalysisRunnerDialog({
                     <Grid item>
                         <FormControl component="fieldset">
                             <FormLabel component="legend" className={classes.text}>
-                                Pipelines*:
+                                Pipelines:
                             </FormLabel>
                             <RadioGroup
                                 row
@@ -159,6 +159,7 @@ export default function AnalysisRunnerDialog({
                     Cancel
                 </Button>
                 <Button
+                    disabled={!pipeline}
                     variant="contained"
                     onClick={async () => {
                         onClose();

--- a/react/src/Datasets/components/AnalysisRunnerDialog.tsx
+++ b/react/src/Datasets/components/AnalysisRunnerDialog.tsx
@@ -35,10 +35,6 @@ const useStyles = makeStyles(theme => ({
     text: {
         paddingBottom: theme.spacing(1),
     },
-    warningText: {
-        paddingBottom: theme.spacing(1),
-        color: theme.palette.error.dark,
-    },
 }));
 
 export default function AnalysisRunnerDialog({
@@ -77,10 +73,7 @@ export default function AnalysisRunnerDialog({
                 <Grid container direction="column">
                     <Grid item>
                         <FormControl component="fieldset">
-                            <FormLabel
-                                component="legend"
-                                className={pipeline ? classes.text : classes.warningText}
-                            >
+                            <FormLabel component="legend" className={classes.text}>
                                 Pipelines*:
                             </FormLabel>
                             <RadioGroup
@@ -166,7 +159,6 @@ export default function AnalysisRunnerDialog({
                     Cancel
                 </Button>
                 <Button
-                    disabled={!pipeline}
                     variant="contained"
                     onClick={async () => {
                         onClose();

--- a/react/src/hooks/analyses/useAnalysisCreateMutation.tsx
+++ b/react/src/hooks/analyses/useAnalysisCreateMutation.tsx
@@ -1,10 +1,11 @@
 import { useMutation, useQueryClient } from "react-query";
-import { Analysis, Dataset, Pipeline } from "../../typings";
+import { Analysis, AnalysisPriority, Dataset, Pipeline } from "../../typings";
 import { addToCachedList, changeFetch } from "../utils";
 
 interface NewAnalysisParams {
     datasets: Dataset["dataset_id"][];
     pipeline_id: Pipeline["pipeline_id"];
+    priority?: AnalysisPriority;
 }
 
 async function createAnalysis(params: NewAnalysisParams) {

--- a/react/src/hooks/analyses/useAnalysisUpdateMutation.tsx
+++ b/react/src/hooks/analyses/useAnalysisUpdateMutation.tsx
@@ -15,6 +15,7 @@ async function patchAnalysis(newAnalysis: AnalysisOptions) {
         // We only allow updating these fields via the MTable row edit feature
         updates = {
             notes: analysis.notes,
+            priority: analysis.priority,
             result_path: analysis.result_path,
         };
     }

--- a/react/src/typings.tsx
+++ b/react/src/typings.tsx
@@ -12,6 +12,11 @@ export enum PipelineStatus {
     CANCELLED = "Cancelled",
 }
 
+export enum AnalysisPriority {
+    CLINICAL = "Clinical",
+    RESEARCH = "Research",
+}
+
 /*****   INTERFACES   *****/
 export interface Family {
     family_id: string;
@@ -95,6 +100,7 @@ export interface Analysis {
     assignee: string;
     requester: string;
     analysis_state: PipelineStatus;
+    priority: AnalysisPriority;
     updated: string;
     notes: string;
     dataset_id: string;
@@ -118,6 +124,7 @@ export type AnalysisChange = Pick<Analysis, "analysis_id"> &
         Pick<
             Analysis,
             | "analysis_state"
+            | "priority"
             | "pipeline_id"
             | "qsubID"
             | "result_path"


### PR DESCRIPTION
close #505 
* Allow users to specify priority in run analysis modal
* Highlight rows in analysis table with Clinical or Research priority
* Filter by priority in analysis table
* Validate priority value in patch/post routes and add priority filter to index route
* Update tests