### PR TITLE
React: ensure default objects have a prototype

### DIFF
--- a/react/src/functions.tsx
+++ b/react/src/functions.tsx
@@ -30,14 +30,14 @@ export function countArray(items: string[]) {
             counts[item] = 1;
         }
         return counts;
-    }, Object.create(null));
+    }, {});
 }
 
 export function toKeyValue(items: string[]) {
     return items.reduce<KeyValue>((map, item) => {
         map[item] = item;
         return map;
-    }, Object.create(null));
+    }, {});
 }
 
 /**


### PR DESCRIPTION
The equality-check used by material-table [here](https://github.com/material-table-core/core/blob/master/src/material-table.js#L214) calls the `valueOf` method on object arguments, but this method does not exist on objects created with a `null` prototype.  This causes occasional errors when the table is rendered before the lookup enums are loaded (can be reproduced by refreshing the analysis page if the network is slow enough that the table renders before enums return). Removing all implementations to prevent issues in the future. [More details from MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/create#custom_and_null_objects).