### PR TITLE
React: Add row-based editing for assignee, status on Analysis table

### DIFF
--- a/react/src/Analyses/components/CancelAnalysisDialog.tsx
+++ b/react/src/Analyses/components/CancelAnalysisDialog.tsx
@@ -8,8 +8,8 @@ import {
     DialogTitle,
     Divider,
 } from "@material-ui/core";
-import { Analysis, PipelineStatus } from "../../typings";
 import { checkPipelineStatusChange } from "../../functions";
+import { Analysis, PipelineStatus } from "../../typings";
 
 interface CancelAnalysisDialogProp {
     title: string;

--- a/react/src/Analyses/components/CancelAnalysisDialog.tsx
+++ b/react/src/Analyses/components/CancelAnalysisDialog.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useMemo } from "react";
 import {
     Button,
     Dialog,
@@ -8,7 +8,8 @@ import {
     DialogTitle,
     Divider,
 } from "@material-ui/core";
-import { Analysis } from "../../typings";
+import { Analysis, PipelineStatus } from "../../typings";
+import { checkPipelineStatusChange } from "../../functions";
 
 interface CancelAnalysisDialogProp {
     title: string;
@@ -18,7 +19,6 @@ interface CancelAnalysisDialogProp {
     onClose: () => void;
     onAccept: () => void;
     affectedRows: Analysis[];
-    cancelFilter: (row: Analysis) => boolean; // What rows are allowed to be cancelled
 }
 
 export default function CancelAnalysisDialog({
@@ -29,14 +29,24 @@ export default function CancelAnalysisDialog({
     onClose,
     onAccept,
     affectedRows,
-    cancelFilter,
 }: CancelAnalysisDialogProp) {
     const message = `Do you really want to stop ${
         affectedRows.length > 1 ? "these analyses" : "this analysis"
     }? Stopping an analysis will delete all intermediate files and progress. Input files will remain untouched.`;
 
-    const rowsToCancel = affectedRows.filter(row => cancelFilter(row));
-    const rowsToSkip = affectedRows.filter(row => !cancelFilter(row));
+    const [rowsToCancel, rowsToSkip] = useMemo(() => {
+        const cancel: Analysis[] = [];
+        const skip: Analysis[] = [];
+
+        for (const row of affectedRows) {
+            if (checkPipelineStatusChange(row.analysis_state, PipelineStatus.CANCELLED)) {
+                cancel.push(row);
+            } else {
+                skip.push(row);
+            }
+        }
+        return [cancel, skip];
+    }, [affectedRows]);
 
     const labeledBy = `${labeledByPrefix}-cancel-alert-dialog-title`;
     const describedBy = `${describedByPrefix}-cancel-alert-dialog-description`;

--- a/react/src/Analyses/components/SelectPipelineStatus.tsx
+++ b/react/src/Analyses/components/SelectPipelineStatus.tsx
@@ -1,0 +1,23 @@
+import React, { useMemo } from "react";
+import { MenuItem, Select } from "@material-ui/core";
+import { EditComponentProps } from "material-table";
+import { Analysis, PipelineStatus } from "../../typings";
+import { checkPipelineStatusChange } from "../../functions";
+
+export default function SelectPipelineStatus(props: EditComponentProps<Analysis>) {
+    const options = useMemo(
+        () =>
+            Object.values(PipelineStatus)
+                .filter(
+                    state => props.value === state || checkPipelineStatusChange(props.value, state)
+                )
+                .map(value => <MenuItem value={value}>{value}</MenuItem>),
+        [props.value]
+    );
+
+    return (
+        <Select value={props.value} onChange={e => props.onChange(e.target.value)}>
+            {options}
+        </Select>
+    );
+}

--- a/react/src/Analyses/components/SelectPipelineStatus.tsx
+++ b/react/src/Analyses/components/SelectPipelineStatus.tsx
@@ -1,19 +1,44 @@
 import React, { useMemo } from "react";
-import { MenuItem, Select } from "@material-ui/core";
+import { MenuItem, Select, ListSubheader } from "@material-ui/core";
 import { EditComponentProps } from "material-table";
 import { Analysis, PipelineStatus } from "../../typings";
 import { checkPipelineStatusChange } from "../../functions";
+import { useUserContext } from "../../contexts";
 
 export default function SelectPipelineStatus(props: EditComponentProps<Analysis>) {
-    const options = useMemo(
-        () =>
-            Object.values(PipelineStatus)
-                .filter(
-                    state => props.value === state || checkPipelineStatusChange(props.value, state)
-                )
-                .map(value => <MenuItem value={value}>{value}</MenuItem>),
-        [props.value]
-    );
+    const userClient = useUserContext();
+    const options = useMemo(() => {
+        if (userClient.user.is_admin) {
+            const [valid, invalid] = Object.values(PipelineStatus).reduce(
+                (prev, curr) => {
+                    if (curr === props.value || checkPipelineStatusChange(props.value, curr)) {
+                        prev[0].push(curr);
+                        return prev;
+                    } else {
+                        prev[1].push(curr);
+                        return prev;
+                    }
+                },
+                [[], []] as string[][]
+            );
+
+            return (
+                <>
+                    <ListSubheader>Valid States</ListSubheader>
+                    {valid.map(value => (
+                        <MenuItem value={value}>{value}</MenuItem>
+                    ))}
+                    <ListSubheader>Invalid States</ListSubheader>
+                    {invalid.map(value => (
+                        <MenuItem value={value}>{value}</MenuItem>
+                    ))}
+                </>
+            );
+        }
+        return Object.values(PipelineStatus)
+            .filter(state => props.value === state || checkPipelineStatusChange(props.value, state))
+            .map(value => <MenuItem value={value}>{value}</MenuItem>);
+    }, [props.value, userClient]);
 
     return (
         <Select value={props.value} onChange={e => props.onChange(e.target.value)}>

--- a/react/src/Analyses/components/SelectPipelineStatus.tsx
+++ b/react/src/Analyses/components/SelectPipelineStatus.tsx
@@ -10,7 +10,7 @@ export default function SelectPipelineStatus(props: EditComponentProps<Analysis>
     const [oldValue] = useState<PipelineStatus>(props.value);
     const options = useMemo(() => {
         if (userClient.user.is_admin) {
-            const [valid, invalid] = Object.values(PipelineStatus).reduce(
+            const [valid, invalid] = Object.values(PipelineStatus).reduce<PipelineStatus[][]>(
                 (prev, curr) => {
                     if (curr === oldValue || checkPipelineStatusChange(oldValue, curr)) {
                         prev[0].push(curr);
@@ -20,13 +20,15 @@ export default function SelectPipelineStatus(props: EditComponentProps<Analysis>
                         return prev;
                     }
                 },
-                [[], []] as PipelineStatus[][]
+                [[], []]
             );
 
             return [
                 <ListSubheader>Valid States</ListSubheader>,
                 valid.map(value => (
-                    <MenuItem value={value}>{value === oldValue ? <b>{value}</b> : value}</MenuItem>
+                    <MenuItem value={value} key={value}>
+                        {value === oldValue ? <b>{value}</b> : value}
+                    </MenuItem>
                 )),
                 <ListSubheader>Invalid States</ListSubheader>,
                 invalid.map(value => <MenuItem value={value}>{value}</MenuItem>),
@@ -39,7 +41,11 @@ export default function SelectPipelineStatus(props: EditComponentProps<Analysis>
                     state === oldValue ||
                     checkPipelineStatusChange(oldValue, state)
             )
-            .map(value => <MenuItem value={value}>{value}</MenuItem>);
+            .map(value => (
+                <MenuItem value={value} key={value}>
+                    {value}
+                </MenuItem>
+            ));
     }, [props.value, oldValue, userClient.user.is_admin]);
 
     const handleChange: SelectProps["onChange"] = e => {

--- a/react/src/Analyses/components/SelectPipelineStatus.tsx
+++ b/react/src/Analyses/components/SelectPipelineStatus.tsx
@@ -1,5 +1,5 @@
-import React, { useMemo } from "react";
-import { MenuItem, Select, ListSubheader } from "@material-ui/core";
+import React, { useMemo, useState } from "react";
+import { MenuItem, Select, ListSubheader, SelectProps } from "@material-ui/core";
 import { EditComponentProps } from "material-table";
 import { Analysis, PipelineStatus } from "../../typings";
 import { checkPipelineStatusChange } from "../../functions";
@@ -7,6 +7,7 @@ import { useUserContext } from "../../contexts";
 
 export default function SelectPipelineStatus(props: EditComponentProps<Analysis>) {
     const userClient = useUserContext();
+    const [oldValue] = useState<PipelineStatus>(props.value);
     const options = useMemo(() => {
         if (userClient.user.is_admin) {
             const [valid, invalid] = Object.values(PipelineStatus).reduce(
@@ -19,29 +20,33 @@ export default function SelectPipelineStatus(props: EditComponentProps<Analysis>
                         return prev;
                     }
                 },
-                [[], []] as string[][]
+                [[], []] as PipelineStatus[][]
             );
 
-            return (
-                <>
-                    <ListSubheader>Valid States</ListSubheader>
-                    {valid.map(value => (
-                        <MenuItem value={value}>{value}</MenuItem>
-                    ))}
-                    <ListSubheader>Invalid States</ListSubheader>
-                    {invalid.map(value => (
-                        <MenuItem value={value}>{value}</MenuItem>
-                    ))}
-                </>
-            );
+            return [
+                <ListSubheader>Valid States</ListSubheader>,
+                valid.map(value => <MenuItem value={value}>{value}</MenuItem>),
+                <ListSubheader>Invalid States</ListSubheader>,
+                invalid.map(value => <MenuItem value={value}>{value}</MenuItem>),
+            ].flat();
         }
         return Object.values(PipelineStatus)
-            .filter(state => props.value === state || checkPipelineStatusChange(props.value, state))
+            .filter(
+                state =>
+                    props.value === state ||
+                    state === oldValue ||
+                    checkPipelineStatusChange(oldValue, state)
+            )
             .map(value => <MenuItem value={value}>{value}</MenuItem>);
-    }, [props.value, userClient]);
+    }, [props.value, oldValue, userClient.user.is_admin]);
+
+    const handleChange: SelectProps["onChange"] = e => {
+        const newValue = e.target.value as string;
+        props.onChange(newValue);
+    };
 
     return (
-        <Select value={props.value} onChange={e => props.onChange(e.target.value)}>
+        <Select value={props.value} onChange={handleChange}>
             {options}
         </Select>
     );

--- a/react/src/Analyses/components/SelectPipelineStatus.tsx
+++ b/react/src/Analyses/components/SelectPipelineStatus.tsx
@@ -12,7 +12,7 @@ export default function SelectPipelineStatus(props: EditComponentProps<Analysis>
         if (userClient.user.is_admin) {
             const [valid, invalid] = Object.values(PipelineStatus).reduce(
                 (prev, curr) => {
-                    if (curr === props.value || checkPipelineStatusChange(props.value, curr)) {
+                    if (curr === oldValue || checkPipelineStatusChange(oldValue, curr)) {
                         prev[0].push(curr);
                         return prev;
                     } else {
@@ -25,7 +25,9 @@ export default function SelectPipelineStatus(props: EditComponentProps<Analysis>
 
             return [
                 <ListSubheader>Valid States</ListSubheader>,
-                valid.map(value => <MenuItem value={value}>{value}</MenuItem>),
+                valid.map(value => (
+                    <MenuItem value={value}>{value === oldValue ? <b>{value}</b> : value}</MenuItem>
+                )),
                 <ListSubheader>Invalid States</ListSubheader>,
                 invalid.map(value => <MenuItem value={value}>{value}</MenuItem>),
             ].flat();

--- a/react/src/Analyses/components/SelectPipelineStatus.tsx
+++ b/react/src/Analyses/components/SelectPipelineStatus.tsx
@@ -1,9 +1,9 @@
 import React, { useMemo, useState } from "react";
-import { MenuItem, Select, ListSubheader, SelectProps } from "@material-ui/core";
+import { ListSubheader, MenuItem, Select, SelectProps } from "@material-ui/core";
 import { EditComponentProps } from "material-table";
-import { Analysis, PipelineStatus } from "../../typings";
-import { checkPipelineStatusChange } from "../../functions";
 import { useUserContext } from "../../contexts";
+import { checkPipelineStatusChange } from "../../functions";
+import { Analysis, PipelineStatus } from "../../typings";
 
 export default function SelectPipelineStatus(props: EditComponentProps<Analysis>) {
     const userClient = useUserContext();
@@ -24,14 +24,18 @@ export default function SelectPipelineStatus(props: EditComponentProps<Analysis>
             );
 
             return [
-                <ListSubheader>Valid States</ListSubheader>,
+                <ListSubheader key="ValidStateHeader">Valid States</ListSubheader>,
                 valid.map(value => (
                     <MenuItem value={value} key={value}>
                         {value === oldValue ? <b>{value}</b> : value}
                     </MenuItem>
                 )),
-                <ListSubheader>Invalid States</ListSubheader>,
-                invalid.map(value => <MenuItem value={value}>{value}</MenuItem>),
+                <ListSubheader key="InvalidStateHeader">Invalid States</ListSubheader>,
+                invalid.map(value => (
+                    <MenuItem value={value} key={value}>
+                        {value}
+                    </MenuItem>
+                )),
             ].flat();
         }
         return Object.values(PipelineStatus)

--- a/react/src/Analyses/components/SetAssigneeDialog.tsx
+++ b/react/src/Analyses/components/SetAssigneeDialog.tsx
@@ -20,16 +20,7 @@ interface SetAssigneeDialogProps {
 
 export default function SetAssigneeDialog(props: SetAssigneeDialogProps) {
     const [username, setUsername] = useState<string>("");
-    const [error, setError] = useState<boolean>(false);
-
-    // Returns true if the username is valid.
-    function checkUsername(username: string) {
-        // TODO: GET username to check that it's a valid user
-
-        // placeholder regex check for testing
-        const pattern = new RegExp("^\\w{4,}$");
-        return pattern.test(username);
-    }
+    // const [error, setError] = useState<boolean>(false);
 
     return (
         <Dialog
@@ -50,8 +41,8 @@ export default function SetAssigneeDialog(props: SetAssigneeDialogProps) {
                     type="text"
                     value={username}
                     onChange={event => setUsername(event.target.value)}
-                    error={error}
-                    helperText={error ? "Invalid username." : ""}
+                    // error={error}
+                    // helperText={error ? "Invalid username." : ""}
                 />
             </DialogContent>
             <DialogActions>
@@ -60,17 +51,7 @@ export default function SetAssigneeDialog(props: SetAssigneeDialogProps) {
                         Cancel
                     </Button>
                     <Button
-                        onClick={
-                            checkUsername(username)
-                                ? () => {
-                                      setError(false);
-                                      props.onSubmit(username);
-                                      setUsername("");
-                                  }
-                                : () => {
-                                      setError(true);
-                                  }
-                        }
+                        onClick={() => props.onSubmit(username)}
                         color="primary"
                         autoFocus
                         variant="contained"

--- a/react/src/Analyses/index.tsx
+++ b/react/src/Analyses/index.tsx
@@ -30,7 +30,14 @@ import {
     MaterialTablePrimary,
     Note,
 } from "../components";
-import { exportCSV, isRowSelected, toKeyValue, toTitleCase, updateTableFilter } from "../functions";
+import {
+    exportCSV,
+    isRowSelected,
+    toKeyValue,
+    toTitleCase,
+    updateTableFilter,
+    checkPipelineStatusChange,
+} from "../functions";
 import {
     AnalysisOptions,
     useAnalysesPage,
@@ -86,52 +93,15 @@ function rowsToString(rows: Analysis[], delim?: string) {
 }
 
 /**
- * Returns whether this row can be completed.
- */
-function completeFilter(row: Analysis) {
-    return row.analysis_state === PipelineStatus.RUNNING;
-}
-
-/**
- * Returns whether it's possible for this row to error.
- */
-function errorFilter(row: Analysis) {
-    return (
-        row.analysis_state === PipelineStatus.RUNNING ||
-        row.analysis_state === PipelineStatus.PENDING
-    );
-}
-
-/**
- * Returns whether this analysis is allowed to be cancelled.
- */
-function cancelFilter(row: Analysis) {
-    return (
-        row.analysis_state === PipelineStatus.RUNNING ||
-        row.analysis_state === PipelineStatus.PENDING
-    );
-}
-
-/**
- * Returns whether this analysis is allowed to be run.
- */
-function runFilter(row: Analysis) {
-    return row.analysis_state === PipelineStatus.PENDING;
-}
-
-/**
  * Updates the state of all selected rows.
  * Returns a new list of Analyses, as well as the number of rows that changed, were skipped, or failed to change.
- * TODO: Revisit after overfetch #283
  *
  * @param selectedRows
- * @param filter A function which returns true for a row that is allowed to be changed to newState, false otherwise.
  * @param mutation The mutation object to use to update the analyses.
  * @param newState The new state to apply to rows which pass the filter.
  */
 async function _changeStateForSelectedRows(
     selectedRows: Analysis[],
-    filter: (row: Analysis) => boolean,
     mutation: UseMutationResult<Analysis, Response, AnalysisOptions>,
     newState: PipelineStatus
 ) {
@@ -140,7 +110,7 @@ async function _changeStateForSelectedRows(
     let failed = 0;
     for (let i = 0; i < selectedRows.length; i++) {
         let row = selectedRows[i];
-        if (filter(row)) {
+        if (checkPipelineStatusChange(row.analysis_state, newState)) {
             try {
                 await mutation.mutateAsync({
                     analysis_id: row.analysis_id,
@@ -197,8 +167,8 @@ export default function Analyses() {
 
     const tableRef = useRef<any>();
 
-    function changeAnalysisState(filter: (row: Analysis) => boolean, newState: PipelineStatus) {
-        return _changeStateForSelectedRows(activeRows, filter, analysisUpdateMutation, newState);
+    function changeAnalysisState(newState: PipelineStatus) {
+        return _changeStateForSelectedRows(activeRows, analysisUpdateMutation, newState);
     }
 
     useEffect(() => {
@@ -217,7 +187,7 @@ export default function Analyses() {
                         setCancel(false);
                     }}
                     onAccept={() => {
-                        changeAnalysisState(cancelFilter, PipelineStatus.CANCELLED).then(
+                        changeAnalysisState(PipelineStatus.CANCELLED).then(
                             ({ changed, skipped, failed }) => {
                                 setCancel(false);
                                 if (changed > 0)
@@ -245,7 +215,6 @@ export default function Analyses() {
                             }
                         );
                     }}
-                    cancelFilter={cancelFilter}
                     labeledByPrefix={`${rowsToString(activeRows, "-")}`}
                     describedByPrefix={`${rowsToString(activeRows, "-")}`}
                 />
@@ -457,7 +426,7 @@ export default function Analyses() {
                             position: "toolbarOnSelect",
                             onClick: (event, rowData) => {
                                 setActiveRows(rowData as Analysis[]);
-                                changeAnalysisState(runFilter, PipelineStatus.RUNNING).then(
+                                changeAnalysisState(PipelineStatus.RUNNING).then(
                                     ({ changed, skipped, failed }) => {
                                         if (changed > 0)
                                             enqueueSnackbar(
@@ -491,7 +460,7 @@ export default function Analyses() {
                             position: "toolbarOnSelect",
                             onClick: (event, rowData) => {
                                 setActiveRows(rowData as Analysis[]);
-                                changeAnalysisState(completeFilter, PipelineStatus.COMPLETED).then(
+                                changeAnalysisState(PipelineStatus.COMPLETED).then(
                                     ({ changed, skipped, failed }) => {
                                         if (changed > 0)
                                             enqueueSnackbar(
@@ -527,7 +496,7 @@ export default function Analyses() {
                             position: "toolbarOnSelect",
                             onClick: (event, rowData) => {
                                 setActiveRows(rowData as Analysis[]);
-                                changeAnalysisState(errorFilter, PipelineStatus.ERROR).then(
+                                changeAnalysisState(PipelineStatus.ERROR).then(
                                     ({ changed, skipped, failed }) => {
                                         if (changed > 0)
                                             enqueueSnackbar(

--- a/react/src/Analyses/index.tsx
+++ b/react/src/Analyses/index.tsx
@@ -26,6 +26,7 @@ import {
     AnalysisInfoDialog,
     DateFilterComponent,
     DateTimeText,
+    SelectFilterComponent,
     MaterialTablePrimary,
     Note,
 } from "../components";
@@ -336,7 +337,6 @@ export default function Analyses() {
                             title: "Assignee",
                             field: "assignee",
                             type: "string",
-                            editable: "never",
                             width: "8%",
                         },
                         {
@@ -393,6 +393,12 @@ export default function Analyses() {
                             field: "analysis_state",
                             type: "string",
                             editable: "never",
+                            filterComponent: props => (
+                                <SelectFilterComponent
+                                    {...props}
+                                    options={Object.values(PipelineStatus)}
+                                />
+                            ),
                         },
                         {
                             title: "Notes",

--- a/react/src/Analyses/index.tsx
+++ b/react/src/Analyses/index.tsx
@@ -49,6 +49,7 @@ import AddAnalysisAlert from "./components/AddAnalysisAlert";
 import CancelAnalysisDialog from "./components/CancelAnalysisDialog";
 import PipelineFilter from "./components/PipelineFilter";
 import SetAssigneeDialog from "./components/SetAssigneeDialog";
+import SelectPipelineStatus from "./components/SelectPipelineStatus";
 
 const useStyles = makeStyles(theme => ({
     appBarSpacer: theme.mixins.toolbar,
@@ -362,7 +363,7 @@ export default function Analyses() {
                             title: "Status",
                             field: "analysis_state",
                             type: "string",
-                            editable: "never",
+                            editComponent: props => <SelectPipelineStatus {...props} />,
                             filterComponent: props => (
                                 <SelectFilterComponent
                                     {...props}

--- a/react/src/Analyses/index.tsx
+++ b/react/src/Analyses/index.tsx
@@ -26,7 +26,6 @@ import {
     AnalysisInfoDialog,
     DateFilterComponent,
     DateTimeText,
-    SelectFilterComponent,
     MaterialTablePrimary,
     Note,
 } from "../components";
@@ -158,6 +157,7 @@ export default function Analyses() {
     const theme = useTheme();
 
     const priorityLookup = useMemo(() => toKeyValue(enums?.PriorityType || []), [enums]);
+    const pipelineStatusLookup = useMemo(() => toKeyValue(Object.values(PipelineStatus)), []);
 
     const [activeRows, setActiveRows] = useState<Analysis[]>([]);
 
@@ -363,13 +363,8 @@ export default function Analyses() {
                             title: "Status",
                             field: "analysis_state",
                             type: "string",
+                            lookup: pipelineStatusLookup,
                             editComponent: props => <SelectPipelineStatus {...props} />,
-                            filterComponent: props => (
-                                <SelectFilterComponent
-                                    {...props}
-                                    options={Object.values(PipelineStatus)}
-                                />
-                            ),
                         },
                         {
                             title: "Notes",

--- a/react/src/Analyses/index.tsx
+++ b/react/src/Analyses/index.tsx
@@ -307,6 +307,7 @@ export default function Analyses() {
                             field: "assignee",
                             type: "string",
                             width: "8%",
+                            editable: "always",
                         },
                         {
                             title: "Priority",

--- a/react/src/Analyses/index.tsx
+++ b/react/src/Analyses/index.tsx
@@ -30,12 +30,12 @@ import {
     Note,
 } from "../components";
 import {
+    checkPipelineStatusChange,
     exportCSV,
     isRowSelected,
     toKeyValue,
     toTitleCase,
     updateTableFilter,
-    checkPipelineStatusChange,
 } from "../functions";
 import {
     AnalysisOptions,
@@ -47,8 +47,8 @@ import { Analysis, AnalysisPriority, PipelineStatus } from "../typings";
 import AddAnalysisAlert from "./components/AddAnalysisAlert";
 import CancelAnalysisDialog from "./components/CancelAnalysisDialog";
 import PipelineFilter from "./components/PipelineFilter";
-import SetAssigneeDialog from "./components/SetAssigneeDialog";
 import SelectPipelineStatus from "./components/SelectPipelineStatus";
+import SetAssigneeDialog from "./components/SetAssigneeDialog";
 
 const useStyles = makeStyles(theme => ({
     appBarSpacer: theme.mixins.toolbar,

--- a/react/src/App.tsx
+++ b/react/src/App.tsx
@@ -3,6 +3,7 @@ import { createMuiTheme, IconButton, ThemeProvider } from "@material-ui/core";
 import { Close } from "@material-ui/icons";
 import { SnackbarKey, SnackbarProvider } from "notistack";
 import { QueryClient, QueryClientProvider } from "react-query";
+import { ReactQueryDevtools } from "react-query/devtools";
 
 import { emptyUser, UserClient, UserContext } from "./contexts";
 import { clearQueryCache } from "./hooks/utils";
@@ -96,6 +97,7 @@ function BaseApp(props: { darkMode: boolean; toggleDarkMode: () => void }) {
                             darkMode={props.darkMode}
                             toggleDarkMode={props.toggleDarkMode}
                         />
+                        <ReactQueryDevtools initialIsOpen={false} />
                     </SnackbarProvider>
                 </QueryClientProvider>
             </UserContext.Provider>

--- a/react/src/components/SelectFilterComponent.tsx
+++ b/react/src/components/SelectFilterComponent.tsx
@@ -26,7 +26,9 @@ export default function SelectFilterComponent<RowData extends object>(props: {
             inputProps={{ "aria-label": `${props.columnDef.title} filter` }}
         >
             {props.options.map(label => (
-                <MenuItem value={label}>{label}</MenuItem>
+                <MenuItem value={label} key={label}>
+                    {label}
+                </MenuItem>
             ))}
         </Select>
     );

--- a/react/src/components/SelectFilterComponent.tsx
+++ b/react/src/components/SelectFilterComponent.tsx
@@ -2,6 +2,9 @@ import React, { useState } from "react";
 import { Column } from "material-table";
 import { MenuItem, Select } from "@material-ui/core";
 
+/**
+ * Unused. Standard filter component compatible with material-table.
+ */
 export default function SelectFilterComponent<RowData extends object>(props: {
     columnDef: Column<RowData>;
     onFilterChanged: (columnID: string, value: any) => void;

--- a/react/src/components/SelectFilterComponent.tsx
+++ b/react/src/components/SelectFilterComponent.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
-import { Column } from "material-table";
 import { MenuItem, Select } from "@material-ui/core";
+import { Column } from "material-table";
 
 /**
  * Unused. Standard filter component compatible with material-table.

--- a/react/src/components/SelectFilterComponent.tsx
+++ b/react/src/components/SelectFilterComponent.tsx
@@ -1,0 +1,33 @@
+import React, { useState } from "react";
+import { Column } from "material-table";
+import { MenuItem, Select } from "@material-ui/core";
+
+export default function SelectFilterComponent<RowData extends object>(props: {
+    columnDef: Column<RowData>;
+    onFilterChanged: (columnID: string, value: any) => void;
+    options: string[];
+}) {
+    const [selected, setSelected] = useState("");
+
+    function updateFilter(newSelection: string) {
+        if (newSelection) {
+            // https://github.com/mbrn/material-table/pull/2435
+            const rowId = (props.columnDef as any).tableData.id;
+            setSelected(newSelection);
+            props.onFilterChanged(rowId, newSelection);
+        }
+    }
+
+    return (
+        <Select
+            value={selected}
+            onChange={e => updateFilter(e.target.value as string)}
+            displayEmpty
+            inputProps={{ "aria-label": `${props.columnDef.title} filter` }}
+        >
+            {props.options.map(label => (
+                <MenuItem value={label}>{label}</MenuItem>
+            ))}
+        </Select>
+    );
+}

--- a/react/src/components/index.tsx
+++ b/react/src/components/index.tsx
@@ -34,4 +34,3 @@ export { default as Note } from "./Note";
 export { default as Notification } from "./Notification";
 export { default as NotificationPopover } from "./NotificationPopover";
 export { default as SecretDisplay } from "./SecretDisplay";
-export { default as SelectFilterComponent } from "./SelectFilterComponent";

--- a/react/src/components/index.tsx
+++ b/react/src/components/index.tsx
@@ -34,3 +34,4 @@ export { default as Note } from "./Note";
 export { default as Notification } from "./Notification";
 export { default as NotificationPopover } from "./NotificationPopover";
 export { default as SecretDisplay } from "./SecretDisplay";
+export { default as SelectFilterComponent } from "./SelectFilterComponent";

--- a/react/src/functions.tsx
+++ b/react/src/functions.tsx
@@ -376,3 +376,17 @@ export const updateTableFilter = (
         }
     }
 };
+
+export const checkPipelineStatusChange = (fromState: PipelineStatus, toState: PipelineStatus) => {
+    const endStates = [PipelineStatus.COMPLETED, PipelineStatus.ERROR, PipelineStatus.CANCELLED];
+    return (
+        // End states cannot change to another state
+        !(fromState in endStates) &&
+        // Error or Cancel can happen to non-end states
+        (toState === PipelineStatus.ERROR ||
+            toState === PipelineStatus.CANCELLED ||
+            // Specific state changes
+            (toState === PipelineStatus.COMPLETED && fromState === PipelineStatus.RUNNING) ||
+            (toState === PipelineStatus.RUNNING && fromState === PipelineStatus.PENDING))
+    );
+};

--- a/react/src/functions.tsx
+++ b/react/src/functions.tsx
@@ -381,7 +381,7 @@ export const checkPipelineStatusChange = (fromState: PipelineStatus, toState: Pi
     const endStates = [PipelineStatus.COMPLETED, PipelineStatus.ERROR, PipelineStatus.CANCELLED];
     return (
         // End states cannot change to another state
-        !(fromState in endStates) &&
+        !endStates.includes(fromState) &&
         // Error or Cancel can happen to non-end states
         (toState === PipelineStatus.ERROR ||
             toState === PipelineStatus.CANCELLED ||

--- a/react/src/hooks/analyses/useAnalysisCreateMutation.tsx
+++ b/react/src/hooks/analyses/useAnalysisCreateMutation.tsx
@@ -23,11 +23,12 @@ export function useAnalysisCreateMutation() {
     const mutation = useMutation<Analysis, Response, NewAnalysisParams>(createAnalysis, {
         onSuccess: newAnalysis => {
             queryClient.setQueryData(["analyses", newAnalysis.analysis_id], newAnalysis);
-            // TODO: Replace below with invalidateQueries after overfetch #283
-            addToCachedList<Analysis>("analyses", queryClient, newAnalysis, {
-                invalidateQueryFilters: {
-                    exact: true,
-                },
+            queryClient.invalidateQueries({
+                predicate: query =>
+                    query.queryKey.length === 2 &&
+                    query.queryKey[0] === "analyses" &&
+                    (typeof query.queryKey[1] !== "string" ||
+                        query.queryKey[1] === newAnalysis.analysis_id),
             });
         },
     });

--- a/react/src/hooks/analyses/useAnalysisCreateMutation.tsx
+++ b/react/src/hooks/analyses/useAnalysisCreateMutation.tsx
@@ -1,6 +1,6 @@
 import { useMutation, useQueryClient } from "react-query";
 import { Analysis, AnalysisPriority, Dataset, Pipeline } from "../../typings";
-import { addToCachedList, changeFetch } from "../utils";
+import { invalidateAnalysisPredicate, changeFetch } from "../utils";
 
 interface NewAnalysisParams {
     datasets: Dataset["dataset_id"][];
@@ -24,11 +24,7 @@ export function useAnalysisCreateMutation() {
         onSuccess: newAnalysis => {
             queryClient.setQueryData(["analyses", newAnalysis.analysis_id], newAnalysis);
             queryClient.invalidateQueries({
-                predicate: query =>
-                    query.queryKey.length === 2 &&
-                    query.queryKey[0] === "analyses" &&
-                    (typeof query.queryKey[1] !== "string" ||
-                        query.queryKey[1] === newAnalysis.analysis_id),
+                predicate: invalidateAnalysisPredicate,
             });
         },
     });

--- a/react/src/hooks/analyses/useAnalysisCreateMutation.tsx
+++ b/react/src/hooks/analyses/useAnalysisCreateMutation.tsx
@@ -1,6 +1,6 @@
 import { useMutation, useQueryClient } from "react-query";
 import { Analysis, AnalysisPriority, Dataset, Pipeline } from "../../typings";
-import { invalidateAnalysisPredicate, changeFetch } from "../utils";
+import { changeFetch, invalidateAnalysisPredicate } from "../utils";
 
 interface NewAnalysisParams {
     datasets: Dataset["dataset_id"][];

--- a/react/src/hooks/analyses/useAnalysisDeleteMutation.tsx
+++ b/react/src/hooks/analyses/useAnalysisDeleteMutation.tsx
@@ -1,5 +1,5 @@
 import { useMutation, useQueryClient } from "react-query";
-import { changeFetch } from "../utils";
+import { changeFetch, invalidateAnalysisPredicate } from "../utils";
 
 async function deleteAnalysis(analysis_id: string) {
     return await changeFetch<string, Response>("/api/analyses/" + analysis_id, "DELETE", null, {
@@ -18,10 +18,7 @@ export function useAnalysisDeleteMutation() {
         onSuccess: (data, analysis_id) => {
             queryClient.removeQueries(["analyses", analysis_id]);
             queryClient.invalidateQueries({
-                predicate: query =>
-                    query.queryKey.length === 2 &&
-                    query.queryKey[0] === "analyses" &&
-                    (typeof query.queryKey[1] !== "string" || query.queryKey[1] === analysis_id),
+                predicate: invalidateAnalysisPredicate,
             });
         },
     });

--- a/react/src/hooks/analyses/useAnalysisDeleteMutation.tsx
+++ b/react/src/hooks/analyses/useAnalysisDeleteMutation.tsx
@@ -1,6 +1,5 @@
 import { useMutation, useQueryClient } from "react-query";
-import { Analysis } from "../../typings";
-import { changeFetch, deleteFromCachedList } from "../utils";
+import { changeFetch } from "../utils";
 
 async function deleteAnalysis(analysis_id: string) {
     return await changeFetch<string, Response>("/api/analyses/" + analysis_id, "DELETE", null, {
@@ -18,8 +17,12 @@ export function useAnalysisDeleteMutation() {
     const mutation = useMutation<string, Response, string>(deleteAnalysis, {
         onSuccess: (data, analysis_id) => {
             queryClient.removeQueries(["analyses", analysis_id]);
-            // TODO: Replace below with invalidate queries after overfetch #283
-            deleteFromCachedList<Analysis>("analyses", queryClient, analysis_id, "analysis_id");
+            queryClient.invalidateQueries({
+                predicate: query =>
+                    query.queryKey.length === 2 &&
+                    query.queryKey[0] === "analyses" &&
+                    (typeof query.queryKey[1] !== "string" || query.queryKey[1] === analysis_id),
+            });
         },
     });
     return mutation;

--- a/react/src/hooks/analyses/useAnalysisUpdateMutation.tsx
+++ b/react/src/hooks/analyses/useAnalysisUpdateMutation.tsx
@@ -1,6 +1,6 @@
 import { useMutation, useQueryClient } from "react-query";
 import { Analysis, AnalysisChange, AnalysisDetailed } from "../../typings";
-import { changeFetch, updateInCachedList } from "../utils";
+import { changeFetch, invalidateAnalysisPredicate } from "../utils";
 
 interface UpdateSource {
     source?: "selection" | "row-edit";
@@ -55,11 +55,7 @@ export function useAnalysisUpdateMutation() {
             const updatedAnalysis = { ...oldAnalysis, ...newAnalysis };
             queryClient.setQueryData(["analyses", newAnalysis.analysis_id], updatedAnalysis);
             queryClient.invalidateQueries({
-                predicate: query =>
-                    query.queryKey.length === 2 &&
-                    query.queryKey[0] === "analyses" &&
-                    (typeof query.queryKey[1] !== "string" ||
-                        query.queryKey[1] === newAnalysis.analysis_id),
+                predicate: invalidateAnalysisPredicate,
             });
         },
     });

--- a/react/src/hooks/analyses/useAnalysisUpdateMutation.tsx
+++ b/react/src/hooks/analyses/useAnalysisUpdateMutation.tsx
@@ -17,6 +17,7 @@ async function patchAnalysis(newAnalysis: AnalysisOptions) {
             notes: analysis.notes,
             priority: analysis.priority,
             result_path: analysis.result_path,
+            assignee: analysis.assignee,
         };
     }
     const data = await changeFetch("/api/analyses/" + newAnalysis.analysis_id, "PATCH", updates);

--- a/react/src/hooks/analyses/useAnalysisUpdateMutation.tsx
+++ b/react/src/hooks/analyses/useAnalysisUpdateMutation.tsx
@@ -54,8 +54,13 @@ export function useAnalysisUpdateMutation() {
             }
             const updatedAnalysis = { ...oldAnalysis, ...newAnalysis };
             queryClient.setQueryData(["analyses", newAnalysis.analysis_id], updatedAnalysis);
-            // TODO: Replace below with invalidate queries after overfetch #283
-            updateInCachedList<Analysis>("analyses", queryClient, updatedAnalysis, "analysis_id");
+            queryClient.invalidateQueries({
+                predicate: query =>
+                    query.queryKey.length === 2 &&
+                    query.queryKey[0] === "analyses" &&
+                    (typeof query.queryKey[1] !== "string" ||
+                        query.queryKey[1] === newAnalysis.analysis_id),
+            });
         },
     });
     return mutation;

--- a/react/src/hooks/analyses/useAnalysisUpdateMutation.tsx
+++ b/react/src/hooks/analyses/useAnalysisUpdateMutation.tsx
@@ -18,6 +18,7 @@ async function patchAnalysis(newAnalysis: AnalysisOptions) {
             priority: analysis.priority,
             result_path: analysis.result_path,
             assignee: analysis.assignee,
+            analysis_state: analysis.analysis_state,
         };
     }
     const data = await changeFetch("/api/analyses/" + newAnalysis.analysis_id, "PATCH", updates);

--- a/react/src/hooks/utils.tsx
+++ b/react/src/hooks/utils.tsx
@@ -1,7 +1,6 @@
 // Function patterns that commonly occur in this set of hooks.
 
 import { Query as MTQuery, QueryResult } from "material-table";
-import { stringToBoolean } from "../functions";
 import {
     InvalidateOptions,
     InvalidateQueryFilters,
@@ -12,6 +11,7 @@ import {
     UseQueryResult,
 } from "react-query";
 import { Query, SetDataOptions } from "react-query/types/core/query";
+import { stringToBoolean } from "../functions";
 
 /**
  * Fetch the provided url. Return the JSON response if successful.

--- a/react/src/hooks/utils.tsx
+++ b/react/src/hooks/utils.tsx
@@ -1,6 +1,7 @@
 // Function patterns that commonly occur in this set of hooks.
 
-import { Query, QueryResult } from "material-table";
+import { Query as MTQuery, QueryResult } from "material-table";
+import { stringToBoolean } from "../functions";
 import {
     InvalidateOptions,
     InvalidateQueryFilters,
@@ -10,8 +11,7 @@ import {
     UseQueryOptions,
     UseQueryResult,
 } from "react-query";
-import { SetDataOptions } from "react-query/types/core/query";
-import { stringToBoolean } from "../functions";
+import { Query, SetDataOptions } from "react-query/types/core/query";
 
 /**
  * Fetch the provided url. Return the JSON response if successful.
@@ -80,7 +80,7 @@ export const downloadCsvResponse = (args: { filename: string; blob: Blob }) => {
  * @param url The API url to request from (/api/example)
  */
 export async function queryTableData<RowData extends object>(
-    query: Query<RowData>,
+    query: MTQuery<RowData>,
     url: string
 ): Promise<QueryResult<RowData>> {
     const searchParams = new URLSearchParams();
@@ -278,3 +278,11 @@ export function clearQueryCache(queryClient: QueryClient, preserve: string[] = [
             }
         });
 }
+
+/**
+ * Predicate for invalidating Analysis queries after a mutation.
+ */
+export const invalidateAnalysisPredicate = (query: Query) =>
+    query.queryKey.length === 2 &&
+    query.queryKey[0] === "analyses" &&
+    typeof query.queryKey[1] === "object";


### PR DESCRIPTION
Also adds a filter component for filtering by status, and fixed query invalidation for analyses after mutations.

Known bug: 500 server error when updating analysis.assignee with valid, non-blank username; `'int' object has no attribute '_sa_instance_state'`. Seems to be related to line 421 in `analyses.py`. Blank usernames (removing assignee) works as expected. Fixed in #536.

Row-edits send all editable fields on update so due to the above backend bug, editing status can be tested by first setting the assignee field to be blank.