### PR TITLE
React: Update participant info dialog content and formatting

### DIFF
--- a/flask/app/datasets.py
+++ b/flask/app/datasets.py
@@ -92,6 +92,9 @@ def list_datasets(page: int, limit: int) -> Response:
     updated_by = request.args.get("updated_by", type=str)
     if updated_by:
         filters.append(func.instr(models.User.username, updated_by))
+    dataset_id = request.args.get("dataset_id", type=str)
+    if dataset_id:
+        filters.append(models.Dataset.dataset_id == dataset_id)
     linked_files = request.args.get("linked_files", type=str)
     if linked_files:
         filters.append(func.instr(models.DatasetFile.path, linked_files))

--- a/react/src/Analyses/index.tsx
+++ b/react/src/Analyses/index.tsx
@@ -537,7 +537,6 @@ export default function Analyses() {
                         },
                     }}
                 />
-                )
             </Container>
         </main>
     );

--- a/react/src/Participants/components/ParticipantInfoDialog.tsx
+++ b/react/src/Participants/components/ParticipantInfoDialog.tsx
@@ -1,5 +1,14 @@
-import React, { useMemo } from "react";
-import { Dialog, DialogContent, Divider, makeStyles } from "@material-ui/core";
+import React, { useMemo, useState } from "react";
+import {
+    Box,
+    Button,
+    Collapse,
+    Dialog,
+    DialogContent,
+    Divider,
+    makeStyles,
+    Typography,
+} from "@material-ui/core";
 import { ShowChart } from "@material-ui/icons";
 import { DetailSection, DialogHeader, InfoList } from "../../components";
 import {
@@ -25,17 +34,35 @@ const useStyles = makeStyles(theme => ({
 function getParticipantFields(participant: Participant): Field[] {
     return [
         createFieldObj("Family Codename", participant.family_codename, "family_codename", true),
-        createFieldObj("Participant Type", participant.participant_type, "participant_type"),
-        createFieldObj("Sex", participant.sex, "sex"),
-        createFieldObj("Affected", stringToBoolean(participant.affected), "affected"),
-        createFieldObj("Solved", stringToBoolean(participant.solved), "solved"),
-        createFieldObj("Dataset Types", participant.dataset_types, "dataset_types", true),
-        createFieldObj("Notes", participant.notes, "notes"),
-        createFieldObj("Time of Creation", formatDateString(participant.created), "created", true),
-        createFieldObj("Created By", participant.created_by, "created_by", true),
-        createFieldObj("Time of Update", formatDateString(participant.updated), "updated", true),
-        createFieldObj("Updated By", participant.updated_by, "updated_by", true),
-        createFieldObj("Institution", participant.institution, "institution", true),
+        createFieldObj(
+            "Participant Type",
+            participant.participant_type,
+            "participant_type",
+            false,
+            true
+        ),
+        createFieldObj("Sex", participant.sex, "sex", false, true),
+        createFieldObj("Affected", stringToBoolean(participant.affected), "affected", false, true),
+        createFieldObj("Solved", stringToBoolean(participant.solved), "solved", false, true),
+        createFieldObj("Dataset Types", participant.dataset_types, "dataset_types", true, true),
+        createFieldObj("Notes", participant.notes, "notes", false, true),
+        createFieldObj(
+            "Time of Creation",
+            formatDateString(participant.created),
+            "created",
+            true,
+            true
+        ),
+        createFieldObj("Created By", participant.created_by, "created_by", true, true),
+        createFieldObj(
+            "Time of Update",
+            formatDateString(participant.updated),
+            "updated",
+            true,
+            true
+        ),
+        createFieldObj("Updated By", participant.updated_by, "updated_by", true, true),
+        createFieldObj("Institution", participant.institution, "institution", true, true),
     ];
 }
 
@@ -48,6 +75,7 @@ interface DialogProp {
 
 export default function ParticipantInfoDialog(props: DialogProp) {
     const classes = useStyles();
+    const [analysisInfoListOpen, setAnalysisInfoListOpen] = useState(false);
     const datasets = useMemo(
         () => props.participant.tissue_samples.flatMap(sample => sample.datasets),
         [props.participant]
@@ -78,6 +106,7 @@ export default function ParticipantInfoDialog(props: DialogProp) {
             <DialogContent className={classes.dialogContent} dividers>
                 <div className={classes.infoSection}>
                     <DetailSection
+                        mainColumnWidth={3}
                         fields={getParticipantFields(props.participant)}
                         enums={enums}
                         dataInfo={{
@@ -96,20 +125,31 @@ export default function ParticipantInfoDialog(props: DialogProp) {
                         </div>
                     </>
                 )}
-                {analyses.length > 0 && (
-                    <>
-                        <Divider />
-                        <div className={classes.infoSection}>
-                            <InfoList
-                                infoList={getAnalysisInfoList(analyses)}
-                                title="Analyses"
-                                enums={enums}
-                                icon={<ShowChart />}
-                                linkPath="/analysis"
-                            />
-                        </div>
-                    </>
-                )}
+
+                <>
+                    <Divider />
+                    <Box margin={3}>
+                        <Button
+                            variant="contained"
+                            size="small"
+                            onClick={() => setAnalysisInfoListOpen(!analysisInfoListOpen)}
+                        >
+                            {`${analysisInfoListOpen ? "Hide" : "Show"} Analyses`}
+                        </Button>
+                        <Collapse in={analysisInfoListOpen}>
+                            {analyses && analyses.length ? (
+                                <InfoList
+                                    infoList={getAnalysisInfoList(analyses)}
+                                    enums={enums}
+                                    icon={<ShowChart />}
+                                    linkPath="/analysis"
+                                />
+                            ) : (
+                                <Typography>There are no analyses for this participant</Typography>
+                            )}
+                        </Collapse>
+                    </Box>
+                </>
             </DialogContent>
         </Dialog>
     );

--- a/react/src/Participants/components/ParticipantInfoDialog.tsx
+++ b/react/src/Participants/components/ParticipantInfoDialog.tsx
@@ -1,14 +1,5 @@
-import React, { useMemo, useState } from "react";
-import {
-    Box,
-    Button,
-    Collapse,
-    Dialog,
-    DialogContent,
-    Divider,
-    makeStyles,
-    Typography,
-} from "@material-ui/core";
+import React, { useMemo } from "react";
+import { Box, Dialog, DialogContent, Divider, makeStyles } from "@material-ui/core";
 import { ShowChart } from "@material-ui/icons";
 import { DetailSection, DialogHeader, InfoList } from "../../components";
 import {
@@ -75,7 +66,6 @@ interface DialogProp {
 
 export default function ParticipantInfoDialog(props: DialogProp) {
     const classes = useStyles();
-    const [analysisInfoListOpen, setAnalysisInfoListOpen] = useState(false);
     const datasets = useMemo(
         () => props.participant.tissue_samples.flatMap(sample => sample.datasets),
         [props.participant]
@@ -129,25 +119,15 @@ export default function ParticipantInfoDialog(props: DialogProp) {
                 <>
                     <Divider />
                     <Box margin={3}>
-                        <Button
-                            variant="contained"
-                            size="small"
-                            onClick={() => setAnalysisInfoListOpen(!analysisInfoListOpen)}
-                        >
-                            {`${analysisInfoListOpen ? "Hide" : "Show"} Analyses`}
-                        </Button>
-                        <Collapse in={analysisInfoListOpen}>
-                            {analyses && analyses.length ? (
-                                <InfoList
-                                    infoList={getAnalysisInfoList(analyses)}
-                                    enums={enums}
-                                    icon={<ShowChart />}
-                                    linkPath="/analysis"
-                                />
-                            ) : (
-                                <Typography>There are no analyses for this participant</Typography>
-                            )}
-                        </Collapse>
+                        {analyses.length > 0 && (
+                            <InfoList
+                                infoList={getAnalysisInfoList(analyses)}
+                                title="Analyses"
+                                enums={enums}
+                                icon={<ShowChart />}
+                                linkPath="/analysis"
+                            />
+                        )}
                     </Box>
                 </>
             </DialogContent>

--- a/react/src/Participants/components/SampleTable.tsx
+++ b/react/src/Participants/components/SampleTable.tsx
@@ -72,8 +72,10 @@ export default function SampleTable(props: {
             detailPanel={rowData => {
                 const infoList: Info[] = rowData.datasets.map(dataset => {
                     return {
-                        primaryListTitle: `Dataset ID ${dataset.dataset_id}`,
                         fields: getFields(dataset),
+                        identifier: dataset.dataset_id,
+                        linkPath: "datasets",
+                        primaryListTitle: `Dataset ID ${dataset.dataset_id}`,
                     };
                 });
                 return (

--- a/react/src/Participants/components/SampleTable.tsx
+++ b/react/src/Participants/components/SampleTable.tsx
@@ -45,7 +45,6 @@ export default function SampleTable(props: {
     return (
         <MaterialTable
             columns={[
-                { title: "Sample ID", field: "tissue_sample_id" },
                 {
                     title: "Extraction Date",
                     field: "extraction_date",
@@ -59,7 +58,7 @@ export default function SampleTable(props: {
                     field: "created",
                     render: rowData => <DateTimeText datetime={rowData.created} />,
                 },
-                { title: "Create By", field: "created_by" },
+                { title: "Created By", field: "created_by" },
                 {
                     title: "Update Time",
                     field: "updated",

--- a/react/src/components/DateTimeText.tsx
+++ b/react/src/components/DateTimeText.tsx
@@ -8,8 +8,8 @@ dayjs.extend(LocalizedFormat);
 
 export default function DateTimeText(props: { datetime: string }) {
     const dateObj = dayjs.utc(props.datetime);
-    const displayText = dateObj.local().format("YYYY-MM-DD");
-    const titleText = dateObj.local().format("LLLL");
+    const displayText = dateObj.isValid() ? dateObj.local().format("YYYY-MM-DD") : null;
+    const titleText = dateObj.isValid() ? dateObj.local().format("LLLL") : "";
 
     return <span title={titleText}>{displayText}</span>;
 }

--- a/react/src/components/DetailSection.tsx
+++ b/react/src/components/DetailSection.tsx
@@ -12,7 +12,7 @@ import {
 import { Check } from "@material-ui/icons";
 import { useSnackbar } from "notistack";
 import { Field } from "../typings";
-import GridFieldsDisplay from "./GridFieldsDisplay";
+import GridFieldsDisplay, { Width } from "./GridFieldsDisplay";
 
 const gridSpacing = 2;
 const titleWidth = 12;
@@ -46,6 +46,7 @@ interface DataInfo {
 interface DetailSectionProps {
     fields: Field[];
     enums?: Record<string, string[]>;
+    mainColumnWidth?: Width;
     collapsibleFields?: Field[];
     title?: string;
     dataInfo?: DataInfo; // dataInfo indicates data is editable
@@ -164,6 +165,7 @@ export default function DetailSection(props: DetailSectionProps) {
                         editMode={editMode}
                         onEdit={OnEditData}
                         enums={props.enums}
+                        columnWidth={props.mainColumnWidth}
                     />
                 </Grid>
                 {props.dataInfo && (

--- a/react/src/components/FieldDisplayEditable.tsx
+++ b/react/src/components/FieldDisplayEditable.tsx
@@ -36,7 +36,6 @@ function getFieldInEnums(fieldName: string): string {
 const useTextStyles = makeStyles(theme => ({
     textField: {
         margin: theme.spacing(0.2),
-        width: "50%",
     },
 }));
 
@@ -65,6 +64,7 @@ function EnhancedTextField({
     // Props common to all variants
     const textFieldProps: TextFieldProps = {
         className: classes.textField,
+        fullWidth: field.fullWidth,
         margin: "dense",
         label: field.title,
         value: formatFieldValue(field.value),

--- a/react/src/components/GridFieldsDisplay.tsx
+++ b/react/src/components/GridFieldsDisplay.tsx
@@ -4,7 +4,7 @@ import { Field } from "../typings";
 import FieldDisplayEditable from "./FieldDisplayEditable";
 
 // Grids are very picky about what sizes are allowed
-type Width = Exclude<GridProps["xs"], boolean | "auto">;
+export type Width = Exclude<GridProps["xs"], boolean | "auto">;
 
 const useStyles = makeStyles(theme => ({
     flexChild: { minWidth: 0, overflowWrap: "break-word" },

--- a/react/src/functions.tsx
+++ b/react/src/functions.tsx
@@ -98,12 +98,9 @@ export function isRowSelected(row: any): boolean {
  */
 export function getAnalysisFields(analysis: Analysis) {
     return [
-        createFieldObj("Analysis ID", analysis.analysis_id),
         createFieldObj("State", analysis.analysis_state),
-        createFieldObj("Pipeline ID", analysis.pipeline_id),
         createFieldObj("Assigned to", analysis.assignee),
         createFieldObj("Path Prefix", analysis.result_path),
-        createFieldObj("qSub ID", analysis.qsubID),
         createFieldObj("Notes", analysis.notes),
         createFieldObj("Requested", formatDateString(analysis.requested)),
         createFieldObj("Requested By", analysis.requester),
@@ -222,7 +219,7 @@ export function snakeCaseToTitle(str: string): string {
 }
 
 /**
- * Given a string, returns the string with first word capitalized
+ * Given a string, returns the string with the first letter of each word capitalized
  */
 export function toTitleCase(str: string): string {
     return str.replace(/\w\S*/g, txt => txt.charAt(0).toUpperCase() + txt.substr(1).toLowerCase());
@@ -232,13 +229,15 @@ export function createFieldObj(
     title: string,
     value: FieldDisplayValueType,
     fieldName?: string,
-    disableEdit?: boolean
+    disableEdit?: boolean,
+    fullWidth?: boolean
 ): Field {
     return {
-        title: title,
-        value: value,
-        fieldName: fieldName,
-        disableEdit: disableEdit,
+        fullWidth,
+        title,
+        value,
+        fieldName,
+        disableEdit,
     };
 }
 

--- a/react/src/typings.tsx
+++ b/react/src/typings.tsx
@@ -231,6 +231,7 @@ export interface Field {
     title: string;
     value: FieldDisplayValueType;
     fieldName?: string;
+    fullWidth?: boolean;
     disableEdit?: boolean;
 }
 


### PR DESCRIPTION
- add link to datasets table in participant info dialog
  * includes adding dataset_id filter to datasets endpoint 
- update datetimetext component to return empty string when date is invalid (e.g., `null`)
- allow for variable column count in detail section to reduce vertical space
- add fullwidth option to `Field` component
- hide analyses in participant dialogue by default and toggle with button
- remove unnecessary primary keys from participant info dialogue