### PR TITLE
React: Save column order, orderBy column to localStorage

### DIFF
--- a/react/src/Analyses/index.tsx
+++ b/react/src/Analyses/index.tsx
@@ -27,6 +27,7 @@ import {
     GET_ANALYSES_URL,
     useAnalysesPage,
     useAnalysisUpdateMutation,
+    useColumnOrderCache,
     useDownloadCsv,
     useEnumsQuery,
 } from "../hooks";
@@ -155,6 +156,8 @@ export default function Analyses() {
     useEffect(() => {
         document.title = `Analyses | ${process.env.REACT_APP_NAME}`;
     }, []);
+
+    const handleColumnDrag = useColumnOrderCache(tableRef, "analysisTableColumnOrder");
 
     function changeAnalysisState(newState: PipelineStatus) {
         return _changeStateForSelectedRows(activeRows, analysisUpdateMutation, newState);
@@ -545,6 +548,7 @@ export default function Analyses() {
                             );
                         },
                     }}
+                    onColumnDragged={handleColumnDrag}
                 />
             </Container>
         </main>

--- a/react/src/Analyses/index.tsx
+++ b/react/src/Analyses/index.tsx
@@ -30,6 +30,7 @@ import {
     useColumnOrderCache,
     useDownloadCsv,
     useEnumsQuery,
+    useSortOrderCache,
 } from "../hooks";
 import { transformMTQueryToCsvDownloadParams } from "../hooks/utils";
 import { Analysis, AnalysisPriority, PipelineStatus } from "../typings";
@@ -138,7 +139,8 @@ export default function Analyses() {
 
     const analysisUpdateMutation = useAnalysisUpdateMutation();
 
-    const { data: enums } = useEnumsQuery();
+    const enumsQuery = useEnumsQuery();
+    const enums = enumsQuery.data;
 
     const theme = useTheme();
 
@@ -157,7 +159,10 @@ export default function Analyses() {
         document.title = `Analyses | ${process.env.REACT_APP_NAME}`;
     }, []);
 
-    const handleColumnDrag = useColumnOrderCache(tableRef, "analysisTableColumnOrder");
+    const cacheDeps = [enumsQuery.isFetched];
+
+    const handleColumnDrag = useColumnOrderCache(tableRef, "analysisTableColumnOrder", cacheDeps);
+    const handleSortChange = useSortOrderCache(tableRef, "analysisTableSortOrder", cacheDeps);
 
     function changeAnalysisState(newState: PipelineStatus) {
         return _changeStateForSelectedRows(activeRows, analysisUpdateMutation, newState);
@@ -549,6 +554,7 @@ export default function Analyses() {
                         },
                     }}
                     onColumnDragged={handleColumnDrag}
+                    onOrderChange={handleSortChange}
                 />
             </Container>
         </main>

--- a/react/src/Datasets/components/DatasetTable.tsx
+++ b/react/src/Datasets/components/DatasetTable.tsx
@@ -17,6 +17,7 @@ import { useUserContext } from "../../contexts";
 import { rowDiff, toKeyValue, updateTableFilter } from "../../functions";
 import {
     GET_DATASETS_URL,
+    useColumnOrderCache,
     useDatasetsPage,
     useDatasetUpdateMutation,
     useDownloadCsv,
@@ -163,6 +164,8 @@ export default function DatasetTable() {
     //setting to `any` b/c MTable typing doesn't include dataManager
     const MTRef = useRef<any>();
 
+    const handleColumnDrag = useColumnOrderCache(MTRef, "datasetTableColumnOrder");
+
     return (
         <div>
             <AnalysisRunnerDialog
@@ -302,6 +305,7 @@ export default function DatasetTable() {
                         },
                     },
                 ]}
+                onColumnDragged={handleColumnDrag}
             />
         </div>
     );

--- a/react/src/Datasets/components/DatasetTable.tsx
+++ b/react/src/Datasets/components/DatasetTable.tsx
@@ -23,6 +23,7 @@ import {
     useDownloadCsv,
     useEnumsQuery,
     useMetadatasetTypesQuery,
+    useSortOrderCache,
     useUnlinkedFilesQuery,
 } from "../../hooks";
 import { transformMTQueryToCsvDownloadParams } from "../../hooks/utils";
