### PR TITLE
Flask/Database: Add index to Variant.position

### DIFF
--- a/flask/app/models.py
+++ b/flask/app/models.py
@@ -441,7 +441,10 @@ class GeneAlias(db.Model):
     # Optional flexible type label, e.g., current hgnc gene symbol, previous gene symbol, synonyms
     kind: str = db.Column(db.String(50))
     # No point in allowing dupes for the same identifier though
-    __table_args__ = (db.UniqueConstraint("ensembl_id", "name"),)
+    __table_args__ = (
+        db.UniqueConstraint("ensembl_id", "name"),
+        db.Index("gene_alias_ensembl_id_IDX", "ensembl_id"),
+    )
 
 
 @dataclass

--- a/flask/app/models.py
+++ b/flask/app/models.py
@@ -458,7 +458,7 @@ class Variant(db.Model):
     )
     chromosome: str = db.Column(db.String(2), nullable=False)
     # GRCh37 coordinates, incompatible with others
-    position: int = db.Column(db.Integer, nullable=False)
+    position: int = db.Column(db.Integer, nullable=False, index=True)
     reference_allele: str = db.Column(db.String(300), nullable=False)
     alt_allele: str = db.Column(db.String(300), nullable=False)
     variation: str = db.Column(db.String(50), nullable=False)

--- a/flask/migrations/versions/45ed820bb437_add_variant_position_index.py
+++ b/flask/migrations/versions/45ed820bb437_add_variant_position_index.py
@@ -1,0 +1,24 @@
+"""Add variant position index
+
+Revision ID: 45ed820bb437
+Revises: 6f448fc94a2d
+Create Date: 2021-07-28 15:54:09.038932
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import mysql
+
+# revision identifiers, used by Alembic.
+revision = "45ed820bb437"
+down_revision = "6f448fc94a2d"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_index(op.f("ix_variant_position"), "variant", ["position"], unique=False)
+
+
+def downgrade():
+    op.drop_index(op.f("ix_variant_position"), table_name="variant")


### PR DESCRIPTION
Closes #751 

Also adds an index to GeneAlias.ensembl_id in `models.py`, which was leftover from #700 