### PR TITLE
React/Flask: Add support for multiplex files

### DIFF
--- a/flask/app/buckets.py
+++ b/flask/app/buckets.py
@@ -55,21 +55,23 @@ def get_unlinked_files():
 
     files = []
 
-    linked_files = [
-        f.path
+    linked_files = {
+        f.path: True
         for f in models.File.query.filter(
             or_(models.File.multiplexed == None, models.File.multiplexed == False)
         ).all()
-    ]
+    }
 
-    linkable_files = [
-        f.path for f in models.File.query.filter(models.File.multiplexed == True).all()
-    ]
+    linkable_files = {
+        f.path: True
+        for f in models.File.query.filter(models.File.multiplexed == True).all()
+    }
 
     for file_name in all_files:
-        if file_name in linkable_files:
+        if linkable_files.get(file_name):
             files.append({"path": file_name, "multiplexed": True})
-        elif file_name not in linked_files:
+        elif not linked_files.get(file_name):
+            app.logger.debug(file_name)
             files.append({"path": file_name, "multiplexed": False})
 
     app.logger.debug("Returning JSON array..")

--- a/flask/app/buckets.py
+++ b/flask/app/buckets.py
@@ -50,7 +50,7 @@ def get_unlinked_files():
             all_files.append(bucket + "/" + obj.object_name)
 
     app.logger.debug("Getting all linked files..")
-    linked_files = {f.path: ":)" for f in models.DatasetFile.query.all()}
+    linked_files = {f.path: ":)" for f in models.File.query.all()}
 
     # Put all unlinked files in new list
     unlinked_files = []

--- a/flask/app/buckets.py
+++ b/flask/app/buckets.py
@@ -1,7 +1,9 @@
+from dataclasses import asdict
 from flask import jsonify, Blueprint, current_app as app
 from flask_login import current_user, login_required
 from minio import Minio
 from sqlalchemy.orm import joinedload
+from sqlalchemy import or_
 
 from . import models
 
@@ -50,14 +52,21 @@ def get_unlinked_files():
             all_files.append(bucket + "/" + obj.object_name)
 
     app.logger.debug("Getting all linked files..")
-    linked_files = {f.path: ":)" for f in models.File.query.all()}
+    
+    linked_files = [
+        f.path
+        for f in models.File.query.all()
+    ]
 
-    # Put all unlinked files in new list
-    unlinked_files = []
+    linkable_files = [
+        asdict(f)
+        for f in models.File.query.filter(models.File.multiplexed == True).all()
+    ]
+
     for file_name in all_files:
         if file_name not in linked_files:
-            unlinked_files.append(file_name)
+            linkable_files.append({"path": file_name, "multiplexed": False})
 
     app.logger.debug("Returning JSON array..")
 
-    return jsonify(sorted(unlinked_files))
+    return jsonify(sorted(linkable_files, key=lambda f: f["path"]))

--- a/flask/app/datasets.py
+++ b/flask/app/datasets.py
@@ -469,7 +469,7 @@ def create_dataset():
 def update_dataset_linked_files(
     dataset: models.Dataset, linked_files: List[models.File]
 ):
-    """ update linked file relationship, validating input and deleting orphans """
+    """update linked file relationship, validating input and deleting orphans"""
     existing_files = (
         models.File.query.filter(
             models.File.path.in_([f["path"] for f in linked_files])

--- a/flask/app/datasets.py
+++ b/flask/app/datasets.py
@@ -67,7 +67,7 @@ def list_datasets(page: int, limit: int) -> Response:
     elif order_by == "updated_by":
         order = models.User.username
     elif order_by == "linked_files":
-        order = models.DatasetFile.path
+        order = models.File.path
     elif order_by == "tissue_sample_type":
         order = models.TissueSample.tissue_sample_type
     elif order_by == "participant_codename":
@@ -104,7 +104,7 @@ def list_datasets(page: int, limit: int) -> Response:
         filters.append(models.Dataset.dataset_id == dataset_id)
     linked_files = request.args.get("linked_files", type=str)
     if linked_files:
-        filters.append(func.instr(models.DatasetFile.path, linked_files))
+        filters.append(func.instr(models.File.path, linked_files))
     participant_codename = request.args.get("participant_codename", type=str)
     if participant_codename:
         filters.append(
@@ -348,7 +348,7 @@ def update_dataset(id: int):
                 db.session.delete(existing)
         for path in request.json["linked_files"]:
             if path not in dataset.linked_files:
-                dataset.files.append(models.DatasetFile(path=path))
+                dataset.files.append(models.File(path=path))
 
     if user_id:
         dataset.updated_by_id = user_id
@@ -440,7 +440,7 @@ def create_dataset():
     # TODO: add stricter checks?
     if request.json.get("linked_files"):
         for path in request.json["linked_files"]:
-            dataset.files.append(models.DatasetFile(path=path))
+            dataset.files.append(models.File(path=path))
     db.session.add(dataset)
     transaction_or_abort(db.session.commit)
     ds_id = dataset.dataset_id

--- a/flask/app/models.py
+++ b/flask/app/models.py
@@ -304,26 +304,13 @@ class Dataset(db.Model):
     )
     updated_by = db.relationship("User", foreign_keys=[updated_by_id], lazy="joined")
     created_by = db.relationship("User", foreign_keys=[created_by_id], lazy="joined")
-    files = db.relationship(
+    linked_files = db.relationship(
         "File",
         secondary=datasets_files_table,
         backref="datasets",
+        #todo: test this
         passive_deletes=True,
     )
-
-    """ files = db.relationship(
-        "DatasetFile",
-        backref="dataset",
-        cascade="all, delete",
-        passive_deletes=True,
-        lazy="joined",
-    ) """
-
-    linked_files: List[str]
-
-    @property
-    def linked_files(self) -> List[str]:
-        return [x.path for x in self.files]
 
 
 @dataclass

--- a/flask/app/models.py
+++ b/flask/app/models.py
@@ -308,7 +308,6 @@ class Dataset(db.Model):
         "File",
         secondary=datasets_files_table,
         backref="datasets",
-        #todo: test this
         passive_deletes=True,
     )
 

--- a/flask/app/routes.py
+++ b/flask/app/routes.py
@@ -548,7 +548,7 @@ def bulk_update():
                 row.get("linked_files", []),
             )
             files = row.get("linked_files", [])
-        dataset.files += [models.DatasetFile(path=path) for path in files if path]
+        dataset.files += [models.File(path=path) for path in files if path]
 
         app.logger.debug("\tAdding users groups to the dataset")
         dataset.groups += groups

--- a/flask/app/routes.py
+++ b/flask/app/routes.py
@@ -1,17 +1,10 @@
 from dataclasses import asdict
-from datetime import datetime
 from enum import Enum
 import inspect
 from io import StringIO
+from typing import Any, Dict
 
-from flask import (
-    Blueprint,
-    abort,
-    current_app as app,
-    jsonify,
-    request,
-    redirect,
-)
+from flask import Blueprint, abort, current_app as app, jsonify, request, Request
 from flask.helpers import url_for
 from flask_login import current_user, login_required, login_user, logout_user
 import pandas as pd
@@ -19,7 +12,13 @@ from sqlalchemy.orm import joinedload
 
 from . import models
 from .extensions import db, oauth
-from .utils import enum_validate, transaction_or_abort, validate_json, update_last_login
+from .utils import (
+    enum_validate,
+    find,
+    transaction_or_abort,
+    validate_json,
+    update_last_login,
+)
 
 routes = Blueprint("routes", __name__)
 
@@ -536,19 +535,8 @@ def bulk_update():
             batch_id=row.get("batch_id"),
         )
         app.logger.debug("\tLinking files to dataset..")
