### PR TITLE
Flask/DB: Drop deprecated dataset_file table and update models

### DIFF
--- a/flask/app/models.py
+++ b/flask/app/models.py
@@ -252,8 +252,10 @@ datasets_analyses_table = db.Table(
 datasets_files_table = db.Table(
     "datasets_files",
     db.Model.metadata,
-    db.Column("file_id", db.Integer, db.ForeignKey("file.file_id")),
-    db.Column("dataset_id", db.Integer, db.ForeignKey("dataset.dataset_id")),
+    db.Column("file_id", db.Integer, db.ForeignKey("file.file_id"), nullable=False),
+    db.Column(
+        "dataset_id", db.Integer, db.ForeignKey("dataset.dataset_id"), nullable=False
+    ),
 )
 
 

--- a/flask/app/models.py
+++ b/flask/app/models.py
@@ -242,7 +242,11 @@ groups_datasets_table = db.Table(
 datasets_analyses_table = db.Table(
     "datasets_analyses",
     db.Model.metadata,
-    db.Column("dataset_id", db.Integer, db.ForeignKey("dataset.dataset_id")),
+    db.Column(
+        "dataset_id",
+        db.Integer,
+        db.ForeignKey("dataset.dataset_id"),
+    ),
     db.Column("analysis_id", db.Integer, db.ForeignKey("analysis.analysis_id")),
     db.PrimaryKeyConstraint(
         "dataset_id", "analysis_id"
@@ -252,9 +256,17 @@ datasets_analyses_table = db.Table(
 datasets_files_table = db.Table(
     "datasets_files",
     db.Model.metadata,
-    db.Column("file_id", db.Integer, db.ForeignKey("file.file_id"), nullable=False),
     db.Column(
-        "dataset_id", db.Integer, db.ForeignKey("dataset.dataset_id"), nullable=False
+        "file_id",
+        db.Integer,
+        db.ForeignKey("file.file_id"),
+        nullable=False,
+    ),
+    db.Column(
+        "dataset_id",
+        db.Integer,
+        db.ForeignKey("dataset.dataset_id", ondelete="cascade"),
+        nullable=False,
     ),
 )
 

--- a/flask/migrations/versions/b7e6ad115b13_drop_old_dataset_file_table.py
+++ b/flask/migrations/versions/b7e6ad115b13_drop_old_dataset_file_table.py
@@ -1,0 +1,46 @@
+"""drop_old_dataset_file_table
+
+Revision ID: b7e6ad115b13
+Revises: 45ed820bb437
+Create Date: 2021-07-29 16:43:21.898351
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from app.models import File
+from app.extensions import db
+
+# revision identifiers, used by Alembic.
+revision = "b7e6ad115b13"
+down_revision = "45ed820bb437"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.drop_table("dataset_file")
+
+
+def downgrade():
+
+    dataset_file_table = op.create_table(
+        "dataset_file",
+        sa.Column("file_id", sa.Integer(), nullable=False),
+        sa.Column("dataset_id", sa.Integer(), nullable=False),
+        sa.Column("path", sa.String(length=500), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["dataset_id"],
+            ["dataset.dataset_id"],
+            onupdate="cascade",
+            ondelete="cascade",
+        ),
+        sa.PrimaryKeyConstraint("file_id"),
+    )
+
+    for file in File.query.all():
+        for dataset in file.datasets:
+            stmt = dataset_file_table.insert().values(
+                path=file.path, dataset_id=dataset.dataset_id
+            )
+            db.session.execute(stmt)
+    db.session.commit()


### PR DESCRIPTION
closes #753
- drops `dataset_file`, which was replaced w/ `file` and `datasets_files`
- fixup dangling mismatches b/w `models.py` and schema to prevent unnecessary diffs in autogenerated migrations
  - still a lingering issue with `genotype.analysis_id_2` index 