### PR TITLE
React: small tweaks to column order, remove analysis chip buttons

### DIFF
--- a/react/src/Analyses/index.tsx
+++ b/react/src/Analyses/index.tsx
@@ -19,10 +19,9 @@ import {
     Error,
 } from "@material-ui/icons";
 import { makeStyles, Theme } from "@material-ui/core/styles";
-import { MTableToolbar } from "material-table";
 import { useSnackbar } from "notistack";
 import { UseMutationResult } from "react-query";
-import { isRowSelected, exportCSV, updateTableFilter, toTitleCase, toKeyValue } from "../functions";
+import { isRowSelected, exportCSV, toKeyValue } from "../functions";
 import { Analysis, AnalysisPriority, PipelineStatus } from "../typings";
 import {
     AnalysisInfoDialog,
@@ -579,33 +578,6 @@ export default function Analyses() {
                                 }
                             );
                         },
-                    }}
-                    components={{
-                        Toolbar: props => (
-                            <div>
-                                <MTableToolbar {...props} />
-                                <div style={{ marginLeft: "24px" }}>
-                                    {Object.entries(PipelineStatus).map(([k, v]) => (
-                                        <Chip
-                                            key={k}
-                                            label={toTitleCase(k)}
-                                            clickable
-                                            className={classes.chip}
-                                            onClick={() =>
-                                                updateTableFilter(tableRef, "analysis_state", v)
-                                            }
-                                        />
-                                    ))}
-                                    <IconButton
-                                        onClick={() =>
-                                            updateTableFilter(tableRef, "analysis_state", "")
-                                        }
-                                    >
-                                        <Cancel />
-                                    </IconButton>
-                                </div>
-                            </div>
-                        ),
                     }}
                 />
             </Container>

--- a/react/src/Analyses/index.tsx
+++ b/react/src/Analyses/index.tsx
@@ -1,14 +1,6 @@
 import React, { useEffect, useMemo, useRef, useState } from "react";
 import { useHistory, useParams } from "react-router";