-        if request.content_type == "text/csv":
-            app.logger.debug(
-                "\tContent type is `text/csv` and linked files are expected to be | separated: '%s'",
-                row.get("linked_files", "").split("|"),
-            )
-            files = row.get("linked_files", "").split("|")
-        else:
-            app.logger.debug(
-                "\tContent type is NOT `test/csv` and linked files are expected to be in a list: '%s'",
-                row.get("linked_files", []),
-            )
-            files = row.get("linked_files", [])
-        dataset.files += [models.File(path=path) for path in files if path]
+
+        dataset = link_files_to_dataset(request, dataset, row)
 
         app.logger.debug("\tAdding users groups to the dataset")
         dataset.groups += groups
@@ -592,3 +580,59 @@ def bulk_update():
     ]
     app.logger.info("Done, returning JSON..")
     return jsonify(datasets)
+
+
+def link_files_to_dataset(
+    req: Request, dataset: models.Dataset, row: Dict[str, Any]
+) -> models.Dataset:
+    """validate filepaths and link to a dataset"""
+    if req.content_type == "text/csv":
+        app.logger.debug(
+            "\tContent type is `text/csv` and linked files are expected to be | separated: '%s'",
+            row.get("linked_files", "").split("|"),
+        )
+        files = []
+        for path in row.get("linked_files", "").split("|"):
+            if path:
+                is_multiplex = path[0] == "*"
+                files.append(
+                    {
+                        "path": path if not is_multiplex else path[1:],
+                        "multiplexed": is_multiplex,
+                    }
+                )
+
+    else:
+        app.logger.debug(
+            "\tContent type is NOT `test/csv` and linked files are expected to be in a list: '%s'",
+            row.get("linked_files", []),
+        )
+        files = row.get("linked_files", [])
+
+    extant_files = models.File.query.filter(
+        models.File.path.in_([f["path"] for f in files])
+    ).all()
+
+    dataset.linked_files = []
+
+    for file in files:
+        extant = find(
+            extant_files,
+            lambda extant, path=file["path"]: extant.path == path,
+        )
+        if extant and (not extant.multiplexed or not file["multiplexed"]):
+            path = file.get("path")
+            abort(
+                400,
+                description=f'File {path} is already linked! If they are multiplexed, please mark with "*"!',
+            )
+        elif extant:
+            dataset.linked_files.append(extant)
+        else:
+            dataset.linked_files.append(
+                models.File(
+                    path=file["path"],
+                    multiplexed=file.get("multiplexed"),
+                )
+            )
+    return dataset

--- a/flask/app/utils.py
+++ b/flask/app/utils.py
@@ -5,7 +5,7 @@ from enum import Enum
 from functools import wraps
 from io import BytesIO, StringIO
 from os import getenv
