### PR TITLE
React: Add progressive loading to Add Datasets suggestions

### DIFF
--- a/react/src/AddDatasets/components/DataEntryTableRow.tsx
+++ b/react/src/AddDatasets/components/DataEntryTableRow.tsx
@@ -1,0 +1,108 @@
+import React from "react";
+import { TableRow } from "@material-ui/core";
+import { Delete, LibraryAdd } from "@material-ui/icons";
+import { useFamiliesQuery } from "../../hooks";
+import { DataEntryHeader, DataEntryRow, Family, Option } from "../../typings";
+import { DataEntryActionCell, DataEntryCell } from "./TableCells";
+import { participantColumns } from "./utils";
+
+interface DataEntryTableRowProps {
+    row: DataEntryRow;
+    rowIndex: number;
+    requiredCols: DataEntryHeader[];
+    optionalCols: DataEntryHeader[];
+    rnaSeqCols: DataEntryHeader[];
+    onDelete: () => void;
+    onDuplicate: () => void;
+    onChange: (
+        newValue: string | boolean | string[],
+        rowIndex: number,
+        col: DataEntryHeader,
+        families: Family[],
+        autopopulate?: boolean
+    ) => void;
+    getOptions: (rowIndex: number, col: DataEntryHeader, families: Family[]) => Option[];
+}
+
+/**
+ * Internal component for handling rows in the body of the DataEntryTable.
+ */
+export default function DataEntryTableRow(props: DataEntryTableRowProps) {
+    const familiesResult = useFamiliesQuery(props.row.family_codename);
+    const families = familiesResult.data || [];
+    const showRNA = props.row.dataset_type === "RRS";
+
+    function handleChange(
+        newValue: string | boolean | string[],
+        col: DataEntryHeader,
+        autopopulate?: boolean
+    ) {
+        return props.onChange(newValue, props.rowIndex, col, families, autopopulate);
+    }
+
+    function getOptions(rowIndex: number, col: DataEntryHeader) {
+        return props.getOptions(rowIndex, col, families);
+    }
+
+    return (
+        <TableRow key={props.rowIndex}>
+            <DataEntryActionCell
+                tooltipTitle="Delete row"
+                icon={<Delete />}
+                onClick={props.onDelete}
+            />
+            <DataEntryActionCell
+                tooltipTitle="Duplicate row"
+                icon={<LibraryAdd />}
+                onClick={props.onDuplicate}
+            />
+
+            {props.requiredCols.map(col => (
+                <DataEntryCell
+                    row={props.row}
+                    rowIndex={props.rowIndex}
+                    col={col}
+                    getOptions={getOptions}
+                    onEdit={(newValue, autocomplete?: boolean) =>
+                        handleChange(newValue, col, autocomplete)
+                    }
+                    key={col.field}
+                    required={!props.row.participantColDisabled} // not required if pre-filled
+                    disabled={
+                        props.row.participantColDisabled &&
+                        (participantColumns as string[]).includes(col.field)
+                    }
+                />
+            ))}
+            {props.optionalCols.map(
+                col =>
+                    !col.hidden && (
+                        <DataEntryCell
+                            row={props.row}
+                            rowIndex={props.rowIndex}
+                            col={col}
+                            getOptions={getOptions}
+                            onEdit={newValue => handleChange(newValue, col)}
+                            key={col.field}
+                            disabled={
+                                props.row.participantColDisabled &&
+                                !!participantColumns.find(currCol => currCol === col.field)
+                            }
+                        />
+                    )
+            )}
+
+            {showRNA &&
+                props.rnaSeqCols.map(col => (
+                    <DataEntryCell
+                        row={props.row}
+                        rowIndex={props.rowIndex}
+                        col={col}
+                        getOptions={getOptions}
+                        onEdit={newValue => handleChange(newValue, col)}
+                        key={col.field}
+                    />
+                ))}
+        </TableRow>
+    );
+}

--- a/react/src/AddDatasets/components/DataEntryTableRow.tsx
+++ b/react/src/AddDatasets/components/DataEntryTableRow.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import { TableRow } from "@material-ui/core";
 import { Delete, LibraryAdd } from "@material-ui/icons";
 import { useFamiliesQuery } from "../../hooks";
