### PR TITLE
Flask: Add gene alias column to export

### DIFF
--- a/flask/app/variants.py
+++ b/flask/app/variants.py
@@ -4,8 +4,8 @@ from typing import Any, List
 from flask import Blueprint, Response, abort, current_app as app, jsonify, request
 from flask_login import current_user, login_required
 from sqlalchemy import distinct, func
-from sqlalchemy.orm import contains_eager, selectinload
-from sqlalchemy.sql import and_, or_
+from sqlalchemy.orm import contains_eager
+from sqlalchemy.sql import and_
 
 import pandas as pd
 from . import models

--- a/flask/app/variants.py
+++ b/flask/app/variants.py
@@ -186,6 +186,8 @@ def summary(type: str):
 
     ensgs = parse_gene_panel()
 
+    # filter out all gene aliases except current_approved_symbol and make result an `aliased` subquery \
+    # so that ORM recognizes it as the GeneAlias model when joining and eager loading
     alias_subquery = aliased(
         models.GeneAlias,
         models.GeneAlias.query.filter(
@@ -252,6 +254,7 @@ def summary(type: str):
                 [
                     {
                         **asdict(tup[0]),  # gene
+                        "name": tup[0].aliases[0].name if tup[0].aliases else None,
                         **asdict(tup[1]),  # variants
                         "genotype": [
                             {

--- a/flask/migrations/versions/184f5edd4719_add_index_to_gene_alias_ensembl_id.py
+++ b/flask/migrations/versions/184f5edd4719_add_index_to_gene_alias_ensembl_id.py
@@ -1,0 +1,24 @@
+"""add_index_to_gene_alias_ensembl_id
+
+Revision ID: 184f5edd4719
+Revises: 5e69ca582792
+Create Date: 2021-06-30 20:35:45.293750
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "184f5edd4719"
+down_revision = "5e69ca582792"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_index("gene_alias_ensembl_id_IDX", "gene_alias", ["ensembl_id"])
+
+
+def downgrade():
+    op.drop_index("gene_alias_ensembl_id_IDX")

--- a/flask/migrations/versions/184f5edd4719_add_index_to_gene_alias_ensembl_id.py
+++ b/flask/migrations/versions/184f5edd4719_add_index_to_gene_alias_ensembl_id.py
@@ -21,4 +21,4 @@ def upgrade():
 
 
 def downgrade():
-    op.drop_index("gene_alias_ensembl_id_IDX")
+    op.drop_index("gene_alias_ensembl_id_IDX", "gene_alias")

--- a/flask/migrations/versions/184f5edd4719_add_index_to_gene_alias_ensembl_id.py
+++ b/flask/migrations/versions/184f5edd4719_add_index_to_gene_alias_ensembl_id.py
@@ -1,7 +1,7 @@
 """add_index_to_gene_alias_ensembl_id
 
 Revision ID: 184f5edd4719
-Revises: 5e69ca582792
+Revises: 99955a52d781
 Create Date: 2021-06-30 20:35:45.293750
 
 """
@@ -11,7 +11,7 @@ import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision = "184f5edd4719"
-down_revision = "5e69ca582792"
+down_revision = "99955a52d781"
 branch_labels = None
 depends_on = None
 


### PR DESCRIPTION
Closes #686 

- Contains a migration for adding an index to alias table. It shares a `head` with other migrations in this sprint, so a rollback might be necessary when switching branches.