-from typing import Any, Callable, Dict, List, Union
+from typing import Any, Callable, Dict, List, Union, Iterable, Mapping
 from flask import (
     abort,
     current_app as app,

--- a/flask/app/utils.py
+++ b/flask/app/utils.py
@@ -298,3 +298,11 @@ class DateTimeEncoder(JSONEncoder):
 
         # default behaviour
         return JSONEncoder.default(self, obj)
+
+
+def find(collection: Iterable[Mapping[str, Any]], pred: Callable):
+    """find an item in a collection"""
+    try:
+        return next((item for item in collection if pred(item)))
+    except StopIteration:
+        return None

--- a/flask/migrations/versions/6f448fc94a2d_many_to_many_dataset_files.py
+++ b/flask/migrations/versions/6f448fc94a2d_many_to_many_dataset_files.py
@@ -21,9 +21,10 @@ depends_on = None
 
 @dataclass
 class LegacyDatasetTable(db.Model):
+    __tablename__ = "dataset_file"
     file_id = db.Column(db.Integer, primary_key=True)
     dataset_id = db.Column(db.Integer)
-    path: db.Column(db.String(500), nullable=False, unique=True)
+    path = db.Column(db.String(500), nullable=False, unique=True)
 
 
 def upgrade():

--- a/flask/migrations/versions/6f448fc94a2d_many_to_many_dataset_files.py
+++ b/flask/migrations/versions/6f448fc94a2d_many_to_many_dataset_files.py
@@ -1,0 +1,63 @@
+"""many_to_many_dataset_files
+
+Revision ID: 6f448fc94a2d
+Revises: 5e69ca582792
+Create Date: 2021-06-23 13:30:06.701210
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+from app.models import DatasetFile
+from app.extensions import db
+
+
+# revision identifiers, used by Alembic.
+revision = "6f448fc94a2d"
+down_revision = "5e69ca582792"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+
+    try:
+
+        file_table = op.create_table(
+            "file",
+            sa.Column("file_id", sa.Integer, primary_key=True),
+            sa.Column("path", sa.String(500), nullable=False, unique=True),
+            sa.Column("multiplexed", sa.Boolean, default=False),
+        )
+
+        joining_table = op.create_table(
+            "datasets_files",
+            sa.Column("file_id", sa.Integer, nullable=False),
+            sa.Column("dataset_id", sa.Integer, nullable=False),
+            sa.ForeignKeyConstraint(
+                ["file_id"],
+                ["file.file_id"],
+            ),
+            sa.ForeignKeyConstraint(
+                ["dataset_id"],
+                ["dataset.dataset_id"],
+                ondelete="CASCADE",  # DB level, ORM logic defined in models
+            ),
+        )
+
+        for file in DatasetFile.query.all():
+            stmt = file_table.insert().values(path=file.path)
+            result = db.session.execute(stmt)
+            db.session.commit()
+            pk = result.inserted_primary_key[0]
+            stmt = joining_table.insert().values(dataset_id=file.dataset_id, file_id=pk)
+            result = db.session.execute(stmt)
+            db.session.commit()
+
+    except Exception as e:
+        print(e)
+
+def downgrade():
+
+    op.drop_table("datasets_files")
+    op.drop_table("file")

--- a/flask/migrations/versions/6f448fc94a2d_many_to_many_dataset_files.py
+++ b/flask/migrations/versions/6f448fc94a2d_many_to_many_dataset_files.py
@@ -1,7 +1,7 @@
 """many_to_many_dataset_files
 
 Revision ID: 6f448fc94a2d
-Revises: 5e69ca582792
+Revises: 184f5edd4719
 Create Date: 2021-06-23 13:30:06.701210
 
 """
@@ -14,7 +14,7 @@ from app.extensions import db
 
 # revision identifiers, used by Alembic.
 revision = "6f448fc94a2d"
-down_revision = "5e69ca582792"
+down_revision = "184f5edd4719"
 branch_labels = None
 depends_on = None
 

--- a/flask/migrations/versions/6f448fc94a2d_many_to_many_dataset_files.py
+++ b/flask/migrations/versions/6f448fc94a2d_many_to_many_dataset_files.py
@@ -8,7 +8,7 @@ Create Date: 2021-06-23 13:30:06.701210
 from alembic import op
 import sqlalchemy as sa
 
-from app.models import DatasetFile
+from app import models
 from app.extensions import db
 
 
@@ -45,7 +45,7 @@ def upgrade():
             ),
         )
 
-        for file in DatasetFile.query.all():
+        for file in models.DatasetFile.query.all():
             stmt = file_table.insert().values(path=file.path)
             result = db.session.execute(stmt)
             db.session.commit()
@@ -56,6 +56,7 @@ def upgrade():
 
     except Exception as e:
         print(e)
+
 
 def downgrade():
 

--- a/flask/migrations/versions/6f448fc94a2d_many_to_many_dataset_files.py
+++ b/flask/migrations/versions/6f448fc94a2d_many_to_many_dataset_files.py
@@ -7,8 +7,8 @@ Create Date: 2021-06-23 13:30:06.701210
 """
 from alembic import op
 import sqlalchemy as sa
+from dataclasses import dataclass
 
-from app import models
 from app.extensions import db
 
 
@@ -19,43 +19,45 @@ branch_labels = None
 depends_on = None
 
 
+@dataclass
+class LegacyDatasetTable(db.Model):
+    file_id = db.Column(db.Integer, primary_key=True)
+    dataset_id = db.Column(db.Integer)
+    path: db.Column(db.String(500), nullable=False, unique=True)
+
+
 def upgrade():
 
-    try:
+    file_table = op.create_table(
+        "file",
+        sa.Column("file_id", sa.Integer, primary_key=True),
+        sa.Column("path", sa.String(500), nullable=False, unique=True),
+        sa.Column("multiplexed", sa.Boolean, default=False),
+    )
 
-        file_table = op.create_table(
-            "file",
-            sa.Column("file_id", sa.Integer, primary_key=True),
-            sa.Column("path", sa.String(500), nullable=False, unique=True),
-            sa.Column("multiplexed", sa.Boolean, default=False),
-        )
+    joining_table = op.create_table(
+        "datasets_files",
+        sa.Column("file_id", sa.Integer, nullable=False),
+        sa.Column("dataset_id", sa.Integer, nullable=False),
+        sa.ForeignKeyConstraint(
+            ["file_id"],
+            ["file.file_id"],
+        ),
+        sa.ForeignKeyConstraint(
+            ["dataset_id"],
+            ["dataset.dataset_id"],
+            ondelete="CASCADE",  # DB level, ORM logic defined in models
+        ),
+    )
 
-        joining_table = op.create_table(
-            "datasets_files",
-            sa.Column("file_id", sa.Integer, nullable=False),
-            sa.Column("dataset_id", sa.Integer, nullable=False),
-            sa.ForeignKeyConstraint(
-                ["file_id"],
-                ["file.file_id"],
-            ),
-            sa.ForeignKeyConstraint(
-                ["dataset_id"],
-                ["dataset.dataset_id"],
-                ondelete="CASCADE",  # DB level, ORM logic defined in models
-            ),
-        )
-
-        for file in models.DatasetFile.query.all():
-            stmt = file_table.insert().values(path=file.path)
-            result = db.session.execute(stmt)
-            db.session.commit()
-            pk = result.inserted_primary_key[0]
-            stmt = joining_table.insert().values(dataset_id=file.dataset_id, file_id=pk)
-            result = db.session.execute(stmt)
-            db.session.commit()
-
-    except Exception as e:
-        print(e)
+    for file in LegacyDatasetTable.query.all():
+        stmt = file_table.insert().values(path=file.path)
+        result = db.session.execute(stmt)
+        db.session.commit()
+        pk = result.inserted_primary_key[0]
+        stmt = joining_table.insert().values(dataset_id=file.dataset_id, file_id=pk)
+        result = db.session.execute(stmt)
+        db.session.commit()
 
 
 def downgrade():

--- a/flask/tests/test_datasets.py
+++ b/flask/tests/test_datasets.py
@@ -145,7 +145,10 @@ def test_update_dataset_admin(client, test_database, login_as):
 
     changes = [
         {"notes": "stop the count"},
-        {"dataset_type": "WES", "linked_files": ["/path/to/file"]},
+        {
+            "dataset_type": "WES",
+            "linked_files": [{"path": "/path/to/file", "multiplexed": False}],
+        },
     ]
     for body in changes:
         response = client.patch("/api/datasets/2", json=body)
@@ -168,7 +171,10 @@ def test_update_dataset_user(client, test_database, login_as):
 
     changes = [
         {"notes": "stop the count"},
-        {"dataset_type": "WES", "linked_files": ["/path/to/file"]},
+        {
+            "dataset_type": "WES",
+            "linked_files": [{"path": "/path/to/file", "multiplexed": False}],
+        },
     ]
     for body in changes:
         response = client.patch("/api/datasets/2", json=body)

--- a/flask/tests/test_misc.py
+++ b/flask/tests/test_misc.py
@@ -386,7 +386,7 @@ HOOD,HERO,Proband,Saliva,WGS,Female,GermLine,2020-12-17,/path/yeet|/path/cross|/
     for dataset in models.Dataset.query.all():
         print(dataset)
     assert models.Dataset.query.count() == 6
-    assert models.DatasetFile.query.count() == 5
+    assert models.File.query.count() == 5
     assert models.TissueSample.query.count() == 5
     assert models.Participant.query.count() == 4
     assert models.Family.query.count() == 3
@@ -431,7 +431,7 @@ def test_bulk_multiple_json(test_database, client, login_as):
     )
 
     assert models.Dataset.query.count() == 6
