### PR TITLE
Flask: bump from 1.1.2 to 2.0.1, drop unused flask_wtf

### DIFF
--- a/flask/app/utils.py
+++ b/flask/app/utils.py
@@ -243,7 +243,7 @@ def csv_response(
         BytesIO(csv.encode("utf-8")),
         "text/csv",
         as_attachment=True,
-        attachment_filename=filename,
+        download_name=filename,
     )
 
 

--- a/flask/requirements-dev.txt
+++ b/flask/requirements-dev.txt
@@ -24,7 +24,7 @@ cffi==1.14.5
     # via cryptography
 chardet==4.0.0
     # via requests
-click==7.1.2
+click==8.0.1
     # via
     #   black
     #   flask
@@ -40,38 +40,37 @@ flask-sqlalchemy==2.5.1
     # via
     #   -r requirements.in
     #   flask-migrate
-flask-wtf==0.14.3
-    # via -r requirements.in
-flask==1.1.2
+flask==2.0.1
     # via
     #   -r requirements.in
     #   flask-login
     #   flask-migrate
     #   flask-sqlalchemy
-    #   flask-wtf
 gunicorn==20.1.0
     # via -r requirements.in
 idna==2.10
     # via requests
+importlib-metadata==4.0.1
+    # via
+    #   click
+    #   pluggy
+    #   pytest
 iniconfig==1.1.1
     # via pytest
 isort==5.8.0
     # via pylint
-itsdangerous==1.1.0
-    # via
-    #   flask
-    #   flask-wtf
-jinja2==2.11.3
+itsdangerous==2.0.1
+    # via flask
+jinja2==3.0.1
     # via flask
 lazy-object-proxy==1.6.0
     # via astroid
 mako==1.1.4
     # via alembic
-markupsafe==1.1.1
+markupsafe==2.0.1
     # via
     #   jinja2
     #   mako
-    #   wtforms
 mccabe==0.6.1
     # via pylint
 minio==7.0.3
@@ -125,21 +124,23 @@ toml==0.10.2
     #   pylint
     #   pytest
 typed-ast==1.4.2
-    # via black
-typing-extensions==3.7.4.3
-    # via black
+    # via
+    #   astroid
+    #   black
+typing-extensions==3.10.0.0
+    # via
+    #   black
+    #   importlib-metadata
 urllib3==1.26.4
     # via
     #   minio
     #   requests
-werkzeug==1.0.1
-    # via
-    #   -r requirements.in
-    #   flask
+werkzeug==2.0.1
+    # via flask
 wrapt==1.12.1
     # via astroid
-wtforms==2.3.3
-    # via flask-wtf
+zipp==3.4.1
+    # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/flask/requirements.in
+++ b/flask/requirements.in
@@ -1,13 +1,11 @@
+authlib
 flask
 flask_sqlalchemy
 flask_login
 flask_migrate
-flask_wtf
-requests
-authlib
 gunicorn
 minio
 pandas
 pymysql[rsa]
+requests
 sqlalchemy
-werkzeug

--- a/flask/requirements.txt
+++ b/flask/requirements.txt
@@ -16,7 +16,7 @@ cffi==1.14.5
     # via cryptography
 chardet==4.0.0
     # via requests
-click==7.1.2
+click==8.0.1
     # via flask
 cryptography==3.4.7
     # via
@@ -30,32 +30,28 @@ flask-sqlalchemy==2.5.1
     # via
     #   -r requirements.in
     #   flask-migrate
-flask-wtf==0.14.3
-    # via -r requirements.in
-flask==1.1.2
+flask==2.0.1
     # via
     #   -r requirements.in
     #   flask-login
     #   flask-migrate
     #   flask-sqlalchemy
-    #   flask-wtf
 gunicorn==20.1.0
     # via -r requirements.in
 idna==2.10
     # via requests
-itsdangerous==1.1.0
-    # via
-    #   flask
-    #   flask-wtf
-jinja2==2.11.3
+importlib-metadata==4.0.1
+    # via click
+itsdangerous==2.0.1
+    # via flask
+jinja2==3.0.1
     # via flask
 mako==1.1.4
     # via alembic
-markupsafe==1.1.1
+markupsafe==2.0.1
     # via
     #   jinja2
     #   mako
-    #   wtforms
 minio==7.0.3
     # via -r requirements.in
 numpy==1.20.2
@@ -83,16 +79,16 @@ sqlalchemy==1.3.24
     #   -r requirements.in
     #   alembic
     #   flask-sqlalchemy
+typing-extensions==3.10.0.0
+    # via importlib-metadata
 urllib3==1.26.4
     # via
     #   minio
     #   requests
-werkzeug==1.0.1
-    # via
-    #   -r requirements.in
-    #   flask
-wtforms==2.3.3
-    # via flask-wtf
+werkzeug==2.0.1
+    # via flask
+zipp==3.4.1
+    # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools


### PR DESCRIPTION
- 'attachment_filename' parameter has been renamed to 'download_name' 
- https://palletsprojects.com/blog/flask-2-0-released/
- https://click.palletsprojects.com/en/8.0.x/changes/#version-8-0
- affected: flask and transitive dependencies like werkzeug; click from 7.1.2 to 8.0.1
- supersedes #593, #594, #612, #614
