### PR TITLE
Flask: accept trailing slashes for endpoints with children

### DIFF
--- a/flask/app/datasets.py
+++ b/flask/app/datasets.py
@@ -41,7 +41,7 @@ datasets_blueprint = Blueprint(
 )
 
 
-@datasets_blueprint.route("/api/datasets", methods=["GET"])
+@datasets_blueprint.route("/api/datasets", methods=["GET"], strict_slashes=False)
 @login_required
 @paged
 def list_datasets(page: int, limit: int) -> Response:
@@ -344,7 +344,7 @@ def delete_dataset(id: int):
         abort(422, description="Dataset has analyses, cannot delete")
 
 
-@datasets_blueprint.route("/api/datasets", methods=["POST"])
+@datasets_blueprint.route("/api/datasets", methods=["POST"], strict_slashes=False)
 @login_required
 @validate_json
 def create_dataset():

--- a/flask/app/families.py
+++ b/flask/app/families.py
@@ -13,7 +13,7 @@ family_blueprint = Blueprint(
 )
 
 
-@family_blueprint.route("/api/families", methods=["GET"])
+@family_blueprint.route("/api/families", methods=["GET"], strict_slashes=False)
 @login_required
 def list_families():
 
@@ -301,7 +301,7 @@ def update_family(id: int):
         abort(500)
 
 
-@family_blueprint.route("/api/families", methods=["POST"])
+@family_blueprint.route("/api/families", methods=["POST"], strict_slashes=False)
 @login_required
 @check_admin
 @validate_json

--- a/flask/app/groups.py
+++ b/flask/app/groups.py
@@ -16,7 +16,7 @@ groups_blueprint = Blueprint(
 )
 
 
-@groups_blueprint.route("/api/groups", methods=["GET"])
+@groups_blueprint.route("/api/groups", methods=["GET"], strict_slashes=False)
 @login_required
 def list_groups() -> Response:
     """
@@ -141,7 +141,7 @@ def update_group(group_code) -> Response:
     return jsonify(group)
 
 
-@groups_blueprint.route("/api/groups", methods=["POST"])
+@groups_blueprint.route("/api/groups", methods=["POST"], strict_slashes=False)
 @login_required
 @check_admin
 @validate_json

--- a/flask/app/participants.py
+++ b/flask/app/participants.py
@@ -35,7 +35,9 @@ participants_blueprint = Blueprint(
 )
 
 
-@participants_blueprint.route("/api/participants", methods=["GET"])
+@participants_blueprint.route(
+    "/api/participants", methods=["GET"], strict_slashes=False
+)
 @login_required
 @paged
 def list_participants(page: int, limit: int) -> Response:
@@ -255,7 +257,9 @@ def update_participant(id: int):
     )
 
 
-@participants_blueprint.route("/api/participants", methods=["POST"])
+@participants_blueprint.route(
+    "/api/participants", methods=["POST"], strict_slashes=False
+)
 @login_required
 @check_admin
 @validate_json

--- a/flask/app/routes.py
+++ b/flask/app/routes.py
@@ -16,7 +16,7 @@ from .utils import enum_validate, transaction_or_abort, validate_json
 routes = Blueprint("routes", __name__)
 
 
-@routes.route("/api")
+@routes.route("/api", strict_slashes=False)
 def version():
     return jsonify({"sha": app.config.get("GIT_SHA")})
 

--- a/flask/app/tissue_samples.py
+++ b/flask/app/tissue_samples.py
@@ -127,7 +127,7 @@ def delete_tissue_sample(id: int):
         abort(422, description="Tissue has dataset(s), cannot delete")
 
 
-@tissue_blueprint.route("/api/tissue_samples", methods=["POST"])
+@tissue_blueprint.route("/api/tissue_samples", methods=["POST"], strict_slashes=False)
 @login_required
 @check_admin
 @validate_json

--- a/flask/app/users.py
+++ b/flask/app/users.py
@@ -18,7 +18,7 @@ users_blueprint = Blueprint(
 )
 
 
-@users_blueprint.route("/api/users", methods=["GET"])
+@users_blueprint.route("/api/users", methods=["GET"], strict_slashes=False)
 @login_required
 @check_admin
 def list_users() -> Response:
@@ -169,7 +169,7 @@ def verify_email(email: str) -> bool:
     return space == -1 and at > 0 and dot > at + 1
 
 
-@users_blueprint.route("/api/users", methods=["POST"])
+@users_blueprint.route("/api/users", methods=["POST"], strict_slashes=False)
 @login_required
 @check_admin
 @validate_json


### PR DESCRIPTION
GET /api
GET, POST /api/users
GET, POST /api/groups
GET, POST /api/families
GET, POST /api/participants
POST /api/tissue_samples
GET, POST /api/datasets

e.g. you can now GET `/api/` instead of just `/api` and getting a 404 on `/api/`