-    assert models.DatasetFile.query.count() == 4
+    assert models.File.query.count() == 4
     assert models.TissueSample.query.count() == 5
     assert models.Participant.query.count() == 4
     assert models.Family.query.count() == 3

--- a/flask/tests/test_misc.py
+++ b/flask/tests/test_misc.py
@@ -1,4 +1,4 @@
-from unittest.mock import Mock, patch
+from unittest.mock import Mock
 from csv import DictReader
 from io import StringIO
 from pytest import raises

--- a/flask/tests/test_misc.py
+++ b/flask/tests/test_misc.py
@@ -408,7 +408,9 @@ def test_bulk_multiple_json(test_database, client, login_as):
                     "sex": "Female",
                     "condition": "GermLine",
                     "sequencing_date": "2020-12-17",
-                    "linked_files": ["/otonashi/yuzuru", "/tachibana/kanade"],
+                    "linked_files": [
+                        {"path": "/otonashi/yuzuru", "path": "/tachibana/kanade"}
+                    ],
                 },
                 {
                     "family_codename": "HOOD",
@@ -420,9 +422,8 @@ def test_bulk_multiple_json(test_database, client, login_as):
                     "condition": "GermLine",
                     "sequencing_date": "2020-12-17",
                     "linked_files": [
-                        "",
-                        "/perfectly/balanced",
-                        "/as/all/things/should/be",
+                        {"path": "/perfectly/balanced"},
+                        {"path": "/as/all/things/should/be"},
                     ],
                 },
             ],
@@ -431,7 +432,7 @@ def test_bulk_multiple_json(test_database, client, login_as):
     )
 
     assert models.Dataset.query.count() == 6
-    assert models.File.query.count() == 4
+    assert models.File.query.count() == 3
     assert models.TissueSample.query.count() == 5
     assert models.Participant.query.count() == 4
     assert models.Family.query.count() == 3

--- a/react/src/AddDatasets/components/DataEntryTable.tsx
+++ b/react/src/AddDatasets/components/DataEntryTable.tsx
@@ -19,8 +19,7 @@ import {
     DataEntryRow,
     DataEntryRowOptional,
     Family,
-    Option,
-    PossiblyLinkedFile,
+    UnlinkedFile,
 } from "../../typings";
 import DataEntryTableRow from "./DataEntryTableRow";
 import DataEntryToolbar from "./DataEntryToolbar";
