### PR TITLE
Flask: changes, re-factoring endpoints for adding requested gene(s) to JSON and CSV

### DIFF
--- a/flask/app/variants.py
+++ b/flask/app/variants.py
@@ -59,11 +59,10 @@ def get_report_df(df: pd.DataFrame, type: str, relevant_cols=relevant_cols):
     # some columns are duplicated eg. dataset_id, is there a way to query so that this doesn't happen?
 
     df = df[~df["zygosity"].str.contains("-|Insufficient")]
-
-    df = df.fillna('')
+    df = df.fillna("")
     df = df.astype(str)
-    df['ensembl_id'] = df['ensembl_id'].apply(lambda x: 'ENSG' + x.rjust(11, '0'))
-    
+    df["ensembl_id"] = df["ensembl_id"].apply(lambda x: "ENSG" + x.rjust(11, "0"))
+
     if type == "participants":
         return df
 
@@ -94,7 +93,6 @@ def get_report_df(df: pd.DataFrame, type: str, relevant_cols=relevant_cols):
             .reset_index()
         )
         df = df[relevant_cols]
-
 
         df["frequency"] = df["participant_codename"].str.len()
         for col in [

--- a/flask/app/variants.py
+++ b/flask/app/variants.py
@@ -60,8 +60,10 @@ def get_report_df(df: pd.DataFrame, type: str, relevant_cols=relevant_cols):
 
     df = df[~df["zygosity"].str.contains("-|Insufficient")]
 
+    df = df.fillna('')
     df = df.astype(str)
-
+    df['ensembl_id'] = df['ensembl_id'].apply(lambda x: 'ENSG' + x.rjust(11, '0'))
+    
     if type == "participants":
         return df
 
@@ -85,15 +87,18 @@ def get_report_df(df: pd.DataFrame, type: str, relevant_cols=relevant_cols):
                     "alt_depths": list,
                     "dataset_id": list,
                     "participant_codename": list,
-                    "family_codename": lambda x: set(x),
+                    "family_codename": set,
                 },
                 axis="columns",
             )
             .reset_index()
         )
         df = df[relevant_cols]
