### PR TITLE
Flask: add query params to perform exact search by codename in GET datasets/participants

### DIFF
--- a/flask/app/datasets.py
+++ b/flask/app/datasets.py
@@ -133,8 +133,7 @@ def list_datasets(page: int, limit: int) -> Response:
         )
         if participant_codename_exact_match:
             filters.append(
-                models.Participant.participant_codename
-                == func.binary(participant_codename)
+                models.Participant.participant_codename == participant_codename
             )
         else:
             filters.append(
@@ -153,9 +152,7 @@ def list_datasets(page: int, limit: int) -> Response:
             "family_codename_exact_match: {}".format(family_codename_exact_match)
         )
         if family_codename_exact_match:
-            filters.append(
-                models.Family.family_codename == func.binary(family_codename)
-            )
+            filters.append(models.Family.family_codename == family_codename)
         else:
             filters.append(func.instr(models.Family.family_codename, family_codename))
 

--- a/flask/app/participants.py
+++ b/flask/app/participants.py
@@ -23,6 +23,7 @@ from .utils import (
     paginated_response,
     transaction_or_abort,
     validate_json,
+    str_to_bool,
 )
 
 editable_columns = [
@@ -48,6 +49,7 @@ participants_blueprint = Blueprint(
 @login_required
 @paged
 def list_participants(page: int, limit: int) -> Response:
+
     order_by = request.args.get("order_by", type=str)
     allowed_columns = [
         "participant_id",
@@ -82,13 +84,37 @@ def list_participants(page: int, limit: int) -> Response:
 
     filters = []
     family_codename = request.args.get("family_codename", type=str)
+    family_codename_exact_match = request.args.get(
+        "family_codename_exact_match", type=str_to_bool, default=False
+    )
+
     if family_codename:
-        filters.append(func.instr(models.Family.family_codename, family_codename))
+        if family_codename_exact_match:
+            filters.append(
+                models.Family.family_codename == func.binary(family_codename)
+            )
+        else:
+            filters.append(func.instr(models.Family.family_codename, family_codename))
+
     participant_codename = request.args.get("participant_codename", type=str)
+    participant_codename_exact_match = request.args.get(
+        "participant_codename_exact_match",
+        type=str_to_bool,
+        default=False,
+    )
     if participant_codename:
-        filters.append(
-            func.instr(models.Participant.participant_codename, participant_codename)
-        )
+        if participant_codename_exact_match:
+            filters.append(
+                models.Participant.participant_codename
+                == func.binary(participant_codename)
+            )
+        else:
+            filters.append(
+                func.instr(
+                    models.Participant.participant_codename, participant_codename
+                )
+            )
+
     notes = request.args.get("notes", type=str)
     if notes:
         filters.append(func.instr(models.Participant.notes, notes))

--- a/flask/app/participants.py
+++ b/flask/app/participants.py
@@ -90,9 +90,7 @@ def list_participants(page: int, limit: int) -> Response:
 
     if family_codename:
         if family_codename_exact_match:
-            filters.append(
-                models.Family.family_codename == func.binary(family_codename)
-            )
+            filters.append(models.Family.family_codename == family_codename)
         else:
             filters.append(func.instr(models.Family.family_codename, family_codename))
 
@@ -105,8 +103,7 @@ def list_participants(page: int, limit: int) -> Response:
     if participant_codename:
         if participant_codename_exact_match:
             filters.append(
-                models.Participant.participant_codename
-                == func.binary(participant_codename)
+                models.Participant.participant_codename == participant_codename
             )
         else:
             filters.append(

--- a/flask/app/utils.py
+++ b/flask/app/utils.py
@@ -27,6 +27,10 @@ from .madmin import MinioAdmin
 from .models import User, Group, Dataset
 
 
+def str_to_bool(param: str) -> bool:
+    return param.lower() == "true"
+
+
 def handle_error(e):
     code = 500
     if isinstance(e, HTTPException):

--- a/flask/tests/conftest.py
+++ b/flask/tests/conftest.py
@@ -188,7 +188,7 @@ def test_database(client):
 
     family_a = Family(
         family_id=1,
-        family_codename="A",
+        family_codename="Aa",
         created_by_id=admin.user_id,
         updated_by_id=admin.user_id,
     )
@@ -292,7 +292,7 @@ def test_database(client):
 
     family_b = Family(
         family_id=2,
-        family_codename="B",
+        family_codename="Bb",
         created_by_id=admin.user_id,
         updated_by_id=admin.user_id,
     )

--- a/flask/tests/test_analyses.py
+++ b/flask/tests/test_analyses.py
@@ -53,7 +53,7 @@ def test_get_analysis(test_database, client, login_as):
     assert len(response.get_json()["datasets"]) == 2
     for dataset in response.get_json()["datasets"]:
         assert dataset["dataset_type"] == "WGS"
-        assert dataset["family_codename"] == "A"
+        assert dataset["family_codename"] == "Aa"
         assert dataset["dataset_id"] == 2 or dataset["dataset_id"] == 3
         if dataset["dataset_id"] == 2:
             assert dataset["participant_codename"] == "001"

--- a/flask/tests/test_datasets.py
+++ b/flask/tests/test_datasets.py
@@ -606,7 +606,7 @@ def test_dataset_order_by_related_column(client, test_database, login_as):
     response = client.get("/api/datasets?order_by=family_codename&order_dir=desc")
     assert response.status_code == 200
     body = response.get_json()
-    
+
     assert len(body["data"]) == 5
     assert body["data"][0]["family_codename"] == "Bb"
 

--- a/flask/tests/test_datasets.py
+++ b/flask/tests/test_datasets.py
@@ -96,6 +96,41 @@ def test_get_dataset_admin(client, test_database, login_as):
     assert client.get(f"/api/datasets/4?user=2").status_code == 404
 
 
+def test_get_dataset_exact_match(test_database, client, login_as):
+    login_as("admin")
+    # the number of datasets returned by the endpoint, matching the specifications
+    ground_truth_d = {
+        "participant": {
+            "exact_match": {"00": 0, "001": 2, "002": 1, "003": 1},
+            "partial_match": {
+                "00": 4
+            },  # ALL datasets belonging to the three participants 001, 002, and 003
+        },
+        "family": {
+            "exact_match": {"A": 0, "Aa": 3},
+            "partial_match": {"A": 3},
+        },
+    }
+    for codename_type in ground_truth_d:
+        for test_type in ground_truth_d[codename_type]:
+            if test_type == "exact_match":
+                exact_match = "True"
+            else:
+                exact_match = "False"
+
+            for ptp_query in ground_truth_d[codename_type][test_type]:
+                response = client.get(
+                    "/api/datasets?{}_codename={}&{}_codename_exact_match={}".format(
+                        codename_type, ptp_query, codename_type, exact_match
+                    )
+                )
+                assert response.status_code == 200
+                assert (
+                    len(response.get_json()["data"])
+                    == ground_truth_d[codename_type][test_type][ptp_query]
+                )
+
+
 def test_get_dataset_user(client, test_database, login_as):
     """
     GET /api/datasets/:id as a regular user
@@ -540,14 +575,14 @@ def test_dataset_order_by_related_column(client, test_database, login_as):
     body = response.get_json()
     assert len(body["data"]) == 4
     assert (
-        body["data"][0]["family_codename"] == body["data"][1]["family_codename"] == "A"
+        body["data"][0]["family_codename"] == body["data"][1]["family_codename"] == "Aa"
     )
 
     response = client.get("/api/datasets?order_by=family_codename&order_dir=desc")
     assert response.status_code == 200
     body = response.get_json()
     assert len(body["data"]) == 4
-    assert body["data"][0]["family_codename"] == "B"
+    assert body["data"][0]["family_codename"] == "Bb"
 
     # check join with tissue sample
     response = client.get("/api/datasets?order_by=tissue_sample_type&order_dir=asc")

--- a/flask/tests/test_families.py
+++ b/flask/tests/test_families.py
@@ -34,7 +34,7 @@ def test_list_families_user(test_database, client, login_as):
     assert len(response.get_json()[0]["participants"]) == 2
 
     # Check if it is the correct family
-    assert response.get_json()[0]["family_codename"] == "A"
+    assert response.get_json()[0]["family_codename"] == "Aa"
 
 
 def test_list_families_user_from_admin(test_database, client, login_as):
@@ -49,7 +49,7 @@ def test_list_families_user_from_admin(test_database, client, login_as):
     assert len(response.get_json()[0]["participants"]) == 2
 
     # Check if it is the correct family
-    assert response.get_json()[0]["family_codename"] == "A"
+    assert response.get_json()[0]["family_codename"] == "Aa"
 
 
 # GET /api/families/:id
@@ -188,7 +188,7 @@ def test_create_family(test_database, client, login_as):
     assert (
         client.post(
             "/api/families",
-            json={"family_codename": "A"},
+            json={"family_codename": "Aa"},
         ).status_code
         == 422
     )


### PR DESCRIPTION
closes #804

example : `curl 'localhost:5000/api/datasets?user=1&family_codename=200&family_codename_exact_match=True'`

- Family codenames for the test database have also been changed from 'A' and 'B' to 'Aa' and 'Bb' respectively so the `*_exact_match` query parameter can be tested