### PR TITLE
React & Flask: Add permission group column to datasets

### DIFF
--- a/flask/app/datasets.py
+++ b/flask/app/datasets.py
@@ -199,9 +199,7 @@ def list_datasets(page: int, limit: int) -> Response:
             "family_codename": dataset.tissue_sample.participant.family.family_codename,
             "created_by": dataset.created_by.username,
             "updated_by": dataset.updated_by.username,
-            "group_code": [group.group_code for group in dataset.groups]
-            if current_user.is_admin or len(current_user.groups) > 1
-            else None,
+            "group_code": [group.group_code for group in dataset.groups],
         }
         for dataset in datasets
     ]

--- a/flask/app/datasets.py
+++ b/flask/app/datasets.py
@@ -199,6 +199,9 @@ def list_datasets(page: int, limit: int) -> Response:
             "family_codename": dataset.tissue_sample.participant.family.family_codename,
             "created_by": dataset.created_by.username,
             "updated_by": dataset.updated_by.username,
+            "group_code": [group.group_code for group in dataset.groups]
+            if current_user.is_admin or len(current_user.groups) > 1
+            else None,
         }
         for dataset in datasets
     ]

--- a/react/src/Datasets/components/DatasetTable.tsx
+++ b/react/src/Datasets/components/DatasetTable.tsx
@@ -190,7 +190,10 @@ export default function DatasetTable() {
                 editable: "never",
                 filtering: false,
                 render: rowData => (
-                    <ChipGroup names={rowData.group_code.map(c => c.toUpperCase())} size="small" />
+                    <ChipGroup
+                        names={rowData.group_code?.map(c => c.toUpperCase()) || []}
+                        size="small"
+                    />
                 ),
             });
         }

--- a/react/src/Datasets/components/DatasetTable.tsx
+++ b/react/src/Datasets/components/DatasetTable.tsx
@@ -189,6 +189,7 @@ export default function DatasetTable() {
                 field: "group_code",
                 editable: "never",
                 filtering: false,
+                sorting: false,
                 render: rowData => (
                     <ChipGroup
                         names={rowData.group_code?.map(c => c.toUpperCase()) || []}

--- a/react/src/Datasets/components/DatasetTable.tsx
+++ b/react/src/Datasets/components/DatasetTable.tsx
@@ -6,6 +6,7 @@ import { useSnackbar } from "notistack";
 import { useQueryClient } from "react-query";
 import { useParams } from "react-router-dom";
 import {
+    ChipGroup,
     DateFilterComponent,
     DateTimeText,
     EditNotes,
@@ -182,6 +183,17 @@ export default function DatasetTable() {
                 defaultFilter: paramID,
             },
         ];
+        if (currentUser.is_admin || currentUser.groups.length > 1) {
+            columns.push({
+                title: "Permission Groups",
+                field: "group_code",
+                editable: "never",
+                filtering: false,
+                render: rowData => (
+                    <ChipGroup names={rowData.group_code.map(c => c.toUpperCase())} size="small" />
+                ),
+            });
+        }
         setInitialSorting(columns);
         setHiddenColumns(columns);
         setInitialFilters(columns);
@@ -191,6 +203,7 @@ export default function DatasetTable() {
         datasetTypes,
         paramID,
         tissueSampleTypes,
+        currentUser,
         setInitialFilters,
         setInitialSorting,
         setHiddenColumns,

--- a/react/src/Participants/components/ParticipantTable.tsx
+++ b/react/src/Participants/components/ParticipantTable.tsx
@@ -133,6 +133,7 @@ export default function ParticipantTable() {
                 editable: "never",
                 lookup: datasetTypes,
                 filtering: false,
+                sorting: false,
                 render: (rowData: Participant) => (
                     <DatasetTypes datasetTypes={countArray(rowData.dataset_types)} />
                 ),

--- a/react/src/components/ChipGroup.tsx
+++ b/react/src/components/ChipGroup.tsx
@@ -3,7 +3,7 @@ import { Box, BoxProps, Chip, ChipProps, makeStyles } from "@material-ui/core";
 
 const useStyles = makeStyles(theme => ({
     chip: {
-        marginLeft: theme.spacing(1),
+        margin: theme.spacing(0.5),
     },
 }));
 

--- a/react/src/typings.tsx
+++ b/react/src/typings.tsx
@@ -82,7 +82,7 @@ export interface Dataset {
     updated: string;
     updated_by: number;
     discriminator: string;
-    group_code: string[];
+    group_code?: string[];
 }
 
 // Result from /api/datasets/:id

--- a/react/src/typings.tsx
+++ b/react/src/typings.tsx
@@ -82,6 +82,7 @@ export interface Dataset {
     updated: string;
     updated_by: number;
     discriminator: string;
+    group_code: string[];
 }
 
 // Result from /api/datasets/:id


### PR DESCRIPTION
Closes #546.
- Datasets returned by GET /api/datasets each include an array of group_codes associated to each dataset if applicable (if current user is admin or belongs to multiple groups).
- Frontend adds column to DatasetTable for group_code iff the current user is an admin or belongs to multiple groups.
- Update frontend typing for Dataset to include group_code