+
+
         df["frequency"] = df["participant_codename"].str.len()
         for col in [
+            "ensembl_id",
             "zygosity",
             "burden",
             "alt_depths",

--- a/flask/app/variants.py
+++ b/flask/app/variants.py
@@ -288,7 +288,7 @@ def summary(type: str):
         response.headers.set(
             "Content-Disposition",
             "attachment",
-            filename="{}_wise_report.csv".format(type),
+            filename="{}_wise_report.csv".format(type[:-1]),
         )
         return response
     else:

--- a/flask/app/variants.py
+++ b/flask/app/variants.py
@@ -9,6 +9,7 @@ from sqlalchemy.sql import and_, or_
 
 import pandas as pd
 from . import models
+from .extensions import db
 
 from .utils import expects_csv, expects_json
 
@@ -18,53 +19,58 @@ variants_blueprint = Blueprint(
     __name__,
 )
 
+relevant_cols = [
+    "ensembl_id",
+    "chromosome",
+    "position",
+    "reference_allele",
+    "alt_allele",
+    "variation",
+    "refseq_change",
+    "depth",
+    "conserved_in_20_mammals",
+    "sift_score",
+    "polyphen_score",
+    "cadd_score",
+    "gnomad_af",
+    "zygosity",
+    "burden",
+    "alt_depths",
+    "dataset_id",
+    "participant_codename",
+    "family_codename",
+]
 
-def get_report_df(df: pd.DataFrame, type: str):
+
+def get_report_df(df: pd.DataFrame, type: str, relevant_cols=relevant_cols):
     """
     The expected input is a de-normalized ('tidy') dataframe returned by pd.read_sql. This function subsets relevant columns and retains variants with sufficient depth to annotate zygosity.
-    It then returns a sample (participant) wise dataframe, where each row is a participant's variant, the variant annotations, and their genotype,
+    It then returns a sample (participant)  wise dataframe, where each row is a participant's variant, the variant annotations, and their genotype,
     or aggregates by variant, where each row is identified by a unique variant and various fields such as depth, zygosity and codenames are concatenated into a single list, delimited by a ';'.
     """
 
     app.logger.debug(df.head(3))
 
     # subsetting by a list of col names ensures ordering is consistent between the two report types
-    relevant_cols = [
-        "chromosome",
-        "position",
-        "reference_allele",
-        "alt_allele",
-        "variation",
-        "refseq_change",
-        "depth",
-        "conserved_in_20_mammals",
-        "sift_score",
-        "polyphen_score",
-        "cadd_score",
-        "gnomad_af",
-        "zygosity",
-        "burden",
-        "alt_depths",
-        "dataset_id",
-        "participant_codename",
-        "family_codename",
-    ]
-    df = df[relevant_cols]
+
     df = df.loc[:, ~df.columns.duplicated()]
+    df = df[relevant_cols]
+
     # some columns are duplicated eg. dataset_id, is there a way to query so that this doesn't happen?
 
     df = df[~df["zygosity"].str.contains("-|Insufficient")]
 
     df = df.astype(str)
 
-    if type == "sample":
+    if type == "participants":
         return df
 
-    elif type == "variant":
+    elif type == "variants":
         df = (
             df.groupby(["position", "reference_allele", "alt_allele"])
             .agg(
                 {
+                    "ensembl_id": set,
                     "chromosome": "first",
                     "variation": "first",
                     "refseq_change": "first",
@@ -87,7 +93,6 @@ def get_report_df(df: pd.DataFrame, type: str):
         )
         df = df[relevant_cols]
         df["frequency"] = df["participant_codename"].str.len()
-
         for col in [
             "zygosity",
             "burden",
@@ -144,22 +149,30 @@ def parse_gene_panel() -> List[Any]:
         abort(400, description="Not all requested genes were found.")
 
     genes = query.all()
-    return [
-        and_(
-            gene.chromosome == models.Variant.chromosome,
-            gene.start <= models.Variant.position,
-            models.Variant.position <= gene.end,
-        )
-        for gene in genes
-    ]
+
+    return ensgs
 
 
-@variants_blueprint.route("/api/summary/participants", methods=["GET"])
+@variants_blueprint.route("/api/summary/<string:type>", methods=["GET"])
 @login_required
-def participant_summary():
+def summary(type: str):
     """
-    GET /api/summary/participants?panel=ENSGXXXXXXXX,ENSGXXXXXXX
+    GET /api/summary/participants\?panel=ENSG00000138131
+    GET /api/summary/variants\?panel=ENSG00000138131
+
+    The same sqlalchemy query is used for both endpoints as the participant-wise report is the precursor to the variant-wise report.
+
+    The JSON response for participants is de-normalized such that each object is a participant and a variant,
+    whereas for the variant JSON response, each object is a variant, the annotations, and an array of genotypes for the involved participants.
+
+    Similarly, the csv output for the participants is de-normalized such that each row is a participant's variant. If the requested genes span similar coordinates duplicated variants will be returned, for each gene.
+    The variant csv output is a summary - each row is a unique variant with various columns collapsed and ';' delimited indicating for example, all participants that had such a variant.
+
     """
+
+    if type not in ["variants", "participants"]:
+        abort(404)
+
     if app.config.get("LOGIN_DISABLED") or current_user.is_admin:
         user_id = request.args.get("user")
         app.logger.debug("User is admin with ID '%s'", user_id)
@@ -167,137 +180,37 @@ def participant_summary():
         user_id = current_user.user_id
         app.logger.debug("User is regular with ID '%s'", user_id)
 
-    filters = parse_gene_panel()
+    ensgs = parse_gene_panel()
 
+    # app.logger.debug(ensgs)
+
+    # returns a tuple (Genes, Variants)
     query = (
-        models.Dataset.query.options(
-            contains_eager(models.Dataset.genotype).contains_eager(
-                models.Genotype.variant
-            ),
-            contains_eager(models.Dataset.tissue_sample)
-            .contains_eager(models.TissueSample.participant)
-            .contains_eager(models.Participant.family),
-        )
-        .join(models.Participant.tissue_samples)
-        .join(models.TissueSample.datasets)
-        .join(models.Dataset.genotype)
-        .join(models.Genotype.analysis, models.Genotype.variant)
-        .join(models.Participant.family)
-        .filter(or_(*filters))
-    )
-
-    if user_id:
-        app.logger.debug("Processing query - restricted based on user id.")
-        query = (
-            query.join(
-                models.groups_datasets_table,
-                models.Dataset.dataset_id
-                == models.groups_datasets_table.columns.dataset_id,
-            )
-            .join(
-                models.users_groups_table,
-                models.groups_datasets_table.columns.group_id
-                == models.users_groups_table.columns.group_id,
-            )
-            .filter(models.users_groups_table.columns.user_id == user_id)
-        )
-
-    else:
-        app.logger.debug("Processing query - unrestricted based on user id.")
-
-    app.logger.info(request.accept_mimetypes)
-
-    if expects_json(request):
-        app.logger.info("Defaulting to json response")
-        q = query.all()
-        app.logger.info(
-            [
-                {
-                    "participant_codename": dataset.tissue_sample.participant.participant_codename,
-                    "family_codename": dataset.tissue_sample.participant.family.family_codename,
-                }
-                for dataset in q
-            ]
-        )
-        return jsonify(
-            [
-                {
-                    "participant_id": dataset.tissue_sample.participant.participant_id,
-                    "participant_codename": dataset.tissue_sample.participant.participant_codename,
-                    "family_id": dataset.tissue_sample.participant.family.family_id,
-                    "family_codename": dataset.tissue_sample.participant.family.family_codename,
-                    "dataset": {
-                        "variants": [
-                            {
-                                **asdict(genotype),
-                                **asdict(genotype.variant),
-                            }
-                            for genotype in dataset.genotype
-                        ],
-                    },
-                }
-                for dataset in q
-            ]
-        )
-    elif expects_csv(request):
-        app.logger.info("text/csv Accept header requested")
-
-        try:
-            sql_df = pd.read_sql(query.statement, query.session.bind)
-        except:
-            app.logger.error(
-                "Unexpected error resulting from sqlalchemy query", exc_info=True
-            )
-            abort(500, "Unexpected error")
-
-        agg_df = get_report_df(sql_df, type="sample")
-        csv_data = agg_df.to_csv(encoding="utf-8", index=False)
-
-        response = Response(csv_data, mimetype="text/csv")
-        response.headers.set(
-            "Content-Disposition", "attachment", filename="participant_wise_report.csv"
-        )
-        return response
-    else:
-        app.logger.error(
-            "Only 'text/csv' and 'application/json' HTTP accept headers supported"
-        )
-        abort(
-            406, "Only 'text/csv' and 'application/json' HTTP accept headers supported"
-        )
-
-
-@variants_blueprint.route("/api/summary/variants", methods=["GET"])
-@login_required
-def variant_summary():
-    """
-    GET /api/summary/variants?panel=ENSGXXXXXXXX,ENSGXXXXXXX
-    """
-    if app.config.get("LOGIN_DISABLED") or current_user.is_admin:
-        user_id = request.args.get("user")
-        app.logger.debug("User is admin with ID '%s'", user_id)
-    else:
-        user_id = current_user.user_id
-        app.logger.debug("User is regular with ID '%s'", user_id)
-
-    filters = parse_gene_panel()
-
-    query = (
-        models.Variant.query.options(
+        db.session.query(models.Gene, models.Variant)
+        .options(
             contains_eager(models.Variant.genotype)
             .contains_eager(models.Genotype.analysis)
             .contains_eager(models.Analysis.datasets)
             .contains_eager(models.Dataset.tissue_sample)
             .contains_eager(models.TissueSample.participant)
-            .contains_eager(models.Participant.family),
+            .contains_eager(models.Participant.family)
+        )
+        .join(
+            models.Variant,
+            and_(
+                models.Gene.chromosome == models.Variant.chromosome,
+                models.Gene.start <= models.Variant.position,
+                models.Variant.position <= models.Gene.end,
+            ),
         )
         .join(models.Variant.genotype)
         .join(models.Genotype.analysis, models.Genotype.dataset)
         .join(models.Dataset.tissue_sample)
         .join(models.TissueSample.participant)
         .join(models.Participant.family)
-        .filter(or_(*filters))
+        .filter(models.Gene.ensembl_id.in_(ensgs))
     )
+
     if user_id:
         app.logger.debug("Processing query - restricted based on user id.")
         query = (
@@ -321,22 +234,40 @@ def variant_summary():
 
     if expects_json(request):
         app.logger.info("Defaulting to json response")
-        q = query.all()
-        return jsonify(
-            [
-                {
-                    **asdict(variant),
-                    "genotype": [
-                        {
-                            **asdict(genotype),
-                            "participant_codename": genotype.dataset.tissue_sample.participant.participant_codename,
-                        }
-                        for genotype in variant.genotype
-                    ],
-                }
-                for variant in q
-            ],
-        )
+
+        if type == "variants":
+
+            return jsonify(
+                [
+                    {
+                        **asdict(tup[0]),  # gene
+                        **asdict(tup[1]),  # variants
+                        "genotype": [
+                            {
+                                **asdict(genotype),
+                                "participant_codename": genotype.dataset.tissue_sample.participant.participant_codename,
+                            }
+                            for genotype in tup[1].genotype
+                        ],
+                    }
+                    for tup in query.all()
+                ]
+            )
+
+        elif type == "participants":
+            try:
+                sql_df = pd.read_sql(query.statement, query.session.bind)
+            except:
+                app.logger.error(
+                    "Unexpected error resulting from sqlalchemy query", exc_info=True
+                )
+                abort(500, "Unexpected error")
+
+            ptp_dict = sql_df.loc[:, ~sql_df.columns.duplicated()][
+                relevant_cols
+            ].to_dict(orient="records")
+            return jsonify(ptp_dict)
+
     elif expects_csv(request):
         app.logger.info("text/csv Accept header requested")
         try:
@@ -347,12 +278,14 @@ def variant_summary():
             )
             abort(500, "Unexpected error")
 
-        agg_df = get_report_df(sql_df, type="variant")
+        agg_df = get_report_df(sql_df, type=type)
         csv_data = agg_df.to_csv(encoding="utf-8", index=False)
 
         response = Response(csv_data, mimetype="text/csv")
         response.headers.set(
-            "Content-Disposition", "attachment", filename="variant_wise_report.csv"
+            "Content-Disposition",
+            "attachment",
+            filename="{}_wise_report.csv".format(type),
         )
         return response
     else:

--- a/flask/tests/test_variants.py
+++ b/flask/tests/test_variants.py
@@ -85,12 +85,9 @@ def test_participant_wise_json_single_gene(test_database, client, login_as):
         headers={"Accept": "application/json"},
     )
     assert response.status_code == 200
-    # of participants
-    assert len(response.get_json()) == 2
-    # of variants for LOXL4 for each participant's dataset
-    for ptp in response.get_json():
-        variants = ptp.get("dataset").get("variants")
-        assert len(variants) == 3
+    # num. of participant-variants
+    assert len(response.get_json()) == 6
+    # remove nested structure
 
 
 def test_participant_wise_json_multiple_genes(test_database, client, login_as):
@@ -100,12 +97,13 @@ def test_participant_wise_json_multiple_genes(test_database, client, login_as):
         headers={"Accept": "application/json"},
     )
     assert response.status_code == 200
-    # # of participants
-    assert len(response.get_json()) == 2
-    # of variants for LOXL4 and RTEL1, for each participant's dataset
-    for ptp in response.get_json():
-        variants = ptp.get("dataset").get("variants")
-        assert len(variants) == 6
+    # num. of participant-variants
+    assert len(response.get_json()) == 12
+    
+    # # of variants for LOXL4 and RTEL1, for each participant's dataset
+    # for ptp in response.get_json():
+    #     variants = ptp.get("dataset").get("variants")
+    #     assert len(variants) == 6
 
 
 def test_participant_wise_json_invalid_gene(test_database, client, login_as):
@@ -164,4 +162,4 @@ def test_participant_wise_json_permissions(test_database, client, login_as):
         headers={"Accept": "application/json"},
     )
     assert response.status_code == 200
-    assert len(response.get_json()) == 2
+    assert len(response.get_json()) == 6

--- a/flask/tests/test_variants.py
+++ b/flask/tests/test_variants.py
@@ -99,7 +99,6 @@ def test_participant_wise_json_multiple_genes(test_database, client, login_as):
     assert response.status_code == 200
     # num. of participant-variants (2x6)
     assert len(response.get_json()) == 12
-    
 
 
 def test_participant_wise_json_invalid_gene(test_database, client, login_as):

--- a/flask/tests/test_variants.py
+++ b/flask/tests/test_variants.py
@@ -85,7 +85,7 @@ def test_participant_wise_json_single_gene(test_database, client, login_as):
         headers={"Accept": "application/json"},
     )
     assert response.status_code == 200
-    # num. of participant-variants
+    # num. of participant-variants (1x6)
     assert len(response.get_json()) == 6
     # remove nested structure
 
@@ -97,13 +97,9 @@ def test_participant_wise_json_multiple_genes(test_database, client, login_as):
         headers={"Accept": "application/json"},
     )
     assert response.status_code == 200
-    # num. of participant-variants
+    # num. of participant-variants (2x6)
     assert len(response.get_json()) == 12
     
-    # # of variants for LOXL4 and RTEL1, for each participant's dataset
-    # for ptp in response.get_json():
-    #     variants = ptp.get("dataset").get("variants")
-    #     assert len(variants) == 6
 
 
 def test_participant_wise_json_invalid_gene(test_database, client, login_as):


### PR DESCRIPTION

closes #653 

- merged participant and variant endpoints into one endpoint since both now use the same query
- description below, from endpoint docstrings
```

    The same sqlalchemy query is used for both endpoints as the participant-wise report is the precursor to the variant-wise report.

    The JSON response for participants is de-normalized such that each object is a participant and a variant,
    whereas for the variant JSON response, each object is a variant, the annotations, and an array of genotypes for the involved participants.

    Similarly, the csv output for the participants is de-normalized such that each row is a participant's variant. If the requested genes span similar coordinates duplicated variants will be returned, for each gene.
    The variant csv output is a summary - each row is a unique variant with various columns collapsed and ';' delimited indicating for example, all participants that had such a variant.

```
