### PR TITLE
CI: fix stale yarn caches from always using the same key

### DIFF
--- a/.github/workflows/react.yml
+++ b/.github/workflows/react.yml
@@ -32,7 +32,7 @@ jobs:
         path: |
           ${{ steps.yarn-cache-path.outputs.dir }}
           react/node_modules
-        key: ${{ runner.os }}-yarn-${{ hashFiles('yarn.lock') }}
+        key: ${{ runner.os }}-yarn-${{ hashFiles('react/yarn.lock') }}
         restore-keys: |
           ${{ runner.os }}-yarn-
     - run: yarn install


### PR DESCRIPTION
Apparently, hashFiles is relative to GITHUB_WORKSPACE, not the working directory
https://docs.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#hashfiles

I'm surprised this didn't come up earlier