### PR TITLE
React: Save default table filters to localStorage

### DIFF
--- a/react/src/Datasets/components/DatasetTable.tsx
+++ b/react/src/Datasets/components/DatasetTable.tsx
@@ -324,13 +324,6 @@ export default function DatasetTable() {
                 ]}
                 onColumnDragged={handleColumnDrag}
                 onOrderChange={handleSortChange}
-                onQueryChange={query => {
-                    console.log("Query changed!");
-                    if (query) {
-                        handleFilterChanged(query.filters);
-                    }
-                }}
-                // onFilterChange={handleFilterChanged}
             />
         </div>
     );

--- a/react/src/Datasets/components/DatasetTable.tsx
+++ b/react/src/Datasets/components/DatasetTable.tsx
@@ -24,6 +24,7 @@ import {
     useEnumsQuery,
     useMetadatasetTypesQuery,
     useSortOrderCache,
+    useTableFilterCache,
     useUnlinkedFilesQuery,
 } from "../../hooks";
 import { transformMTQueryToCsvDownloadParams } from "../../hooks/utils";
@@ -171,6 +172,11 @@ export default function DatasetTable() {
 
     const handleColumnDrag = useColumnOrderCache(MTRef, "datasetTableColumnOrder", cacheDeps);
     const handleSortChange = useSortOrderCache(MTRef, "datasetTableSortOrder", cacheDeps);
+    const handleFilterChanged = useTableFilterCache<Dataset>(
+        MTRef,
+        "datasetTableFilterCache",
+        cacheDeps
+    );
 
     return (
         <div>
@@ -192,7 +198,10 @@ export default function DatasetTable() {
                 title="Datasets"
                 tableRef={MTRef}
                 columns={columns}
-                data={dataFetch}
+                data={query => {
+                    if (query) handleFilterChanged(query.filters);
+                    return dataFetch(query);
+                }}
                 options={{
                     selection: true,
                     exportMenu: [
@@ -313,6 +322,13 @@ export default function DatasetTable() {
                 ]}
                 onColumnDragged={handleColumnDrag}
                 onOrderChange={handleSortChange}
+                onQueryChange={query => {
+                    console.log("Query changed!");
+                    if (query) {
+                        handleFilterChanged(query.filters);
+                    }
+                }}
+                // onFilterChange={handleFilterChanged}
             />
         </div>
     );

--- a/react/src/Datasets/components/DatasetTable.tsx
+++ b/react/src/Datasets/components/DatasetTable.tsx
@@ -112,8 +112,12 @@ export default function DatasetTable() {
         downloadCsv(transformMTQueryToCsvDownloadParams(MTRef.current?.state.query || {}));
     };
 
-    const columns: Column<Dataset>[] = useMemo(() => {
-        return [
+    const { handleFilterChanged, setInitialFilters } = useTableFilterCache<Dataset>(
+        "datasetTableFilterCache"
+    );
+
+    const columns = useMemo(() => {
+        const columns: Column<Dataset>[] = [
             { title: "Family", field: "family_codename", editable: "never" },
             { title: "Participant", field: "participant_codename", editable: "never" },
             {
@@ -163,7 +167,10 @@ export default function DatasetTable() {
                 defaultFilter: paramID,
             },
         ];
-    }, [conditions, datasetTypes, paramID, tissueSampleTypes]);
+
+        setInitialFilters(columns);
+        return columns;
+    }, [conditions, datasetTypes, paramID, tissueSampleTypes, setInitialFilters]);
 
     //setting to `any` b/c MTable typing doesn't include dataManager
     const MTRef = useRef<any>();
@@ -172,11 +179,6 @@ export default function DatasetTable() {
 
     const handleColumnDrag = useColumnOrderCache(MTRef, "datasetTableColumnOrder", cacheDeps);
     const handleSortChange = useSortOrderCache(MTRef, "datasetTableSortOrder", cacheDeps);
-    const handleFilterChanged = useTableFilterCache<Dataset>(
-        MTRef,
-        "datasetTableFilterCache",
-        cacheDeps
-    );
 
     return (
         <div>

--- a/react/src/Datasets/components/DatasetTable.tsx
+++ b/react/src/Datasets/components/DatasetTable.tsx
@@ -112,8 +112,8 @@ export default function DatasetTable() {
         downloadCsv(transformMTQueryToCsvDownloadParams(MTRef.current?.state.query || {}));
     };
 
-    const { handleFilterChanged, setInitialFilters } = useTableFilterCache<Dataset>(
-        "datasetTableFilterCache"
+    const { handleFilterChange, setInitialFilters } = useTableFilterCache<Dataset>(
+        "datasetTableDefaultFilters"
     );
 
     const columns = useMemo(() => {
@@ -201,7 +201,7 @@ export default function DatasetTable() {
                 tableRef={MTRef}
                 columns={columns}
                 data={query => {
-                    if (query) handleFilterChanged(query.filters);
+                    if (query) handleFilterChange(query.filters);
                     return dataFetch(query);
                 }}
                 options={{

--- a/react/src/Participants/components/ParticipantTable.tsx
+++ b/react/src/Participants/components/ParticipantTable.tsx
@@ -20,6 +20,7 @@ import {
     useMetadatasetTypesQuery,
     useParticipantsPage,
     useSortOrderCache,
+    useTableFilterCache,
 } from "../../hooks";
 import { transformMTQueryToCsvDownloadParams } from "../../hooks/utils";
 import { Participant } from "../../typings";
@@ -47,8 +48,12 @@ export default function ParticipantTable() {
         [metadatasetTypesQuery.data]
     );
 
-    const columns: Column<Participant>[] = useMemo(() => {
-        return [
+    const { handleFilterChange, setInitialFilters } = useTableFilterCache<Participant>(
+        "participantTableDefaultFilters"
+    );
+
+    const columns = useMemo(() => {
+        const columns: Column<Participant>[] = [
             {
                 title: "Family Codename",
                 field: "family_codename",
@@ -105,7 +110,9 @@ export default function ParticipantTable() {
                 ),
             },
         ];
-    }, [datasetTypes, sexTypes, participantTypes, paramID]);
+        setInitialFilters(columns);
+        return columns;
+    }, [datasetTypes, sexTypes, participantTypes, paramID, setInitialFilters]);
 
     const tableRef = useRef<any>();
 
@@ -168,7 +175,10 @@ export default function ParticipantTable() {
             <MaterialTablePrimary
                 tableRef={tableRef}
                 columns={columns}
-                data={dataFetch}
+                data={query => {
+                    if (query) handleFilterChange(query.filters);
+                    return dataFetch(query);
+                }}
                 title="Participants"
                 options={{
                     selection: false,

--- a/react/src/hooks/index.tsx
+++ b/react/src/hooks/index.tsx
@@ -41,3 +41,4 @@ export { useDatasetDeleteMutation } from "./datasets/useDatasetDeleteMutation";
 export * from "./useDownloadCsv";
 export { useColumnOrderCache } from "./useColumnOrderCache";
 export { useSortOrderCache } from "./useSortOrderCache";
+export { useTableFilterCache } from "./useTableFilterCache";

--- a/react/src/hooks/useTableFilterCache.tsx
+++ b/react/src/hooks/useTableFilterCache.tsx
@@ -13,7 +13,7 @@ export function useTableFilterCache<RowData extends object>(cacheKey: string) {
      * Filters should be extracted from material-table query
      * when data is fetched.
      */
-    const handleFilterChanged = (filters: Filter<RowData>[]) => {
+    const handleFilterChange = (filters: Filter<RowData>[]) => {
         localStorage.setItem(cacheKey, JSON.stringify(filters));
     };
 
@@ -42,7 +42,7 @@ export function useTableFilterCache<RowData extends object>(cacheKey: string) {
     };
 
     return {
-        handleFilterChanged: handleFilterChanged,
+        handleFilterChange: handleFilterChange,
         setInitialFilters: setInitialFilters,
     };
 }

--- a/react/src/hooks/useTableFilterCache.tsx
+++ b/react/src/hooks/useTableFilterCache.tsx
@@ -42,7 +42,7 @@ export function useTableFilterCache<RowData extends object>(cacheKey: string) {
     };
 
     return {
-        handleFilterChange: handleFilterChange,
-        setInitialFilters: setInitialFilters,
+        handleFilterChange,
+        setInitialFilters,
     };
 }

--- a/react/src/hooks/useTableFilterCache.tsx
+++ b/react/src/hooks/useTableFilterCache.tsx
@@ -1,14 +1,37 @@
 import { Column, Filter } from "@material-table/core";
 
+/**
+ * Return functions for handling table filter caching.
+ *
+ * Instead of loading saved filters on mount via side effect,
+ * use `setInitialFilters` to set the default filter values
+ * for all columns before providing them to material-table as a prop.
+ */
 export function useTableFilterCache<RowData extends object>(cacheKey: string) {
-    const handleFilterChanged = (filters: Filter<RowData>[]) =>
+    /**
+     * Update the stored filters for this table.
+     * Filters should be extracted from material-table query
+     * when data is fetched.
+     */
+    const handleFilterChanged = (filters: Filter<RowData>[]) => {
         localStorage.setItem(cacheKey, JSON.stringify(filters));
+    };
 
+    /**
+     * Sets default filter values for an array of columns
+     * using saved localStorage filters, if possible.
+     */
     const setInitialFilters = (columns: Column<RowData>[]) => {
         const filterCache = localStorage.getItem(cacheKey);
         if (filterCache !== null) {
+            const parsedCache = JSON.parse(filterCache);
+            if (!Array.isArray(parsedCache)) {
+                console.error(`${cacheKey} has invalid format`);
+                localStorage.removeItem(cacheKey);
+                return;
+            }
             const filterMapping = new Map(
-                (JSON.parse(filterCache) as Filter<RowData>[]).map(f => [f.column.field, f.value])
+                (parsedCache as Filter<RowData>[]).map(f => [f.column?.field, f.value])
             );
 
             columns.forEach(col => {

--- a/react/src/hooks/useTableFilterCache.tsx
+++ b/react/src/hooks/useTableFilterCache.tsx
@@ -1,0 +1,58 @@
+import React, { useCallback, useLayoutEffect, useState } from "react";
+import { Filter, MaterialTableProps } from "@material-table/core";
+import { setTableFilters } from "../functions";
+
+export function useTableFilterCache<RowData extends object>(
+    tableRef: React.MutableRefObject<any>,
+    cacheKey: string,
+    dependencies?: (boolean | undefined)[]
+) {
+    const [applied, setApplied] = useState(false);
+
+    const handleFilterChanged: MaterialTableProps<RowData>["onFilterChange"] = useCallback(
+        filters => {
+            // const filterCache: string[] = [];
+            // filters.forEach(filter => {
+            //     filterCache.push(`${filter.column.field};${filter.value}`);
+            // });
+            localStorage.setItem(cacheKey, JSON.stringify(filters));
+        },
+        [cacheKey]
+    );
+
+    useLayoutEffect(() => {
+        if (tableRef.current && !applied) {
+            // Get stored settings
+            const filterCache = localStorage.getItem(cacheKey);
+            if (filterCache === null) {
+                // not found
+                // is this legal?
+                handleFilterChanged(tableRef.current.state.query.filters);
+            } else {
+                // found
+                // const filters = filterCache.split(",");
+                // integrity check
+                // if (!filters.every(f => f.split(";").length === 2)) {
+                //     console.error(`${cacheKey} has invalid format`);
+                //     localStorage.removeItem(cacheKey);
+                // } else {
+                //     const filterMapping = filters.map(f => f.split(";"));
+                //     filterMapping.forEach();
+                //     setTableFilters<object>(tableRef, new Map(filters.map(f => f.split(";"))));
+                // }
+
+                console.log("setting filters...");
+                const filters: Filter<RowData>[] = JSON.parse(filterCache);
+
+                setTableFilters<RowData>(
+                    tableRef,
+                    new Map(filters.map(f => [f.column.field as keyof RowData, f.value]))
+                );
+            }
+
+            setApplied(true);
+        }
+    }, [tableRef, cacheKey, dependencies, handleFilterChanged, applied]);
+
+    return handleFilterChanged;
+}


### PR DESCRIPTION
Part of #550 
Sets default filters by setting defaultFilter values for columns before they are added to material-table, as opposed to injecting them into the table via ref as a side effect.