-import {
-    Chip,
-    IconButton,
-    TextField,
-    Container,
-    Select,
-    MenuItem,
-    useTheme,
-} from "@material-ui/core";
+import { TextField, Container, Select, MenuItem, useTheme } from "@material-ui/core";
 import {
     Cancel,
     Add,

--- a/react/src/Analyses/index.tsx
+++ b/react/src/Analyses/index.tsx
@@ -316,34 +316,23 @@ export default function Analyses() {
                     tableRef={tableRef}
                     columns={[
                         {
-                            title: "Analysis ID",
-                            field: "analysis_id",
-                            type: "string",
-                            editable: "never",
-                            width: "8%",
-                            defaultFilter: paramID,
-                        },
-                        {
                             title: "Pipeline",
                             field: "pipeline_id",
                             type: "string",
-                            width: "8%",
                             editable: "never",
-                            render: (row, type) => pipeName(row),
-                            filterComponent: props => <PipelineFilter {...props} />,
+                            render: row => pipeName(row),
+                            filterComponent: PipelineFilter,
                         },
                         {
-                            title: "Assignee",
-                            field: "assignee",
+                            title: "Status",
+                            field: "analysis_state",
                             type: "string",
                             editable: "never",
-                            width: "8%",
                         },
                         {
                             title: "Priority",
                             field: "priority",
                             type: "string",
-                            width: "8%",
                             lookup: priorityLookup,
                             editComponent: ({ onChange, value }) => {
                                 return (
@@ -373,7 +362,12 @@ export default function Analyses() {
                             field: "requester",
                             type: "string",
                             editable: "never",
-                            width: "8%",
+                        },
+                        {
+                            title: "Assignee",
+                            field: "assignee",
+                            type: "string",
+                            editable: "never",
                         },
                         {
                             title: "Updated",
@@ -381,18 +375,12 @@ export default function Analyses() {
                             type: "string",
                             editable: "never",
                             render: rowData => <DateTimeText datetime={rowData.updated} />,
-                            filterComponent: props => <DateFilterComponent {...props} />,
+                            filterComponent: DateFilterComponent,
                         },
                         {
                             title: "Path Prefix",
                             field: "result_path",
                             type: "string",
-                        },
-                        {
-                            title: "Status",
-                            field: "analysis_state",
-                            type: "string",
-                            editable: "never",
                         },
                         {
                             title: "Notes",
@@ -408,6 +396,13 @@ export default function Analyses() {
                                     fullWidth
                                 />
                             ),
+                        },
+                        {
+                            title: "ID",
+                            field: "analysis_id",
+                            type: "string",
+                            editable: "never",
+                            defaultFilter: paramID,
                         },
                     ]}
                     isLoading={analysisUpdateMutation.isLoading}

--- a/react/src/Datasets/components/DatasetTable.tsx
+++ b/react/src/Datasets/components/DatasetTable.tsx
@@ -132,8 +132,8 @@ export default function DatasetTable() {
                 title="Datasets"
                 tableRef={MTRef}
                 columns={[
-                    { title: "Participant", field: "participant_codename", editable: "never" },
                     { title: "Family", field: "family_codename", editable: "never" },
+                    { title: "Participant", field: "participant_codename", editable: "never" },
                     {
                         title: "Tissue Sample",
                         field: "tissue_sample_type",

--- a/react/src/Participants/components/ParticipantTable.tsx
+++ b/react/src/Participants/components/ParticipantTable.tsx
@@ -36,7 +36,7 @@ export default function ParticipantTable() {
 
     const { id: paramID } = useParams<{ id?: string }>();
 
-    async function CopyToClipboard(event: React.MouseEvent, rowData: Participant | Participant[]) {
+    async function copyToClipboard(event: React.MouseEvent, rowData: Participant | Participant[]) {
         if (!Array.isArray(rowData)) {
             const toCopy = rowData.participant_codename + "_" + rowData.family_codename;
             await navigator.clipboard.writeText(toCopy);
@@ -75,17 +75,17 @@ export default function ParticipantTable() {
             <MaterialTablePrimary
                 columns={[
                     {
-                        title: "Participant Codename",
-                        field: "participant_codename",
-                        defaultFilter: paramID,
-                    },
-                    {
-                        title: "Family Codename",
+                        title: "Family",
                         field: "family_codename",
                         editable: "never",
                     },
                     {
-                        title: "Participant Type",
+                        title: "Participant",
+                        field: "participant_codename",
+                        defaultFilter: paramID,
+                    },
+                    {
+                        title: "Type",
                         field: "participant_type",
                         lookup: participantTypes,
                     },
@@ -95,8 +95,8 @@ export default function ParticipantTable() {
                         render: (rowData, type) => (
                             <BooleanDisplay value={rowData} fieldName={"affected"} type={type} />
                         ),
-                        editComponent: props => <BooleanEditComponent<Participant> {...props} />,
-                        filterComponent: props => <BooleanFilter<Participant> {...props} />,
+                        editComponent: BooleanEditComponent,
+                        filterComponent: BooleanFilter,
                     },
                     {
                         title: "Solved",
@@ -104,8 +104,8 @@ export default function ParticipantTable() {
                         render: (rowData, type) => (
                             <BooleanDisplay value={rowData} fieldName={"solved"} type={type} />
                         ),
-                        editComponent: props => <BooleanEditComponent<Participant> {...props} />,
-                        filterComponent: props => <BooleanFilter<Participant> {...props} />,
+                        editComponent: BooleanEditComponent,
+                        filterComponent: BooleanFilter,
                     },
                     {
                         title: "Sex",
@@ -200,7 +200,7 @@ export default function ParticipantTable() {
                     {
                         tooltip: "Copy combined codename",
                         icon: FileCopy,
-                        onClick: CopyToClipboard,
+                        onClick: copyToClipboard,
                     },
                 ]}
             />

--- a/react/src/components/MaterialTablePrimary.tsx
+++ b/react/src/components/MaterialTablePrimary.tsx
@@ -23,6 +23,7 @@ export default function MaterialTablePrimary<T extends object>(props: MaterialTa
                 ...props.components,
             }}
             options={{
+                columnsButton: true,
                 pageSize: 20,
                 pageSizeOptions: [
                     20,


### PR DESCRIPTION
`width` isn't correctly applied so I removed it.
Enable the material-table column hiding feature.
Material-table also has a resizable columns feature but it's not really reliable. Using the re-resizable component would seemingly require reimplementing MTableHeader as the individual cell is just another table cell.
Remove redundant chip buttons on analysis table.