@@ -114,7 +113,7 @@ export default function DataEntryTable(props: DataEntryTableProps) {
     const [optionals, setOptionals] = useState<DataEntryHeader[]>(getOptionalHeaders());
 
     const filesQuery = useUnlinkedFilesQuery();
-    const [files, setFiles] = useState<string[]>([]);
+    const [files, setFiles] = useState<UnlinkedFile[]>([]);
     const institutionResult = useInstitutionsQuery();
     const institutions = institutionResult.data || [];
     const { data: enums } = useEnumsQuery();
@@ -125,7 +124,7 @@ export default function DataEntryTable(props: DataEntryTableProps) {
     }, [filesQuery]);
 
     function onEdit(
-        newValue: string | boolean | PossiblyLinkedFile,
+        newValue: string | boolean | UnlinkedFile[],
         rowIndex: number,
         col: DataEntryHeader,
         families: Family[],
@@ -167,7 +166,7 @@ export default function DataEntryTable(props: DataEntryTableProps) {
     }
 
     // Return the options for a given cell based on row, column
-    function getOptions(rowIndex: number, col: DataEntryHeader, families: Family[]): Option[] {
+    function getOptions(rowIndex: number, col: DataEntryHeader, families: Family[]) {
         return _getOptions(props.data, col, rowIndex, families, enums, files, institutions);
     }
 

--- a/react/src/AddDatasets/components/DataEntryTable.tsx
+++ b/react/src/AddDatasets/components/DataEntryTable.tsx
@@ -14,7 +14,14 @@ import { Add } from "@material-ui/icons";
 import dayjs from "dayjs";
 import { createEmptyRows, getDataEntryHeaders, setProp } from "../../functions";
 import { useEnumsQuery, useInstitutionsQuery, useUnlinkedFilesQuery } from "../../hooks";
-import { DataEntryHeader, DataEntryRow, DataEntryRowOptional, Family, Option } from "../../typings";
+import {
+    DataEntryHeader,
+    DataEntryRow,
+    DataEntryRowOptional,
+    Family,
+    Option,
+    PossiblyLinkedFile,
+} from "../../typings";
 import DataEntryTableRow from "./DataEntryTableRow";
 import DataEntryToolbar from "./DataEntryToolbar";
 import { HeaderCell } from "./TableCells";
@@ -118,7 +125,7 @@ export default function DataEntryTable(props: DataEntryTableProps) {
     }, [filesQuery]);
 
     function onEdit(
-        newValue: string | boolean | string[],
+        newValue: string | boolean | PossiblyLinkedFile,
         rowIndex: number,
         col: DataEntryHeader,
         families: Family[],

--- a/react/src/AddDatasets/components/DataEntryTableRow.tsx
+++ b/react/src/AddDatasets/components/DataEntryTableRow.tsx
@@ -2,14 +2,7 @@ import React, { useState } from "react";
 import { TableRow } from "@material-ui/core";
 import { Delete, LibraryAdd } from "@material-ui/icons";
 import { useFamiliesQuery } from "../../hooks";
-import {
-    DataEntryHeader,
-    DataEntryRow,
-    Family,
-    LinkedFile,
-    Option,
-    UnlinkedFile,
-} from "../../typings";
+import { DataEntryHeader, DataEntryRow, Family, UnlinkedFile } from "../../typings";
 import { DataEntryActionCell, DataEntryCell } from "./TableCells";
 import { participantColumns } from "./utils";
 
@@ -22,13 +15,13 @@ interface DataEntryTableRowProps {
     onDelete: () => void;
     onDuplicate: () => void;
     onChange: (
-        newValue: string | boolean | LinkedFile[] | UnlinkedFile[],
+        newValue: string | boolean | UnlinkedFile[],
         rowIndex: number,
         col: DataEntryHeader,
         families: Family[],
         autopopulate?: boolean
     ) => void;
-    getOptions: (rowIndex: number, col: DataEntryHeader, families: Family[]) => Option[];
+    getOptions: (rowIndex: number, col: DataEntryHeader, families: Family[]) => any[];
 }
 
 /**
@@ -41,7 +34,7 @@ export default function DataEntryTableRow(props: DataEntryTableRowProps) {
     const showRNA = props.row.dataset_type === "RRS";
 
     function handleChange(
-        newValue: string | boolean | LinkedFile[] | UnlinkedFile[],
+        newValue: string | boolean | UnlinkedFile[],
         col: DataEntryHeader,
         autopopulate?: boolean
     ) {

--- a/react/src/AddDatasets/components/DataEntryTableRow.tsx
+++ b/react/src/AddDatasets/components/DataEntryTableRow.tsx
@@ -2,7 +2,14 @@ import React, { useState } from "react";
 import { TableRow } from "@material-ui/core";
 import { Delete, LibraryAdd } from "@material-ui/icons";
 import { useFamiliesQuery } from "../../hooks";
-import { DataEntryHeader, DataEntryRow, Family, Option } from "../../typings";
+import {
+    DataEntryHeader,
+    DataEntryRow,
+    Family,
+    LinkedFile,
+    Option,
+    UnlinkedFile,
+} from "../../typings";
 import { DataEntryActionCell, DataEntryCell } from "./TableCells";
 import { participantColumns } from "./utils";
 
@@ -15,7 +22,7 @@ interface DataEntryTableRowProps {
     onDelete: () => void;
     onDuplicate: () => void;
     onChange: (
-        newValue: string | boolean | string[],
+        newValue: string | boolean | LinkedFile[] | UnlinkedFile[],
         rowIndex: number,
         col: DataEntryHeader,
         families: Family[],
@@ -34,7 +41,7 @@ export default function DataEntryTableRow(props: DataEntryTableRowProps) {
     const showRNA = props.row.dataset_type === "RRS";
 
     function handleChange(
-        newValue: string | boolean | string[],
+        newValue: string | boolean | LinkedFile[] | UnlinkedFile[],
         col: DataEntryHeader,
         autopopulate?: boolean
     ) {

--- a/react/src/AddDatasets/components/TableCells.tsx
+++ b/react/src/AddDatasets/components/TableCells.tsx
@@ -12,7 +12,7 @@ import { Autocomplete, createFilterOptions } from "@material-ui/lab";
 import { Resizable } from "re-resizable";
 import FileLinkingComponent from "../../components/FileLinkingComponent";
 import { strIsEmpty } from "../../functions";
-import { DataEntryHeader, DataEntryRow, Option, PossiblyLinkedFile } from "../../typings";
+import { DataEntryHeader, DataEntryRow, Option, UnlinkedFile } from "../../typings";
 import { booleanColumns, dateColumns, enumerableColumns, toOption } from "./utils";
 
 const useCellStyles = makeStyles(theme => ({
@@ -39,8 +39,8 @@ export function DataEntryCell(props: {
     row: DataEntryRow;
     rowIndex: number;
     col: DataEntryHeader;
-    getOptions: (rowIndex: number, col: DataEntryHeader) => Option[];
-    onEdit: (newValue: string | boolean | PossiblyLinkedFile, autocomplete?: boolean) => void;
+    getOptions: (rowIndex: number, col: DataEntryHeader) => any[];
+    onEdit: (newValue: string | boolean | UnlinkedFile[], autocomplete?: boolean) => void;
     disabled?: boolean;
     required?: boolean;
     onSearch?: (value: string) => void;

--- a/react/src/AddDatasets/components/TableCells.tsx
+++ b/react/src/AddDatasets/components/TableCells.tsx
@@ -12,7 +12,7 @@ import { Autocomplete, createFilterOptions } from "@material-ui/lab";
 import { Resizable } from "re-resizable";
 import FileLinkingComponent from "../../components/FileLinkingComponent";
 import { strIsEmpty } from "../../functions";
-import { DataEntryHeader, DataEntryRow, Option } from "../../typings";
+import { DataEntryHeader, DataEntryRow, Option, PossiblyLinkedFile } from "../../typings";
 import { booleanColumns, dateColumns, enumerableColumns, toOption } from "./utils";
 
 const useCellStyles = makeStyles(theme => ({
@@ -40,7 +40,7 @@ export function DataEntryCell(props: {
     rowIndex: number;
     col: DataEntryHeader;
     getOptions: (rowIndex: number, col: DataEntryHeader) => Option[];
-    onEdit: (newValue: string | boolean | string[], autocomplete?: boolean) => void;
+    onEdit: (newValue: string | boolean | PossiblyLinkedFile, autocomplete?: boolean) => void;
     disabled?: boolean;
     required?: boolean;
     onSearch?: (value: string) => void;

--- a/react/src/AddDatasets/components/utils.tsx
+++ b/react/src/AddDatasets/components/utils.tsx
@@ -1,5 +1,12 @@
 import { getDataEntryHeaders, snakeCaseToTitle, strIsEmpty } from "../../functions";
-import { DataEntryHeader, DataEntryRow, Family, Option, Participant } from "../../typings";
+import {
+    DataEntryHeader,
+    DataEntryRow,
+    Family,
+    Option,
+    Participant,
+    UnlinkedFile,
+} from "../../typings";
 
 export const booleanColumns: Array<keyof DataEntryRow> = ["affected", "solved"];
 export const dateColumns: Array<keyof DataEntryRow> = ["sequencing_date"];
@@ -92,9 +99,9 @@ export function getOptions(
     rowIndex: number,
     families: Family[],
     enums: Record<string, string[]> | undefined,
-    files: string[],
+    files: UnlinkedFile[],
     institutions: string[]
-): Option[] {
+) {
     const row = rows[rowIndex];
     const rowOptions = rows
         .filter((val, index) => index !== rowIndex) // not this row
@@ -172,7 +179,7 @@ export function getOptions(
             return booleans.map(b => toOption(b, "Is Solved"));
 
         case "linked_files":
-            return files.map(f => toOption(f, "Unlinked files"));
+            return files;
 
         case "condition":
             if (enums) {

--- a/react/src/Datasets/components/DatasetTable.tsx
+++ b/react/src/Datasets/components/DatasetTable.tsx
@@ -60,7 +60,7 @@ const EditFilesComponent = (props: EditComponentProps<Dataset>) => {
     return (
         <FileLinkingComponent
             values={props.rowData.linked_files}
-            options={files.map(file => ({ title: file, inputValue: file }))}
+            options={files}
             onEdit={newValue => props.onChange(newValue)}
             disableTooltip
         />
@@ -262,7 +262,7 @@ export default function DatasetTable() {
                                             file =>
                                                 !receivedDataset.linked_files
                                                     .map(f => f.path)
-                                                    .includes(file)
+                                                    .includes(file.path)
                                         );
                                         //refresh data
                                         MTRef.current.onQueryChange();

--- a/react/src/Datasets/components/DatasetTable.tsx
+++ b/react/src/Datasets/components/DatasetTable.tsx
@@ -166,7 +166,7 @@ export default function DatasetTable() {
                 render: RenderLinkedFilesButton,
                 editComponent: EditFilesComponent,
                 sorting: false,
-                filtering: false,
+                filtering: true,
             },
             {
                 title: "Updated",

--- a/react/src/Datasets/components/DatasetTable.tsx
+++ b/react/src/Datasets/components/DatasetTable.tsx
@@ -30,7 +30,7 @@ import {
     useUnlinkedFilesQuery,
 } from "../../hooks";
 import { transformMTQueryToCsvDownloadParams } from "../../hooks/utils";
-import { Dataset } from "../../typings";
+import { Dataset, LinkedFile } from "../../typings";
 import AnalysisRunnerDialog from "./AnalysisRunnerDialog";
 import DatasetInfoDialog from "./DatasetInfoDialog";
 import LinkedFilesButton from "./LinkedFilesButton";
@@ -50,7 +50,7 @@ const useStyles = makeStyles(theme => ({
 const customFileFilterAndSearch = (filter: string, rowData: Dataset) => {
     return (
         filter === "" + rowData.linked_files.length ||
-        rowData.linked_files.some(name => name.includes(filter))
+        rowData.linked_files.some(f => f.path.includes(filter))
     );
 };
 
@@ -61,19 +61,19 @@ const EditFilesComponent = (props: EditComponentProps<Dataset>) => {
         <FileLinkingComponent
             values={props.rowData.linked_files}
             options={files.map(file => ({ title: file, inputValue: file }))}
-            onEdit={(newValue: string[]) => props.onChange(newValue)}
+            onEdit={newValue => props.onChange(newValue)}
             disableTooltip
         />
     );
 };
 
-const linkedFileSort = (a: { linked_files: string[] }, b: { linked_files: string[] }) =>
+const linkedFileSort = (a: { linked_files: LinkedFile[] }, b: { linked_files: LinkedFile[] }) =>
     a.linked_files.length - b.linked_files.length;
 
 const RenderDatePicker = (rowData: Dataset) => <DateTimeText datetime={rowData.updated} />;
 
 const RenderLinkedFilesButton = (props: Dataset) => (
-    <LinkedFilesButton fileNames={props.linked_files} />
+    <LinkedFilesButton fileNames={(props.linked_files || []).map(f => f.path)} />
 );
 
 const RenderNotes = (rowData: Dataset) => <Note>{rowData.notes}</Note>;
@@ -259,7 +259,10 @@ export default function DatasetTable() {
                                 {
                                     onSuccess: receivedDataset => {
                                         const removeUsed = files.filter(
-                                            file => !receivedDataset.linked_files.includes(file)
+                                            file =>
+                                                !receivedDataset.linked_files
+                                                    .map(f => f.path)
+                                                    .includes(file)
                                         );
                                         //refresh data
                                         MTRef.current.onQueryChange();

--- a/react/src/Participants/components/SampleTable.tsx
+++ b/react/src/Participants/components/SampleTable.tsx
@@ -18,7 +18,7 @@ const useStyles = makeStyles(theme => ({
 
 function getFields(dataset: Dataset) {
     return [
-        createFieldObj("Linked Files", dataset.linked_files),
+        createFieldObj("Linked Files", dataset.linked_files.map(f => f.path)),
         createFieldObj("Condition", dataset.condition),
         createFieldObj("Extraction Protocol", dataset.extraction_protocol),
         createFieldObj("Capture Kit", dataset.capture_kit),

--- a/react/src/Participants/components/SampleTable.tsx
+++ b/react/src/Participants/components/SampleTable.tsx
@@ -18,7 +18,10 @@ const useStyles = makeStyles(theme => ({
 
 function getFields(dataset: Dataset) {
     return [
-        createFieldObj("Linked Files", dataset.linked_files.map(f => f.path)),
+        createFieldObj(
+            "Linked Files",
+            dataset.linked_files.map(f => f.path)
+        ),
         createFieldObj("Condition", dataset.condition),
         createFieldObj("Extraction Protocol", dataset.extraction_protocol),
         createFieldObj("Capture Kit", dataset.capture_kit),

--- a/react/src/components/DateFilterComponent.tsx
+++ b/react/src/components/DateFilterComponent.tsx
@@ -27,7 +27,7 @@ export default function DateFilterComponent<RowData extends object>(props: {
     const classes = useStyles();
     const filterValue: string | null = (props.columnDef as any).tableData.filterValue || null;
     const isBefore = filterValue === null ? true : filterValue.split(",")?.[0] === "before";
-    const date = filterValue?.split(",")?.[1] || null;
+    const date = filterValue?.split(",")?.[1] || "";
 
     function updateFilter(newBefore: boolean, newDate: string | null) {
         // https://github.com/mbrn/material-table/pull/2435
@@ -48,16 +48,19 @@ export default function DateFilterComponent<RowData extends object>(props: {
                 startAdornment: (
                     <InputAdornment position="start">
                         <Tooltip title={isBefore ? "Before" : "After"}>
-                            <IconButton
-                                disabled={filterValue === null}
-                                size="small"
-                                className={clsx(classes.button, {
-                                    [classes.buttonFlipped]: !isBefore,
-                                })}
-                                onClick={() => updateFilter(!isBefore, date)}
-                            >
-                                <NavigateBefore />
-                            </IconButton>
+                            {/* prevent mui warnings about tooltip wrapping disabled button */}
+                            <span>
+                                <IconButton
+                                    disabled={filterValue === null}
+                                    size="small"
+                                    className={clsx(classes.button, {
+                                        [classes.buttonFlipped]: !isBefore,
+                                    })}
+                                    onClick={() => updateFilter(!isBefore, date)}
+                                >
+                                    <NavigateBefore />
+                                </IconButton>
+                            </span>
                         </Tooltip>
                     </InputAdornment>
                 ),

