### PR TITLE
CI: login to registry with GITHUB_TOKEN

### DIFF
--- a/.github/workflows/flask.yml
+++ b/.github/workflows/flask.yml
@@ -35,7 +35,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
-          password: ${{ secrets.GHCR_PAT }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build development image
         uses: docker/build-push-action@v2
         with:


### PR DESCRIPTION
https://docs.github.com/en/packages/guides/using-github-packages-with-github-actions#authenticating-to-github-container-registry GITHUB_TOKEN now supported over PATs, access permitted here https://github.com/orgs/ccmbioinfo/packages/container/stager/settings/actions_access