### PR TITLE
Docker: fix nginx resolving to stale DNS entries when containers are replaced

### DIFF
--- a/nginx/conf.d/default.conf
+++ b/nginx/conf.d/default.conf
@@ -10,6 +10,7 @@ server {
   server_name _;
   ssl_certificate /etc/nginx/certs/bundle.crt;
   ssl_certificate_key /etc/nginx/certs/star_ccm_sickkids_ca.key;
+  resolver 127.0.0.11 valid=15s;
 
   location @index {
     rewrite ^(.*)$ /stager-site/index.html break;
@@ -25,7 +26,8 @@ server {
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
   }
   location /api {
-    proxy_pass "http://app:5000";
+    set $app "http://app:5000";
+    proxy_pass $app$request_uri;
     proxy_connect_timeout 300;
     proxy_buffering off;
     proxy_set_header Host $host;
@@ -38,7 +40,8 @@ server {
 #   ignore_invalid_headers off;
     client_max_body_size 0;
     proxy_buffering off;
-    proxy_pass "http://minio:9000";
+    set $backend "http://minio:9000";
+    proxy_pass $backend$request_uri;
     proxy_connect_timeout 300;
     proxy_http_version 1.1;
     proxy_set_header Host $http_host;
@@ -59,9 +62,11 @@ server {
   ignore_invalid_headers off;
   client_max_body_size 0;
   proxy_buffering off;
+  resolver 127.0.0.11 valid=15s;
 
   location / {
-    proxy_pass "http://minio:9000";
+    set $backend "http://minio:9000";
+    proxy_pass $backend$request_uri;
     proxy_connect_timeout 300;
     proxy_http_version 1.1;
     proxy_set_header Host $http_host;


### PR DESCRIPTION
This has proved effective on https://stager-dev.ccm.sickkids.ca for weeks now.