@@ -28,7 +28,8 @@ interface DataEntryTableRowProps {
  * Internal component for handling rows in the body of the DataEntryTable.
  */
 export default function DataEntryTableRow(props: DataEntryTableRowProps) {
-    const familiesResult = useFamiliesQuery(props.row.family_codename);
+    const [familySearch, setFamilySearch] = useState("");
+    const familiesResult = useFamiliesQuery(familySearch);
     const families = familiesResult.data || [];
     const showRNA = props.row.dataset_type === "RRS";
 
@@ -38,6 +39,12 @@ export default function DataEntryTableRow(props: DataEntryTableRowProps) {
         autopopulate?: boolean
     ) {
         return props.onChange(newValue, props.rowIndex, col, families, autopopulate);
+    }
+
+    function onSearch(col: DataEntryHeader, value: string) {
+        if (col.field === "family_codename") {
+            setFamilySearch(value);
+        }
     }
 
     function getOptions(rowIndex: number, col: DataEntryHeader) {
@@ -72,6 +79,7 @@ export default function DataEntryTableRow(props: DataEntryTableRowProps) {
                         props.row.participantColDisabled &&
                         (participantColumns as string[]).includes(col.field)
                     }
+                    onSearch={search => onSearch(col, search)}
                 />
             ))}
             {props.optionalCols.map(

--- a/react/src/AddDatasets/components/DataEntryTableRow.tsx
+++ b/react/src/AddDatasets/components/DataEntryTableRow.tsx
@@ -80,6 +80,7 @@ export default function DataEntryTableRow(props: DataEntryTableRowProps) {
                         (participantColumns as string[]).includes(col.field)
                     }
                     onSearch={search => onSearch(col, search)}
+                    loading={col.field === "family_codename" && familiesResult.isLoading}
                 />
             ))}
             {props.optionalCols.map(

--- a/react/src/AddDatasets/components/DataEntryToolbar.tsx
+++ b/react/src/AddDatasets/components/DataEntryToolbar.tsx
@@ -1,0 +1,128 @@
+import React, { useState } from "react";
+import {
+    Box,
+    IconButton,
+    Link,
+    makeStyles,
+    Menu,
+    MenuItem,
+    Switch,
+    Toolbar,
+    Tooltip,
+    Typography,
+} from "@material-ui/core";
+import { CloudDownload, CloudUpload, OpenInNew, Restore, ViewColumn } from "@material-ui/icons";
+import { GroupDropdownSelect } from "../../components";
+import { DataEntryHeader, DataEntryRow } from "../../typings";
+import UploadDialog from "./UploadDialog";
+
+/**
+ * A special action button which opens a menu for showing / hiding
+ * optional columns.
+ */
+function DataEntryColumnMenuAction(props: {
+    columns: DataEntryHeader[];
+    onClick: (field: keyof DataEntryRow) => void;
+}) {
+    const [anchor, setAnchor] = useState<null | HTMLElement>(null);
+
+    return (
+        <>
+            <Tooltip title="Show/Hide columns">
+                <IconButton
+                    onClick={event => {
+                        setAnchor(event.currentTarget);
+                    }}
+                >
+                    <ViewColumn />
+                </IconButton>
+            </Tooltip>
+            <Menu
+                anchorEl={anchor}
+                open={Boolean(anchor)}
+                keepMounted
+                onClose={() => setAnchor(null)}
+            >
+                {props.columns.map(column => (
+                    <MenuItem onClick={() => props.onClick(column.field)} key={column.title}>
+                        <Box display="flex" flexGrow={1}>
+                            {column.title}
+                        </Box>
+                        <Switch edge="end" checked={!column.hidden} />
+                    </MenuItem>
+                ))}
+            </Menu>
+        </>
+    );
+}
+
+const useToolbarStyles = makeStyles(theme => ({
+    toolbar: {
+        paddingRight: theme.spacing(1),
+        paddingLeft: theme.spacing(2),
+    },
+}));
+
+/**
+ * The toolbar for the DataEntryTable, which displays the title and other action
+ * buttons that do not depend on specific rows.
+ */
+export default function DataEntryToolbar(props: {
+    handleColumnAction: (field: keyof DataEntryRow) => void;
+    handleResetAction: () => void;
+    handleCSVTemplateAction: () => void;
+    columns: DataEntryHeader[];
+    allGroups: string[]; // this user's groups
+    groups: string[]; // selected groups
+    setGroups: (selectedGroups: string[]) => void;
+}) {
+    const classes = useToolbarStyles();
+    const [openUpload, setOpenUpload] = useState(false);
+
+    return (
+        <>
+            <Toolbar className={classes.toolbar}>
+                <Box display="flex" flexGrow={1}>
+                    <Typography variant="h6">Enter Metadata</Typography>
+                </Box>
+                <GroupDropdownSelect
+                    selectedGroupCodes={props.groups}
+                    allGroupCodes={props.allGroups}
+                    onChange={props.setGroups}
+                    disabled={props.allGroups.length <= 1}
+                />
+                <Tooltip title="Download Template CSV">
+                    <IconButton onClick={props.handleCSVTemplateAction}>
+                        <CloudDownload />
+                    </IconButton>
+                </Tooltip>
+                <Tooltip title="Upload CSV">
+                    <IconButton onClick={() => setOpenUpload(true)}>
+                        <CloudUpload />
+                    </IconButton>
+                </Tooltip>
+                <DataEntryColumnMenuAction
+                    columns={props.columns}
+                    onClick={props.handleColumnAction}
+                />
+                <Tooltip title="Reset column defaults">
+                    <IconButton onClick={props.handleResetAction}>
+                        <Restore />
+                    </IconButton>
+                </Tooltip>
+                <Tooltip title="Go to MinIO">
+                    <Link href={process.env.REACT_APP_MINIO_URL} target="_blank">
+                        <IconButton>
+                            <OpenInNew />
+                        </IconButton>
+                    </Link>
+                </Tooltip>
+            </Toolbar>
+            <UploadDialog
+                open={openUpload}
+                onClose={() => setOpenUpload(false)}
+                groups={props.groups}
+            />
+        </>
+    );
+}

--- a/react/src/AddDatasets/components/TableCells.tsx
+++ b/react/src/AddDatasets/components/TableCells.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode } from "react";
+import React, { ReactNode, useState } from "react";
 import {
     Checkbox,
     IconButton,
@@ -47,6 +47,7 @@ export function DataEntryCell(props: {
     onEdit: (newValue: string | boolean | string[], autocomplete?: boolean) => void;
     disabled?: boolean;
     required?: boolean;
+    onSearch?: (value: string) => void;
 }) {
     if (booleanColumns.includes(props.col.field)) {
         return (
@@ -85,6 +86,7 @@ export function DataEntryCell(props: {
             column={props.col}
             aria-label={`enter ${props.col.title} row ${props.rowIndex}`}
             required={props.required}
+            onSearch={props.onSearch}
         />
     );
 }
@@ -100,9 +102,19 @@ export function AutocompleteCell(
         disabled?: boolean;
         column: DataEntryHeader;
         required?: boolean;
+        onSearch?: (value: string) => void;
     } & TableCellProps
 ) {
+    // We control the inputValue so that we can query with it
+    const [search, setSearch] = useState("");
+
+    const onSearch = (value: string) => {
+        setSearch(value);
+        if (props.onSearch) props.onSearch(value);
+    };
+
     const onEdit = (newValue: Option, autopopulate?: boolean) => {
+        onSearch(newValue.inputValue);
         props.onEdit(newValue.inputValue, autopopulate);
     };
 
@@ -123,6 +135,14 @@ export function AutocompleteCell(
                 clearOnBlur
                 handleHomeEndKeys
                 autoHighlight
+                inputValue={search}
+                onInputChange={(event, value, reason) => {
+                    if (reason === "clear") {
+                        onSearch("");
+                    } else {
+                        onSearch(value);
+                    }
+                }}
                 onChange={(event, newValue) => {
                     const autocomplete =
                         props.column.field === "participant_codename" ||

--- a/react/src/AddDatasets/components/TableCells.tsx
+++ b/react/src/AddDatasets/components/TableCells.tsx
@@ -139,7 +139,7 @@ export function AutocompleteCell(
                 onInputChange={(event, value, reason) => {
                     if (reason === "clear") {
                         onSearch("");
-                    } else {
+                    } else if (reason === "input") {
                         onSearch(value);
                     }
                 }}

--- a/react/src/AddDatasets/components/TableCells.tsx
+++ b/react/src/AddDatasets/components/TableCells.tsx
@@ -44,7 +44,7 @@ export function DataEntryCell(props: {
     rowIndex: number;
     col: DataEntryHeader;
     getOptions: (rowIndex: number, col: DataEntryHeader) => Option[];
-    onEdit: (newValue: string | boolean | string[]) => void;
+    onEdit: (newValue: string | boolean | string[], autocomplete?: boolean) => void;
     disabled?: boolean;
     required?: boolean;
 }) {

--- a/react/src/AddDatasets/components/TableCells.tsx
+++ b/react/src/AddDatasets/components/TableCells.tsx
@@ -48,6 +48,7 @@ export function DataEntryCell(props: {
     disabled?: boolean;
     required?: boolean;
     onSearch?: (value: string) => void;
+    loading?: boolean;
 }) {
     if (booleanColumns.includes(props.col.field)) {
         return (
@@ -87,6 +88,7 @@ export function DataEntryCell(props: {
             aria-label={`enter ${props.col.title} row ${props.rowIndex}`}
             required={props.required}
             onSearch={props.onSearch}
+            loading={props.loading}
         />
     );
 }
@@ -103,6 +105,7 @@ export function AutocompleteCell(
         column: DataEntryHeader;
         required?: boolean;
         onSearch?: (value: string) => void;
+        loading?: boolean;
     } & TableCellProps
 ) {
     // We control the inputValue so that we can query with it
@@ -129,6 +132,8 @@ export function AutocompleteCell(
     return (
         <TableCell>
             <Autocomplete
+                loading={props.loading}
+                loadingText="Fetching..."
                 disabled={props.disabled}
                 aria-label={props["aria-label"]}
                 selectOnFocus

--- a/react/src/hooks/useFamiliesQuery.tsx
+++ b/react/src/hooks/useFamiliesQuery.tsx
@@ -2,8 +2,8 @@ import { useQuery } from "react-query";
 import { Family } from "../typings";
 import { basicFetch } from "./utils";
 
-async function fetchFamilies() {
-    return await basicFetch("/api/families");
+async function fetchFamilies(familyCodename?: string) {
+    return await basicFetch("/api/families", { starts_with: familyCodename });
 }
 
 /**
@@ -11,7 +11,10 @@ async function fetchFamilies() {
  *
  * That is, return an array of all families.
  */
-export function useFamiliesQuery() {
-    const result = useQuery<Family[], Response>("families", fetchFamilies);
+export function useFamiliesQuery(familyCodename?: string) {
+    const result = useQuery<Family[], Response>(
+        familyCodename ? ["families", familyCodename] : "families",
+        () => fetchFamilies(familyCodename)
+    );
     return result;
 }

--- a/react/src/hooks/useFamiliesQuery.tsx
+++ b/react/src/hooks/useFamiliesQuery.tsx
@@ -2,8 +2,8 @@ import { useQuery } from "react-query";
 import { Family } from "../typings";
 import { basicFetch } from "./utils";
 
-async function fetchFamilies(familyCodename?: string) {
-    return await basicFetch("/api/families", { starts_with: familyCodename });
+async function fetchFamilies(params: Record<string, any>) {
+    return await basicFetch("/api/families", params);
 }
 
 /**
@@ -12,9 +12,13 @@ async function fetchFamilies(familyCodename?: string) {
  * That is, return an array of all families.
  */
 export function useFamiliesQuery(familyCodename?: string) {
+    const params = {
+        starts_with: familyCodename,
+    };
+
     const result = useQuery<Family[], Response>(
-        familyCodename ? ["families", familyCodename] : "families",
-        () => fetchFamilies(familyCodename)
+        familyCodename ? ["families", params] : "families",
+        () => fetchFamilies(params)
     );
     return result;
 }


### PR DESCRIPTION
Families are fetched on a per-row basis depending on that row's `family_codename` field, as opposed to being fetched once at table level.

TODO: ~~Fetch families based on `inputValue` (what the user types in the Autocomplete box) as opposed to `row.family_codename` (what the user selects from the Autocomplete selection box).~~ Finished. May require some form of debounce function to prevent fetching on every keystroke.

Functionality for Add Datasets should appear identical to master. Only difference should be in how families are fetched.