@@ -166,11 +167,10 @@ export default function DatasetTable() {
     //setting to `any` b/c MTable typing doesn't include dataManager
     const MTRef = useRef<any>();
 
-    const handleColumnDrag = useColumnOrderCache(MTRef, "datasetTableColumnOrder", [
-        enumsQuery.isSuccess,
-        metadatasetTypesQuery.isSuccess,
-        filesQuery.isSuccess,
-    ]);
+    const cacheDeps = [enumsQuery.isFetched, metadatasetTypesQuery.isFetched, filesQuery.isFetched];
+
+    const handleColumnDrag = useColumnOrderCache(MTRef, "datasetTableColumnOrder", cacheDeps);
+    const handleSortChange = useSortOrderCache(MTRef, "datasetTableSortOrder", cacheDeps);
 
     return (
         <div>
@@ -312,6 +312,7 @@ export default function DatasetTable() {
                     },
                 ]}
                 onColumnDragged={handleColumnDrag}
+                onOrderChange={handleSortChange}
             />
         </div>
     );

--- a/react/src/Datasets/components/DatasetTable.tsx
+++ b/react/src/Datasets/components/DatasetTable.tsx
@@ -83,8 +83,10 @@ export default function DatasetTable() {
 
     const dataFetch = useDatasetsPage();
     const datasetUpdateMutation = useDatasetUpdateMutation();
-    const { data: enums } = useEnumsQuery();
-    const { data: metadatasetTypes } = useMetadatasetTypesQuery();
+    const enumsQuery = useEnumsQuery();
+    const enums = enumsQuery.data;
+    const metadatasetTypesQuery = useMetadatasetTypesQuery();
+    const metadatasetTypes = metadatasetTypesQuery.data;
     const datasetTypes = useMemo(
         () => metadatasetTypes && toKeyValue(Object.values(metadatasetTypes).flat()),
         [metadatasetTypes]
@@ -164,7 +166,11 @@ export default function DatasetTable() {
     //setting to `any` b/c MTable typing doesn't include dataManager
     const MTRef = useRef<any>();
 
-    const handleColumnDrag = useColumnOrderCache(MTRef, "datasetTableColumnOrder");
+    const handleColumnDrag = useColumnOrderCache(MTRef, "datasetTableColumnOrder", [
+        enumsQuery.isSuccess,
+        metadatasetTypesQuery.isSuccess,
+        filesQuery.isSuccess,
+    ]);
 
     return (
         <div>

--- a/react/src/Participants/components/ParticipantTable.tsx
+++ b/react/src/Participants/components/ParticipantTable.tsx
@@ -14,6 +14,7 @@ import {
 import { countArray, rowDiff, stringToBoolean, toKeyValue } from "../../functions";
 import {
     GET_PARTICIPANTS_URL,
+    useColumnOrderCache,
     useDownloadCsv,
     useEnumsQuery,
     useMetadatasetTypesQuery,
@@ -105,6 +106,8 @@ export default function ParticipantTable() {
     const dataFetch = useParticipantsPage();
 
     const { enqueueSnackbar } = useSnackbar();
+
+    const handleColumnDrag = useColumnOrderCache(tableRef, "participantTableColumnOrder");
 
     async function copyToClipboard(event: React.MouseEvent, rowData: Participant | Participant[]) {
         if (!Array.isArray(rowData)) {
@@ -223,6 +226,7 @@ export default function ParticipantTable() {
                         onClick: copyToClipboard,
                     },
                 ]}
+                onColumnDragged={handleColumnDrag}
             />
         </div>
     );

--- a/react/src/Participants/components/ParticipantTable.tsx
+++ b/react/src/Participants/components/ParticipantTable.tsx
@@ -19,6 +19,7 @@ import {
     useEnumsQuery,
     useMetadatasetTypesQuery,
     useParticipantsPage,
+    useSortOrderCache,
 } from "../../hooks";
 import { transformMTQueryToCsvDownloadParams } from "../../hooks/utils";
 import { Participant } from "../../typings";
@@ -114,7 +115,14 @@ export default function ParticipantTable() {
 
     const { enqueueSnackbar } = useSnackbar();
 
-    const handleColumnDrag = useColumnOrderCache(tableRef, "participantTableColumnOrder");
+    const cacheDeps = [enumsQuery.isFetched, metadatasetTypesQuery.isFetched];
+
+    const handleColumnDrag = useColumnOrderCache(
+        tableRef,
+        "participantTableColumnOrder",
+        cacheDeps
+    );
+    const handleSortChange = useSortOrderCache(tableRef, "participantTableSortOrder", cacheDeps);
 
     async function copyToClipboard(event: React.MouseEvent, rowData: Participant | Participant[]) {
         if (!Array.isArray(rowData)) {
@@ -234,6 +242,7 @@ export default function ParticipantTable() {
                     },
                 ]}
                 onColumnDragged={handleColumnDrag}
+                onOrderChange={handleSortChange}
             />
         </div>
     );

--- a/react/src/Participants/components/ParticipantTable.tsx
+++ b/react/src/Participants/components/ParticipantTable.tsx
@@ -29,14 +29,21 @@ export default function ParticipantTable() {
     const [participants, setParticipants] = useState<Participant[]>([]);
     const [detail, setDetail] = useState(false);
     const [activeRow, setActiveRow] = useState<Participant | undefined>(undefined);
-    const { data: enums } = useEnumsQuery();
-    const sexTypes = useMemo(() => enums && toKeyValue(enums.Sex), [enums]);
-    const participantTypes = useMemo(() => enums && toKeyValue(enums.ParticipantType), [enums]);
+    const enumsQuery = useEnumsQuery();
+    const sexTypes = useMemo(() => enumsQuery.data && toKeyValue(enumsQuery.data.Sex), [
+        enumsQuery.data,
+    ]);
+    const participantTypes = useMemo(
+        () => enumsQuery.data && toKeyValue(enumsQuery.data.ParticipantType),
+        [enumsQuery.data]
+    );
     const { id: paramID } = useParams<{ id?: string }>();
-    const { data: metadatasetTypes } = useMetadatasetTypesQuery();
+    const metadatasetTypesQuery = useMetadatasetTypesQuery();
     const datasetTypes = useMemo(
-        () => metadatasetTypes && toKeyValue(Object.values(metadatasetTypes).flat()),
-        [metadatasetTypes]
+        () =>
+            metadatasetTypesQuery.data &&
+            toKeyValue(Object.values(metadatasetTypesQuery.data).flat()),
+        [metadatasetTypesQuery.data]
     );
 
     const columns: Column<Participant>[] = useMemo(() => {

--- a/react/src/functions.tsx
+++ b/react/src/functions.tsx
@@ -1,3 +1,4 @@
+import React from "react";
 import dayjs from "dayjs";
 import LocalizedFormat from "dayjs/plugin/localizedFormat";
 import utc from "dayjs/plugin/utc";
@@ -372,6 +373,31 @@ export const updateTableFilter = (
             tableRef.current.onQueryChange();
         }
     }
+};
+
+/**
+ * Get the columns currently stored by material-table.
+ */
+export const getTableColumns = (tableRef: React.MutableRefObject<any>): any[] | null => {
+    if (tableRef.current) return tableRef.current.dataManager.columns;
+    return null;
+};
+
+/**
+ * Return a mapping of column ids to column order indexes currently stored by material-table.
+ */
+export const getTableColumnOrder = (
+    tableRef: React.MutableRefObject<any>
+): Record<number, number> | null => {
+    const cols = getTableColumns(tableRef);
+    const result: Record<number, number> = {};
+    if (cols) {
+        cols.forEach(col => {
+            result[col.tableData.id] = col.tableData.columnOrder;
+        });
+        return result;
+    }
+    return null;
 };
 
 export const checkPipelineStatusChange = (fromState: PipelineStatus, toState: PipelineStatus) => {

--- a/react/src/hooks/index.tsx
+++ b/react/src/hooks/index.tsx
@@ -40,3 +40,4 @@ export { useDatasetDeleteMutation } from "./datasets/useDatasetDeleteMutation";
 
 export * from "./useDownloadCsv";
 export { useColumnOrderCache } from "./useColumnOrderCache";
+export { useSortOrderCache } from "./useSortOrderCache";

--- a/react/src/hooks/index.tsx
+++ b/react/src/hooks/index.tsx
@@ -39,3 +39,4 @@ export { useDatasetUpdateMutation } from "./datasets/useDatasetUpdateMutation";
 export { useDatasetDeleteMutation } from "./datasets/useDatasetDeleteMutation";
 
 export * from "./useDownloadCsv";
+export { useColumnOrderCache } from "./useColumnOrderCache";

--- a/react/src/hooks/useColumnOrderCache.tsx
+++ b/react/src/hooks/useColumnOrderCache.tsx
@@ -1,0 +1,57 @@
+import React, { useEffect } from "react";
+import { MaterialTableProps } from "@material-table/core";
+import { getTableColumnOrder } from "../functions";
+
+/**
+ * Handle updating a given material-table with localStorage-cached column order.
+ *
+ * Return a function for updating the cache on column drag.
+ */
+export function useColumnOrderCache(tableRef: React.MutableRefObject<any>, cacheKey: string) {
+    const handleOrderChange: MaterialTableProps<object>["onColumnDragged"] = () => {
+        // source and dest are just the visible indexes
+        // not the true indexes that take hidden columns into account
+        // so we just dig the the new column orders out of the table's data manager
+        const columnOrderRecord = getTableColumnOrder(tableRef);
+        if (columnOrderRecord !== null) {
+            localStorage.setItem(cacheKey, JSON.stringify(columnOrderRecord));
+        } else {
+            console.error(`Failed to cache column order for ${cacheKey}.`);
+        }
+    };
+
+    useEffect(() => {
+        if (tableRef.current) {
+            // Get stored settings
+            const columnOrderCache = localStorage.getItem(cacheKey);
+            // maps id -> columnIndex
+            let columnOrderRecord: Record<number, number> = {};
+            if (columnOrderCache === null) {
+                // Cache is empty, use table columns and update cache
+                const temp = getTableColumnOrder(tableRef);
+                if (temp === null) {
+                    console.error("Failed to get table column order.");
+                } else {
+                    columnOrderRecord = temp;
+                    localStorage.setItem(cacheKey, JSON.stringify(columnOrderRecord));
+                }
+            } else {
+                // Cache is non-empty
+                columnOrderRecord = JSON.parse(columnOrderCache);
+                // TODO: verify the format and integrity of the result from localStorage
+                try {
+                    // Update the table
+                    (tableRef.current.dataManager.columns as any[]).forEach(col => {
+                        col.tableData.columnOrder = columnOrderRecord[col.tableData.id];
+                    });
+                } catch (error) {
+                    // Bad cache
+                    console.error(error);
+                    localStorage.removeItem(cacheKey);
+                }
+            }
+        }
+    }, [tableRef, cacheKey]);
+
+    return handleOrderChange;
+}

--- a/react/src/hooks/useColumnOrderCache.tsx
+++ b/react/src/hooks/useColumnOrderCache.tsx
@@ -1,13 +1,24 @@
-import React, { useEffect } from "react";
+import React, { useEffect, useState } from "react";
 import { MaterialTableProps } from "@material-table/core";
 import { getTableColumnOrder } from "../functions";
 
 /**
  * Handle updating a given material-table with localStorage-cached column order.
  *
+ * If any dependencies are specified, ensure that they are all true before
+ * loading column order from cache. Dependencies include any other state variables
+ * or queries that must be completed for the table to render properly on first try.
+ *
  * Return a function for updating the cache on column drag.
  */
-export function useColumnOrderCache(tableRef: React.MutableRefObject<any>, cacheKey: string) {
+export function useColumnOrderCache(
+    tableRef: React.MutableRefObject<any>,
+    cacheKey: string,
+    dependencies?: boolean[]
+) {
+    // ensures that the side effect only occurs once
+    const [applied, setApplied] = useState(false);
+
     const handleOrderChange: MaterialTableProps<object>["onColumnDragged"] = () => {
         // source and dest are just the visible indexes
         // not the true indexes that take hidden columns into account
@@ -21,11 +32,15 @@ export function useColumnOrderCache(tableRef: React.MutableRefObject<any>, cache
     };
 
     useEffect(() => {
-        if (tableRef.current) {
+        if (
+            tableRef.current &&
+            (dependencies === undefined || dependencies.find(dep => !dep) === undefined) &&
+            !applied
+        ) {
             // Get stored settings
             const columnOrderCache = localStorage.getItem(cacheKey);
             // maps id -> columnIndex
-            let columnOrderRecord: Record<number, number> = {};
+            let columnOrderRecord: Record<string, number> = {};
             if (columnOrderCache === null) {
                 // Cache is empty, use table columns and update cache
                 const temp = getTableColumnOrder(tableRef);
@@ -42,7 +57,7 @@ export function useColumnOrderCache(tableRef: React.MutableRefObject<any>, cache
                 try {
                     // Update the table
                     (tableRef.current.dataManager.columns as any[]).forEach(col => {
-                        col.tableData.columnOrder = columnOrderRecord[col.tableData.id];
+                        col.tableData.columnOrder = columnOrderRecord[`${col.tableData.id}`];
                     });
                 } catch (error) {
                     // Bad cache
@@ -50,8 +65,9 @@ export function useColumnOrderCache(tableRef: React.MutableRefObject<any>, cache
                     localStorage.removeItem(cacheKey);
                 }
             }
+            setApplied(true);
         }
-    }, [tableRef, cacheKey]);
+    }, [tableRef, cacheKey, dependencies, applied]);
 
     return handleOrderChange;
 }

--- a/react/src/hooks/useSortOrderCache.tsx
+++ b/react/src/hooks/useSortOrderCache.tsx
@@ -1,0 +1,63 @@
+import React, { useEffect, useState } from "react";
+import { MaterialTableProps } from "@material-table/core";
+
+/**
+ * Handle updating a given material-table with localStorage-cached sort order (orderBy, orderDirection).
+ *
+ * If any dependencies are specified, ensure that they are all true before
+ * loading sort order from cache. Dependencies include any other state variables
+ * or queries that must be completed for the table to render properly on first try.
+ *
+ * Return a function for updating the cache when sort order changes.
+ */
+export function useSortOrderCache(
+    tableRef: React.MutableRefObject<any>,
+    cacheKey: string,
+    dependencies?: boolean[]
+) {
+    const [applied, setApplied] = useState(false);
+
+    const handleSortChange: MaterialTableProps<object>["onOrderChange"] = (
+        orderBy,
+        orderDirection
+    ) => {
+        localStorage.setItem(cacheKey, [orderBy, orderDirection].join(","));
+    };
+
+    useEffect(() => {
+        if (
+            tableRef.current &&
+            (dependencies === undefined || dependencies.find(dep => !dep) === undefined) &&
+            !applied
+        ) {
+            const sortOrderCache = localStorage.getItem(cacheKey);
+            if (sortOrderCache === null) {
+                // empty cache
+                localStorage.setItem(
+                    cacheKey,
+                    [
+                        tableRef.current.dataManager.orderBy,
+                        tableRef.current.dataManager.orderDirection,
+                    ].join(",")
+                );
+            } else {
+                // cache hit
+                try {
+                    // simple format check
+                    const cachedArray = sortOrderCache.split(",");
+                    if (cachedArray.length !== 2) throw Error(`${cacheKey} is not array of size 2`);
+                    const orderBy = parseInt(cachedArray[0]);
+                    const orderDirection = cachedArray[1];
+                    tableRef.current.onChangeOrder(orderBy, orderDirection);
+                } catch (error) {
+                    // bad cache
+                    console.error(error);
+                    localStorage.removeItem(cacheKey);
+                }
+            }
+            setApplied(true);
+        }
+    }, [tableRef, cacheKey, dependencies, applied]);
+
+    return handleSortChange;
+}

--- a/react/src/hooks/useSortOrderCache.tsx
+++ b/react/src/hooks/useSortOrderCache.tsx
@@ -48,7 +48,14 @@ export function useSortOrderCache(
                     if (cachedArray.length !== 2) throw Error(`${cacheKey} is not array of size 2`);
                     const orderBy = parseInt(cachedArray[0]);
                     const orderDirection = cachedArray[1];
+
                     tableRef.current.onChangeOrder(orderBy, orderDirection);
+                    // tableRef.current.dataManager.sortData();
+                    console.log(
+                        tableRef.current.dataManager.orderBy,
+                        tableRef.current.dataManager.orderDirection
+                    );
+                    // tableRef.current.onQueryChange();
                 } catch (error) {
                     // bad cache
                     console.error(error);


### PR DESCRIPTION
Part of #550

- Column order and sorting by column are loaded from localStorage on mount, and saved to localStorage every time order or sorting changes
- Loading sorting on mount triggers a second query with updated orderBy, orderDirection parameters. Unsure if there is a workaround to querying twice.