--- a/react/src/components/FileLinkingComponent.tsx
+++ b/react/src/components/FileLinkingComponent.tsx
@@ -1,8 +1,10 @@
-import React, { useEffect, useState } from "react";
+import React, { useState } from "react";
 import {
     Box,
     Button,
+    Checkbox,
     Chip,
+    FormControlLabel,
     Grid,
     List,
     makeStyles,
@@ -14,7 +16,7 @@ import {
 import { Description } from "@material-ui/icons";
 import { Autocomplete, createFilterOptions } from "@material-ui/lab";
 import { Note } from "../components";
-import { LinkedFile, Option, PossiblyLinkedFile } from "../typings";
+import { LinkedFile, UnlinkedFile } from "../typings";
 
 const useStyles = makeStyles(theme => ({
     popoverBox: {
@@ -43,15 +45,14 @@ const useStyles = makeStyles(theme => ({
 /* A cell for linking files to a dataset. */
 const FileLinkingComponent: React.FC<{
     values: LinkedFile[];
-    options: Option[];
-    onEdit: (newValue: PossiblyLinkedFile[]) => void;
+    options: UnlinkedFile[];
+    onEdit: (newValue: UnlinkedFile[]) => void;
     disabled?: boolean;
     disableTooltip?: boolean;
-}> = ({ values, options: parentOptions, onEdit, disabled, disableTooltip }) => {
+}> = ({ values, options, onEdit, disabled, disableTooltip }) => {
     const classes = useStyles();
     const [anchorEl, setAnchorEl] = useState<HTMLButtonElement | null>(null);
     const [inputValue, setInputValue] = useState("");
-    const [options, setOptions] = useState<Omit<LinkedFile, "file_id">[]>([]);
 
     const open = Boolean(anchorEl);
 
@@ -61,12 +62,6 @@ const FileLinkingComponent: React.FC<{
     const handleClose = () => {
         setAnchorEl(null);
     };
-
-    useEffect(() => {
-        //fix this as things solidify
-        setOptions(parentOptions.map(o => ({ path: o.title, multiplexed: false })));
-    }, [parentOptions]);
-
 
     return (
         <>
@@ -109,6 +104,7 @@ const FileLinkingComponent: React.FC<{
                 }
             >
                 <span>
+                    {/* prevent mui warnings about tooltip wrapping disabled button */}
                     <Button
                         variant="contained"
                         color="default"
@@ -171,7 +167,40 @@ const FileLinkingComponent: React.FC<{
                                                 <Chip
                                                     key={tag.path}
                                                     {...getTagProps({ index: i })}
-                                                    label={<Note>{tag.path}</Note>}
+                                                    label={
+                                                        <Note
+                                                            DetailComponent={
+                                                                <Box margin={1}>
+                                                                    <FormControlLabel
+                                                                        label="Multiplexed?"
+                                                                        control={
+                                                                            <Checkbox
+                                                                                checked={
+                                                                                    tag.multiplexed
+                                                                                }
+                                                                                onChange={() => {
+                                                                                    onEdit(
+                                                                                        tags.map(
+                                                                                            t => ({
+                                                                                                ...t,
+                                                                                                multiplexed:
+                                                                                                    t.path ===
+                                                                                                    tag.path
+                                                                                                        ? !t.multiplexed
+                                                                                                        : t.multiplexed,
+                                                                                            })
+                                                                                        )
+                                                                                    );
+                                                                                }}
+                                                                            />
+                                                                        }
+                                                                    />
+                                                                </Box>
+                                                            }
+                                                        >
+                                                            {tag.path}
+                                                        </Note>
+                                                    }
                                                 />
                                             ))}
                                         </>

--- a/react/src/components/FileLinkingComponent.tsx
+++ b/react/src/components/FileLinkingComponent.tsx
@@ -163,46 +163,43 @@ const FileLinkingComponent: React.FC<{
                                     }}
                                     renderTags={(tags, getTagProps) => (
                                         <>
-                                            {tags.map((tag, i) => (
-                                                <Chip
-                                                    key={tag.path}
-                                                    {...getTagProps({ index: i })}
-                                                    label={
-                                                        <Note
-                                                            DetailComponent={
-                                                                <Box margin={1}>
-                                                                    <FormControlLabel
-                                                                        label="Multiplexed?"
-                                                                        control={
-                                                                            <Checkbox
-                                                                                checked={
-                                                                                    tag.multiplexed
-                                                                                }
-                                                                                onChange={() => {
-                                                                                    onEdit(
-                                                                                        tags.map(
-                                                                                            t => ({
-                                                                                                ...t,
-                                                                                                multiplexed:
-                                                                                                    t.path ===
-                                                                                                    tag.path
-                                                                                                        ? !t.multiplexed
-                                                                                                        : t.multiplexed,
-                                                                                            })
-                                                                                        )
-                                                                                    );
-                                                                                }}
-                                                                            />
-                                                                        }
-                                                                    />
-                                                                </Box>
+                                            {tags.map((tag, i) => {
+                                                const onChange = () => {
+                                                    onEdit(
+                                                        tags.map(t => ({
+                                                            ...t,
+                                                            multiplexed:
+                                                                t.path === tag.path
+                                                                    ? !t.multiplexed
+                                                                    : t.multiplexed,
+                                                        }))
+                                                    );
+                                                };
+                                                const detail = (
+                                                    <Box margin={1}>
+                                                        <FormControlLabel
+                                                            label="Multiplexed?"
+                                                            control={
+                                                                <Checkbox
+                                                                    checked={tag.multiplexed}
+                                                                    onChange={onChange}
+                                                                />
                                                             }
-                                                        >
-                                                            {tag.path}
-                                                        </Note>
-                                                    }
-                                                />
-                                            ))}
+                                                        />
+                                                    </Box>
+                                                );
+                                                return (
+                                                    <Chip
+                                                        key={tag.path}
+                                                        {...getTagProps({ index: i })}
+                                                        label={
+                                                            <Note DetailComponent={detail}>
+                                                                {tag.path}
+                                                            </Note>
+                                                        }
+                                                    />
+                                                );
+                                            })}
                                         </>
                                     )}
                                     renderOption={option => (

--- a/react/src/components/Note.tsx
+++ b/react/src/components/Note.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import { makeStyles, Popover, Typography } from "@material-ui/core";
+import { Grid, makeStyles, Popover, Typography } from "@material-ui/core";
 
 const useStyles = makeStyles(theme => ({
     notes: {
@@ -23,7 +23,10 @@ const useStyles = makeStyles(theme => ({
 /**
  * A style wrapper for strings of text that are really long.
  */
-export default function Note(props: { children: React.ReactNode }) {
+export default function Note(props: {
+    children: React.ReactNode;
+    DetailComponent?: React.ReactNode;
+}) {
     const classes = useStyles();
     const [anchorEl, setAnchorEl] = useState<HTMLDivElement | null>(null);
 
@@ -38,7 +41,12 @@ export default function Note(props: { children: React.ReactNode }) {
                 onClose={() => setAnchorEl(null)}
                 PaperProps={{ className: classes.paper }}
             >
-                <Typography className={classes.typography}>{props.children}</Typography>
+                <Grid container direction="column">
+                    <Grid item>
+                        <Typography className={classes.typography}>{props.children}</Typography>
+                    </Grid>
+                    {!!props.DetailComponent && <Grid item>{props.DetailComponent}</Grid>}
+                </Grid>
             </Popover>
         </>
     );

--- a/react/src/components/SecretDisplay.tsx
+++ b/react/src/components/SecretDisplay.tsx
@@ -27,18 +27,21 @@ export default function SecretDisplay(props: {
                     </IconButton>
                 </Tooltip>
                 <Tooltip title="Copy to clipboard">
-                    <IconButton
-                        disabled={!props.secret}
-                        onClick={() => {
-                            if (props.secret !== undefined) {
-                                navigator.clipboard.writeText(props.secret).then(() => {
-                                    enqueueSnackbar(`${props.title} copied to clipboard.`);
-                                });
-                            }
-                        }}
-                    >
-                        <FileCopy />
-                    </IconButton>
+                    {/* prevent mui warnings about tooltip wrapping disabled button */}
+                    <span>
+                        <IconButton
+                            disabled={!props.secret}
+                            onClick={() => {
+                                if (props.secret !== undefined) {
+                                    navigator.clipboard.writeText(props.secret).then(() => {
+                                        enqueueSnackbar(`${props.title} copied to clipboard.`);
+                                    });
+                                }
+                            }}
+                        >
+                            <FileCopy />
+                        </IconButton>
+                    </span>
                 </Tooltip>
             </Typography>
             {props.loading ? (

--- a/react/src/functions.tsx
+++ b/react/src/functions.tsx
@@ -155,7 +155,7 @@ export function getDatasetFields(dataset: Dataset) {
 export function getSecDatasetFields(dataset: Dataset) {
     return [
         createFieldObj("Batch ID", dataset.batch_id, "batch_id"),
-        createFieldObj("Linked Files", dataset.linked_files, "linked_files"),
+        createFieldObj("Linked Files", dataset.linked_files.map(f => f.path), "linked_files"),
         createFieldObj("Condition", dataset.condition, "condition"),
         createFieldObj("Extraction Protocol", dataset.extraction_protocol, "extraction_protocol"),
         createFieldObj("Capture Kit", dataset.capture_kit, "capture_kit"),

--- a/react/src/functions.tsx
+++ b/react/src/functions.tsx
@@ -155,7 +155,11 @@ export function getDatasetFields(dataset: Dataset) {
 export function getSecDatasetFields(dataset: Dataset) {
     return [
         createFieldObj("Batch ID", dataset.batch_id, "batch_id"),
-        createFieldObj("Linked Files", dataset.linked_files.map(f => f.path), "linked_files"),
+        createFieldObj(
+            "Linked Files",
+            dataset.linked_files.map(f => f.path),
+            "linked_files"
+        ),
         createFieldObj("Condition", dataset.condition, "condition"),
         createFieldObj("Extraction Protocol", dataset.extraction_protocol, "extraction_protocol"),
         createFieldObj("Capture Kit", dataset.capture_kit, "capture_kit"),

--- a/react/src/hooks/unlinked/useUnlinkedFilesQuery.tsx
+++ b/react/src/hooks/unlinked/useUnlinkedFilesQuery.tsx
@@ -1,4 +1,5 @@
 import { useQuery } from "react-query";
+import { UnlinkedFile } from "../../typings";
 import { basicFetch } from "../utils";
 
 async function fetchFiles() {
@@ -12,6 +13,6 @@ async function fetchFiles() {
  * for all unlinked files in MinIO.
  */
 export function useUnlinkedFilesQuery() {
-    const result = useQuery<string[], Response>("unlinked", fetchFiles);
+    const result = useQuery<UnlinkedFile[], Response>("unlinked", fetchFiles);
     return result;
 }

--- a/react/src/typings.tsx
+++ b/react/src/typings.tsx
@@ -60,6 +60,20 @@ export interface Sample {
     updated: string;
     updated_by: number;
 }
+
+//todo: cleanup
+export interface UnlinkedFile {
+    path: string;
+    multiplexed?: boolean;
+}
+export interface LinkedFile extends UnlinkedFile {
+    file_id: number;
+}
+
+export interface PossiblyLinkedFile extends UnlinkedFile {
+    file_id?: number;
+}
+
 export interface Dataset {
     dataset_id: string;
     participant_codename: string;
@@ -69,7 +83,7 @@ export interface Dataset {
     tissue_sample_type: string;
     tissue_sample_id: string;
     dataset_type: string;
-    linked_files: string[]; // paths to files
+    linked_files: LinkedFile[];
     notes: string;
     condition: string;
     extraction_protocol: string;
@@ -174,7 +188,7 @@ export class DataEntryRowOptional {
     sex?: string;
     affected?: boolean;
     solved?: boolean;
-    linked_files?: string[];
+    linked_files?: LinkedFile[];
     notes?: string;
     extraction_protocol?: string;
     capture_kit?: string;

--- a/react/src/typings.tsx
+++ b/react/src/typings.tsx
@@ -61,17 +61,12 @@ export interface Sample {
     updated_by: number;
 }
 
-//todo: cleanup
 export interface UnlinkedFile {
     path: string;
     multiplexed?: boolean;
 }
 export interface LinkedFile extends UnlinkedFile {
     file_id: number;
-}
-
-export interface PossiblyLinkedFile extends UnlinkedFile {
-    file_id?: number;
 }
 
 export interface Dataset {


### PR DESCRIPTION
Closes #684 

Allow files marked `multiplexed` to be associated with multiple datasets

* migration to create new `file` table and linking table
  * migration does not drop old table (for now), so switching between branches should be ok
  * however... it seems we have a few migrations in this sprint, so beware that the 'head' id stored in the `alembic_versions` table might become incomprehensible to  the CLI if it refers to a migration in another branch.
* update ORM mappings to use new relationships
* update `_bulk` and `[PATCH] datasets` endpoint validation, insert, and delete logic
* update/add tests
* update unlinked files endpoint to return files as JSON (pseudo file models, basically)
* update FE file linking component and dependencies to use new file model
* add toggle feature to selected files, so that the popover wrapping the selected filename allows user to toggle on/off `multiplexed` field
* Allow for filtering by file path on dataset table