### PR TITLE
React/Flask: Add RNAseq fields to dataset entry flow

### DIFF
--- a/flask/app/buckets.py
+++ b/flask/app/buckets.py
@@ -70,7 +70,6 @@ def get_unlinked_files():
         if linkable_files.get(file_name):
             files.append({"path": file_name, "multiplexed": True})
         elif not linked_files.get(file_name):
-            app.logger.debug(file_name)
             files.append({"path": file_name, "multiplexed": False})
 
     app.logger.debug("Returning JSON array..")

--- a/flask/app/datasets.py
+++ b/flask/app/datasets.py
@@ -178,6 +178,12 @@ def list_datasets(page: int, limit: int) -> Response:
     if updated:
         filters.append(filter_updated_or_abort(models.Dataset.updated, updated))
 
+    candidate_genes = request.args.get("candidate_genes", type=str)
+    if candidate_genes:
+        filters.append(
+            func.instr(models.RNASeqDataset.candidate_genes, candidate_genes)
+        )
+
     user = get_current_user()
 
     query = (

--- a/flask/app/datasets.py
+++ b/flask/app/datasets.py
@@ -3,7 +3,6 @@ from typing import List
 
 from flask import (
     Blueprint,
-    Request,
     Response,
     abort,
     current_app as app,
@@ -12,7 +11,7 @@ from flask import (
 )
 from flask_login import current_user, login_required
 from sqlalchemy import distinct, func
-from sqlalchemy.orm import contains_eager, joinedload, selectinload
+from sqlalchemy.orm import contains_eager, joinedload, selectinload, with_polymorphic
 
 from . import models
 from .extensions import db

--- a/flask/app/models.py
+++ b/flask/app/models.py
@@ -342,6 +342,7 @@ class Dataset(db.Model):
     __mapper_args__ = {
         "polymorphic_identity": "dataset",
         "polymorphic_on": discriminator,
+        "with_polymorphic": "*",
     }
 
     analyses = db.relationship(
@@ -368,13 +369,17 @@ class RNASeqDataset(Dataset):
         db.ForeignKey("dataset.dataset_id", onupdate="cascade", ondelete="cascade"),
         primary_key=True,
     )
+    candidate_genes: str = db.Column(db.String(255))
     RIN: float = db.Column(db.Float)
     DV200: int = db.Column(db.Integer)
     concentration: float = db.Column(db.Float)
     sequencer: str = db.Column(db.String(50))
     spike_in: str = db.Column(db.String(50))
+    vcf_available: str = db.Column(db.Boolean)
 
-    __mapper_args__ = {"polymorphic_identity": "rnaseq_dataset"}
+    __mapper_args__ = {
+        "polymorphic_identity": "rnaseq_dataset",
+    }
 
 
 @dataclass

--- a/flask/app/models.py
+++ b/flask/app/models.py
@@ -338,7 +338,7 @@ class Dataset(db.Model):
         db.Integer, db.ForeignKey("user.user_id", onupdate="cascade"), nullable=False
     )
 
-    discriminator = db.Column(db.Enum("dataset", "rnaseq_dataset"))
+    discriminator: str = db.Column(db.Enum("dataset", "rnaseq_dataset"))
     __mapper_args__ = {
         "polymorphic_identity": "dataset",
         "polymorphic_on": discriminator,

--- a/flask/app/routes.py
+++ b/flask/app/routes.py
@@ -532,21 +532,28 @@ def bulk_update():
 
         # Create a new dataset under the new tissue sample
         app.logger.debug("\tCreating a new dataset..")
-        dataset = models.Dataset(
-            tissue_sample_id=tissue_sample.tissue_sample_id,
-            dataset_type=row.get("dataset_type"),
-            created_by_id=created_by_id,
-            updated_by_id=updated_by_id,
-            condition=row.get("condition"),
-            extraction_protocol=row.get("extraction_protocol"),
+
+        DatasetType = (
+            models.RNASeqDataset if row.get("dataset_type") == "RRS" else models.Dataset
+        )
+
+        dataset = DatasetType(
+            batch_id=row.get("batch_id"),
+            candidate_genes=row.get("candidate_genes"),
             capture_kit=row.get("capture_kit"),
+            condition=row.get("condition"),
+            created_by_id=created_by_id,
+            dataset_type=row.get("dataset_type"),
+            extraction_protocol=row.get("extraction_protocol"),
             library_prep_method=row.get("library_prep_method"),
             notes=row.get("notes"),
             read_length=row.get("read_length"),
             read_type=row.get("read_type"),
             sequencing_centre=row.get("sequencing_centre"),
             sequencing_date=row.get("sequencing_date"),
-            batch_id=row.get("batch_id"),
+            tissue_sample_id=tissue_sample.tissue_sample_id,
+            updated_by_id=updated_by_id,
+            vcf_available=row.get("vcf_available"),
         )
         app.logger.debug("\tLinking files to dataset..")
 

--- a/flask/migrations/versions/83abd5d883b6_add_vcf_available_and_candidate_genes_.py
+++ b/flask/migrations/versions/83abd5d883b6_add_vcf_available_and_candidate_genes_.py
@@ -36,3 +36,7 @@ def upgrade():
 def downgrade():
     op.drop_column("rnaseq_dataset", "vcf_available")
     op.drop_column("rnaseq_dataset", "candidate_genes")
+    rnaSeq = Pipeline.query.filter_by(pipeline_name="RNAseq").first()
+    if rnaSeq:
+        rnaSeq.pipeline_name = "dig2"
+        db.session.commit()

--- a/flask/migrations/versions/83abd5d883b6_add_vcf_available_and_candidate_genes_.py
+++ b/flask/migrations/versions/83abd5d883b6_add_vcf_available_and_candidate_genes_.py
@@ -1,0 +1,38 @@
+"""add_vcf_available_and_candidate_genes_to_rna_seq_table
+
+Revision ID: 83abd5d883b6
+Revises: b7e6ad115b13
+Create Date: 2021-09-13 20:19:38.571891
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+from app.models import Pipeline
+from app.extensions import db
+
+
+# revision identifiers, used by Alembic.
+revision = "83abd5d883b6"
+down_revision = "b7e6ad115b13"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        "rnaseq_dataset", sa.Column("candidate_genes", sa.String(255), nullable=True)
+    )
+    op.add_column(
+        "rnaseq_dataset", sa.Column("vcf_available", sa.Boolean(), nullable=True)
+    )
+
+    dig2 = Pipeline.query.filter_by(pipeline_name="dig2").first()
+    if dig2:
+        dig2.pipeline_name = "RNAseq"
+        db.session.commit()
+
+
+def downgrade():
+    op.drop_column("rnaseq_dataset", "vcf_available")
+    op.drop_column("rnaseq_dataset", "candidate_genes")

--- a/flask/tests/test_misc.py
+++ b/flask/tests/test_misc.py
@@ -268,6 +268,24 @@ def test_post_bulk_user(test_database, client, login_as):
     assert (
         client.post(
             "/api/_bulk?groups=ach",
+            json=[
+                {
+                    **DEFAULT_PAYLOAD,
+                    "dataset_type": "RRS",
+                    "candidate_genes": "APOE",
+                    "vcf_available": False,
+                }
+            ],
+        ).status_code
+        == 200
+    )
+
+    assert models.RNASeqDataset.query.count() == 1
+
+    # Test allowed permission groups with rnaseq fields
+    assert (
+        client.post(
+            "/api/_bulk?groups=ach",
             json=[DEFAULT_PAYLOAD],
         ).status_code
         == 200
@@ -319,6 +337,7 @@ def test_bulk_multiple_csv(test_database, client, login_as):
 family_codename,participant_codename,participant_type,tissue_sample_type,dataset_type,sex,condition,sequencing_date,linked_files,notes
 HOOD,HERO,Proband,Saliva,WGS,Female,GermLine,2020-12-17,/path/foo|/path/bar||,
 HOOD,HERO,Proband,Saliva,WGS,Female,GermLine,2020-12-17,/path/yeet|/path/cross|/foo/bar,three
+HOOD,HERO,Proband,Saliva,RRS,Female,GermLine,2020-12-17,,three
 """,
             headers={"Content-Type": "text/csv"},
         ).status_code
@@ -327,9 +346,10 @@ HOOD,HERO,Proband,Saliva,WGS,Female,GermLine,2020-12-17,/path/yeet|/path/cross|/
 
     for dataset in models.Dataset.query.all():
         print(dataset)
-    assert models.Dataset.query.count() == 7
+    assert models.Dataset.query.count() == 8
+    assert models.RNASeqDataset.query.count() == 1
     assert models.File.query.count() == 5
-    assert models.TissueSample.query.count() == 6
+    assert models.TissueSample.query.count() == 7
     assert models.Participant.query.count() == 4
     assert models.Family.query.count() == 3
 

--- a/react/src/AddDatasets/components/DataEntryTable.tsx
+++ b/react/src/AddDatasets/components/DataEntryTable.tsx
@@ -12,7 +12,7 @@ import {
 } from "@material-ui/core";
 import { Add } from "@material-ui/icons";
 import dayjs from "dayjs";
-import { createEmptyRow, makeFreshColumns, OPTIONAL_FIELDS } from "..";
+import { ALL_OPTIONAL_FIELDS, createEmptyRow, makeFreshColumns } from "..";
 import { useEnumsQuery, useInstitutionsQuery, useUnlinkedFilesQuery } from "../../hooks";
 import {
     DataEntryColumnConfig,
@@ -101,8 +101,11 @@ export default function DataEntryTable({
                         ? [
                               row,
                               {
-                                  ...row,
-                                  linked_files: [],
+                                  meta: row.meta,
+                                  fields: {
+                                      ...row.fields,
+                                      linked_files: [],
+                                  },
                               },
                           ]
                         : row
@@ -190,7 +193,7 @@ export default function DataEntryTable({
     return (
         <Paper>
             <DataEntryToolbar
-                columns={columns.filter(col => OPTIONAL_FIELDS.includes(col.field))}
+                columns={columns.filter(col => ALL_OPTIONAL_FIELDS.includes(col.field))}
                 handleColumnAction={toggleHideColumn}
                 handleResetAction={() => {
                     window.localStorage.removeItem("data-entry-default-columns");
@@ -210,8 +213,11 @@ export default function DataEntryTable({
                             <TableCell padding="checkbox" aria-hidden={true} />
                             {columns
                                 .filter(col => !col.hidden)
-                                .map(cell => (
-                                    <HeaderCell key={cell.field} header={cell.title + "*"} />
+                                .map(column => (
+                                    <HeaderCell
+                                        key={column.field}
+                                        header={`${column.title}${column.required ? "*" : ""}`}
+                                    />
                                 ))}
                         </TableRow>
                     </TableHead>

--- a/react/src/AddDatasets/components/DataEntryTableRow.tsx
+++ b/react/src/AddDatasets/components/DataEntryTableRow.tsx
@@ -1,13 +1,12 @@
 import { useState } from "react";
 import { TableRow } from "@material-ui/core";
 import { Delete, LibraryAdd } from "@material-ui/icons";
-import { getKeys } from "../../functions";
+import { DNA_ONLY_FIELDS, RNA_ONLY_FIELDS } from "..";
 import { useFamiliesQuery } from "../../hooks";
 import {
     DataEntryColumnConfig,
     DataEntryField,
     DataEntryRow,
-    DataEntryRowRNA,
     Family,
     UnlinkedFile,
 } from "../../typings";
@@ -64,10 +63,12 @@ export default function DataEntryTableRow({
         return _getOptions(rowIndex, col, families);
     }
 
+    /* column can be disabled either b/c participant info has been autofilled or
+       we're showing mixed RNA/DNA data and certain cols aren't relevant to this particular row */
     const getColumnIsDisabled = (field: DataEntryField, row: DataEntryRow) =>
         (row.meta.participantColumnsDisabled && participantColumns.includes(field)) ||
-        (getKeys(new DataEntryRowRNA()).includes(field as any) &&
-            row.fields.dataset_type !== "RRS");
+        ([...RNA_ONLY_FIELDS].includes(field as any) && row.fields.dataset_type !== "RRS") ||
+        ([...DNA_ONLY_FIELDS].includes(field as any) && row.fields.dataset_type === "RRS");
 
     return (
         <TableRow key={rowIndex}>

--- a/react/src/AddDatasets/components/DataEntryTableRow.tsx
+++ b/react/src/AddDatasets/components/DataEntryTableRow.tsx
@@ -87,9 +87,7 @@ export default function DataEntryTableRow({
                             getOptions={getOptions}
                             key={col.field}
                             loading={col.field === "family_codename" && familiesResult.isLoading}
-                            onEdit={(newValue, autocomplete?: boolean) =>
-                                handleChange(newValue, col, autocomplete)
-                            }
+                            onEdit={newValue => handleChange(newValue, col)}
                             onSearch={search => onSearch(col, search)}
                             required={!getColumnIsDisabled(col.field, row) && col.required}
                             row={row}

--- a/react/src/AddDatasets/components/DataEntryToolbar.tsx
+++ b/react/src/AddDatasets/components/DataEntryToolbar.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import {
     Box,
     IconButton,
@@ -13,7 +13,7 @@ import {
 } from "@material-ui/core";
 import { CloudDownload, CloudUpload, OpenInNew, Restore, ViewColumn } from "@material-ui/icons";
 import { GroupDropdownSelect } from "../../components";
-import { DataEntryHeader, DataEntryRow } from "../../typings";
+import { DataEntryColumnConfig, DataEntryField } from "../../typings";
 import UploadDialog from "./UploadDialog";
 
 /**
@@ -21,19 +21,15 @@ import UploadDialog from "./UploadDialog";
  * optional columns.
  */
 function DataEntryColumnMenuAction(props: {
-    columns: DataEntryHeader[];
-    onClick: (field: keyof DataEntryRow) => void;
+    columns: DataEntryColumnConfig[];
+    onClick: (field: DataEntryField) => void;
 }) {
     const [anchor, setAnchor] = useState<null | HTMLElement>(null);
 
     return (
         <>
             <Tooltip title="Show/Hide columns">
-                <IconButton
-                    onClick={event => {
-                        setAnchor(event.currentTarget);
-                    }}
-                >
+                <IconButton onClick={event => setAnchor(event.currentTarget)}>
                     <ViewColumn />
                 </IconButton>
             </Tooltip>
@@ -68,10 +64,10 @@ const useToolbarStyles = makeStyles(theme => ({
  * buttons that do not depend on specific rows.
  */
 export default function DataEntryToolbar(props: {
-    handleColumnAction: (field: keyof DataEntryRow) => void;
+    handleColumnAction: (field: DataEntryField) => void;
     handleResetAction: () => void;
     handleCSVTemplateAction: () => void;
-    columns: DataEntryHeader[];
+    columns: DataEntryColumnConfig[];
     allGroups: string[]; // this user's groups
     groups: string[]; // selected groups
     setGroups: (selectedGroups: string[]) => void;

--- a/react/src/AddDatasets/components/TableCells.tsx
+++ b/react/src/AddDatasets/components/TableCells.tsx
@@ -100,7 +100,8 @@ export function DataEntryCell(props: {
     // todo: string fields should be initialized with empty strings
     else if (
         typeof props.row.fields[fieldName] === "string" ||
-        typeof props.row.fields[fieldName] === "undefined"
+        typeof props.row.fields[fieldName] === "undefined" ||
+        typeof props.row.fields[fieldName] === "object"
     ) {
         return (
             <AutocompleteCell
@@ -116,6 +117,7 @@ export function DataEntryCell(props: {
             />
         );
     } else {
+        console.error(`Failed to find a component for ${fieldName}`);
         return null;
     }
 }

--- a/react/src/AddDatasets/components/TableCells.tsx
+++ b/react/src/AddDatasets/components/TableCells.tsx
@@ -129,7 +129,7 @@ export function AutocompleteCell(
     props: {
         value: Option;
         options: Option[];
-        onEdit: (newValue: string, autopopulate?: boolean) => void;
+        onEdit: (newValue: string) => void;
         disabled?: boolean;
         column: DataEntryColumnConfig;
         required?: boolean;
@@ -182,10 +182,6 @@ export function AutocompleteCell(
         });
     }
 
-    const triggerAutopopulation = ["participant_codename", "family_codename"].includes(
-        props.column.field
-    );
-
     const isError = props.required && strIsEmpty(props.value.inputValue);
 
     return (
@@ -200,7 +196,7 @@ export function AutocompleteCell(
                 onBlur={() => {
                     if (!enumerableColumns.includes(props.column.field)) {
                         //update on blur if user isn't required to select an option
-                        props.onEdit(search, triggerAutopopulation);
+                        props.onEdit(search);
                     } else if (strIsEmpty(props.value.inputValue)) {
                         //if this is an enum col, user might have left a string in the box
                         //if there's no selection, wipe it out
@@ -220,7 +216,7 @@ export function AutocompleteCell(
                 onChange={(event, newValue) => {
                     //value is passed around as an Option, so we need to transform here for typescript
                     const optionValue = toOption(newValue);
-                    props.onEdit(toOption(newValue).inputValue, triggerAutopopulation);
+                    props.onEdit(toOption(newValue).inputValue);
                     setSearch(optionValue.title);
                 }}
                 options={props.options}

--- a/react/src/AddDatasets/components/TableCells.tsx
+++ b/react/src/AddDatasets/components/TableCells.tsx
@@ -70,9 +70,10 @@ export function DataEntryCell(props: {
     } else if (dateColumns.includes(props.col.field)) {
         return (
             <DateCell
-                value={props.row.fields[fieldName]?.toString()}
-                onEdit={props.onEdit}
                 disabled={props.disabled}
+                onEdit={props.onEdit}
+                required={!!props.required}
+                value={props.row.fields[fieldName]?.toString()}
             />
         );
     } else if (fieldName === "linked_files") {
@@ -264,12 +265,13 @@ export function CheckboxCell(props: {
 
 /* A data entry cell for columns which require a date value. */
 export function DateCell(props: {
-    value: string | undefined;
-    onEdit: (newValue: string) => void;
     disabled?: boolean;
+    onEdit: (newValue: string) => void;
+    required: boolean;
+    value: string | undefined;
 }) {
     const classes = useCellStyles();
-    const isError = !props.value || props.value === "";
+    const isError = props.required && !props.value;
     return (
         <TableCell>
             <TextField

--- a/react/src/AddDatasets/components/utils.tsx
+++ b/react/src/AddDatasets/components/utils.tsx
@@ -7,7 +7,7 @@ import {
     UnlinkedFile,
 } from "../../typings";
 
-export const booleanColumns: DataEntryField[] = ["affected", "solved"];
+export const booleanColumns: DataEntryField[] = ["affected", "solved", "vcf_available"];
 export const dateColumns: DataEntryField[] = ["sequencing_date"];
 export const participantColumns = ["participant_type", "sex", "affected", "solved"];
 // Columns whose values are predefined

--- a/react/src/AddDatasets/components/utils.tsx
+++ b/react/src/AddDatasets/components/utils.tsx
@@ -106,7 +106,13 @@ export function getOptions(
     const rowOptions = rows
         .filter((val, index) => index !== rowIndex) // not this row
         .map(val =>
-            toOption(col.field === "linked_files" ? undefined : val[col.field], "Previous rows")
+            toOption(
+                //type discrimination, these fields manage their own options
+                col.field === "linked_files" || col.field === "candidate_genes"
+                    ? undefined
+                    : val[col.field],
+                "Previous rows"
+            )
         );
 
     const familyCodenames: string[] = families.map(value => value.family_codename);

--- a/react/src/AddDatasets/components/utils.tsx
+++ b/react/src/AddDatasets/components/utils.tsx
@@ -1,23 +1,17 @@
-import { getDataEntryHeaders, snakeCaseToTitle, strIsEmpty } from "../../functions";
 import {
-    DataEntryHeader,
+    DataEntryColumnConfig,
+    DataEntryField,
     DataEntryRow,
     Family,
     Option,
-    Participant,
     UnlinkedFile,
 } from "../../typings";
 
-export const booleanColumns: Array<keyof DataEntryRow> = ["affected", "solved"];
-export const dateColumns: Array<keyof DataEntryRow> = ["sequencing_date"];
-export const participantColumns: ("participant_type" | "sex" | "affected" | "solved")[] = [
-    "participant_type",
-    "sex",
-    "affected",
-    "solved",
-];
+export const booleanColumns: DataEntryField[] = ["affected", "solved"];
+export const dateColumns: DataEntryField[] = ["sequencing_date"];
+export const participantColumns = ["participant_type", "sex", "affected", "solved"];
 // Columns whose values are predefined
-export const enumerableColumns: Array<keyof DataEntryRow> = [
+export const enumerableColumns: DataEntryField[] = [
     "linked_files",
     "condition",
     "dataset_type",
@@ -26,31 +20,6 @@ export const enumerableColumns: Array<keyof DataEntryRow> = [
     "tissue_sample_type",
     "institution",
 ];
-
-// Convert a field string (snake_case) into a displayable title (Snake Case)
-function formatFieldToTitle(field: string): string {
-    if (field === "sequencing_date") {
-        return "Report Date";
-    }
-    return snakeCaseToTitle(field) // convert to title case
-        .replace(/([iI][dD])/g, txt => txt.toUpperCase()); // capitalize any occurrance of "ID"
-}
-
-// Given a DataEntryRow field, return a new DataEntryHeader obj
-function toColumn(field: keyof DataEntryRow, hidden?: boolean, title?: string): DataEntryHeader {
-    return {
-        field: field,
-        title: title ? title : formatFieldToTitle(field),
-        hidden: hidden,
-    };
-}
-
-// Return the specified category of DataEntryHeaders for use in the table
-export function getColumns(category: "required" | "optional" | "RNASeq"): DataEntryHeader[] {
-    return (getDataEntryHeaders()[category] as Array<keyof DataEntryRow>).map(field =>
-        toColumn(field, category !== "required")
-    );
-}
 
 // Convert the provided value into an Option
 export function toOption(
@@ -95,7 +64,7 @@ export function toOption(
  */
 export function getOptions(
     rows: DataEntryRow[],
-    col: DataEntryHeader,
+    col: DataEntryColumnConfig,
     rowIndex: number,
     families: Family[],
     enums: Record<string, string[]> | undefined,
@@ -104,13 +73,13 @@ export function getOptions(
 ) {
     const row = rows[rowIndex];
     const rowOptions = rows
-        .filter((val, index) => index !== rowIndex) // not this row
-        .map(val =>
+        .filter((_, index) => index !== rowIndex) // not this row
+        .map(row =>
             toOption(
                 //type discrimination, these fields manage their own options
                 col.field === "linked_files" || col.field === "candidate_genes"
                     ? undefined
-                    : val[col.field],
+                    : row.fields[col.field],
                 "Previous rows"
             )
         );
@@ -126,7 +95,7 @@ export function getOptions(
             return familyOptions.concat(rowOptions);
 
         case "participant_codename":
-            const thisFamily = row.family_codename;
+            const thisFamily = row.fields.family_codename;
             if (familyCodenames.findIndex(family => family === thisFamily) !== -1) {
                 const existingParts = families
                     .filter(family => family.family_codename === thisFamily)
@@ -204,59 +173,17 @@ export function getOptions(
 }
 
 /**
- * Checks if a pre-existing participant has valid values, and should be disabled.
- * Return true if valid, false otherwise.
- * @param participant The pre-existing participant in question.
- * @param enums The result from /api/enums
- */
-export function checkParticipant(
-    participant: Participant,
-    enums?: Record<string, string[]>
-): boolean {
-    const required: string[] = getDataEntryHeaders().required;
-
-    return participantColumns.every(column => {
-        if (required.includes(column)) {
-            // required columns should be checked to be valid
-
-            const index = snakeToTitle(column);
-            // must be defined
-            if (!participant[column]) return false;
-
-            if (enumerableColumns.includes(column)) {
-                // if enumerable, must be valid value
-                return enums?.[index].includes(participant[column]);
-            } else if (booleanColumns.includes(column)) {
-                return ["true", "false"].includes(participant[column]);
-            } else {
-                return !strIsEmpty(participant[column]);
-            }
-        } else {
-            // optional columns are fine
-            return true;
-        }
-    });
-}
-
-function snakeToTitle(str: string): string {
-    return str
-        .split("_")
-        .map(word => word.substring(0, 1).toUpperCase() + word.substring(1))
-        .join("");
-}
-
-/**
  * Convert an array of objects to a CSV string.
  *
  * Precondition: all objects in the array have the same keys.
  *
- * @param rows An array of DataEntryRows.
+ * @param rows An array of DataEntryFields.
  * @param headers Array of column headers aka. keys of the provided rows to return.
  * @param onlyHeaders If true, only returns the header row.
  */
 export function objArrayToCSV(
     rows: DataEntryRow[],
-    headers: (keyof DataEntryRow)[],
+    headers: DataEntryField[],
     onlyHeaders: boolean = false
 ): string {
     if (rows.length === 0 || headers.length === 0) return "";
@@ -268,7 +195,7 @@ export function objArrayToCSV(
     for (const row of rows) {
         let values: string[] = [];
         for (const header of headers) {
-            let value = row[header];
+            let value = row.fields[header];
             if (Array.isArray(value)) value = value.join("|");
             else if (!value) value = "";
             else if (typeof value !== "string") value = "" + value;

--- a/react/src/AddDatasets/index.tsx
+++ b/react/src/AddDatasets/index.tsx
@@ -195,7 +195,7 @@ export default function AddDatasets() {
             }
         }
         if (!columns) {
-            setColumns(makeFreshColumns(["notes", "sex", "linked_files"]));
+            setColumns(makeFreshColumns(["notes", "sex", "linked_files", "vcf_available"]));
         }
     }, [columns, data, setColumns]);
 
@@ -323,7 +323,7 @@ export default function AddDatasets() {
             currCols,
             RNA_ONLY_FIELDS.map(field => ({
                 field,
-                hidden: OPTIONAL_RNA_FIELDS.includes(field),
+                hidden: OPTIONAL_RNA_FIELDS.includes(field) && field !== "vcf_available",
                 required: REQUIRED_RNA_FIELDS.includes(field),
                 title: snakeCaseToTitle(field),
             }))

--- a/react/src/AddDatasets/index.tsx
+++ b/react/src/AddDatasets/index.tsx
@@ -147,13 +147,17 @@ const insertColumnsAfter = (
     field: DataEntryField,
     columns: DataEntryColumnConfig[],
     columnsToAdd: DataEntryColumnConfig[]
-) => columns.flatMap(col => (col.field === field ? [col, ...columnsToAdd] : col));
+) => {
+    if (!columns.find(c => c.field === field)) {
+        throw new Error(`${field} does not exist!`);
+    }
+    return columns.flatMap(col => (col.field === field ? [col, ...columnsToAdd] : col));
+};
 
 type LayoutType = "RNA" | "DNA" | "MIXED";
 
 /* return the current column layout type */
 const getColumnLayoutType = (columns: DataEntryColumnConfig[]): LayoutType => {
-    console.log("calculating column layout type");
     if (columns.filter(c => ALL_RNA_FIELDS.includes(c.field)).length === columns.length) {
         return "RNA";
     } else if (columns.filter(c => ALL_DNA_FIELDS.includes(c.field)).length === columns.length) {
@@ -215,10 +219,10 @@ export default function AddDatasets() {
             if (columnLayoutType !== dataType) {
                 switch (`${columnLayoutType}->${dataType}`) {
                     case "DNA->RNA":
-                        setColumns(addRNACols(removeDNACols(columns)));
+                        setColumns(removeDNACols(addRNACols(columns)));
                         break;
                     case "RNA->DNA":
-                        setColumns(addDNACols(removeRNACols(columns)));
+                        setColumns(removeRNACols(addDNACols(columns)));
                         break;
                     case "RNA->MIXED":
                         setColumns(addDNACols(columns));
@@ -303,7 +307,7 @@ export default function AddDatasets() {
 
     const addDNACols = (currCols: DataEntryColumnConfig[]) =>
         insertColumnsAfter(
-            "sequencing_date",
+            "linked_files",
             currCols,
             DNA_ONLY_FIELDS.map(field => ({
                 field,

--- a/react/src/AddDatasets/index.tsx
+++ b/react/src/AddDatasets/index.tsx
@@ -256,7 +256,7 @@ export default function AddDatasets() {
                     if (row.meta.participantColumnsDisabled && participantColumns.includes(field))
                         continue;
                     const val = row.fields[field];
-                    if (typeof val === "string" && strIsEmpty(val)) {
+                    if ((typeof val === "string" && strIsEmpty(val)) || !val) {
                         if (problemRows.get(i))
                             problemRows.set(i, problemRows.get(i)!.concat(field));
                         else problemRows.set(i, [field]);

--- a/react/src/AddDatasets/index.tsx
+++ b/react/src/AddDatasets/index.tsx
@@ -38,6 +38,11 @@ const useStyles = makeStyles(theme => ({
     },
 }));
 
+/*
+    create an object with all possible data entry fields
+    column filters will determine which rows are displayable
+    `hidden` attribute on column config object determines whether col appears in table or in hidden list
+*/
 export const createEmptyRow = (): DataEntryRow => ({
     fields: {
         ...new DataEntryRowBase(),
@@ -47,8 +52,12 @@ export const createEmptyRow = (): DataEntryRow => ({
     meta: {},
 });
 
+/*
+    get array of all data entry fields
+*/
 const getDataEntryFieldList = () => getKeys(createEmptyRow().fields);
 
+/* fields that cannot be hidden and are required for submission for both DNA and RNA seq */
 const ALWAYS_VISIBLE_BASE_FIELDS: readonly DataEntryField[] = [
     "family_codename",
     "participant_codename",
@@ -59,12 +68,13 @@ const ALWAYS_VISIBLE_BASE_FIELDS: readonly DataEntryField[] = [
     "sequencing_date",
 ];
 
+/* RNA-only fields that are required */
 const ALWAYS_VISIBLE_RNA_FIELDS: readonly DataEntryField[] = [
     ...ALWAYS_VISIBLE_BASE_FIELDS,
     "candidate_genes",
 ];
 
-/* only optional fields can be hidden */
+/* optional fields that can be hidden */
 export const OPTIONAL_FIELDS: readonly DataEntryField[] = getKeys(new DataEntryRowDNAOptional());
 
 const formatFieldToTitle = (field: string) => {
@@ -75,7 +85,8 @@ const formatFieldToTitle = (field: string) => {
         .replace(/ Id /g, " ID "); // capitalize any occurrance of " Id "
 };
 
-export const makeFreshColumns = (fallbackColumns: DataEntryField[]) => {
+/* create fresh set of DNA column configs */
+export const makeFreshColumns = (fallbackColumns: DataEntryField[]): DataEntryColumnConfig[] => {
     let defaultVisible: DataEntryField[];
 
     const storedDefaults = window.localStorage.getItem("data-entry-default-columns");
@@ -102,9 +113,11 @@ export const makeFreshColumns = (fallbackColumns: DataEntryField[]) => {
     );
 };
 
-const getRequiredRows = (row: DataEntryRow) =>
+/* get a list of required fields for the row */
+const getRequiredFields = (row: DataEntryRow) =>
     row.fields.dataset_type === "RRS" ? ALWAYS_VISIBLE_RNA_FIELDS : ALWAYS_VISIBLE_BASE_FIELDS;
 
+/* add columns to the current list after a specified field */
 const insertColumnsAfter = (
     field: DataEntryField,
     columns: DataEntryColumnConfig[],
@@ -130,7 +143,6 @@ export default function AddDatasets() {
     }, []);
 
     useEffect(() => {
-        document.title = `Add Datasets | ${process.env.REACT_APP_NAME}`;
         if (!data) {
             const savedProgress = sessionStorage.getItem("add-datasets-progress");
 
@@ -147,6 +159,7 @@ export default function AddDatasets() {
     }, [columns, data, setColumns]);
 
     useEffect(() => {
+        /* toggle column display based on dataset type  */
         if (data && columns) {
             const rnaFields = getKeys(new DataEntryRowRNA());
             sessionStorage.setItem("add-datasets-progress", JSON.stringify(data));
@@ -207,8 +220,8 @@ export default function AddDatasets() {
 
             for (let i = 0; i < data.length; i++) {
                 let row = data[i];
-                const requiredRows = getRequiredRows(row);
-                for (const field of requiredRows) {
+                const requiredFields = getRequiredFields(row);
+                for (const field of requiredFields) {
                     if (row.meta.participantColumnsDisabled && participantColumns.includes(field))
                         continue;
                     const val = row.fields[field];

--- a/react/src/Analyses/components/AnalysisNotes.tsx
+++ b/react/src/Analyses/components/AnalysisNotes.tsx
@@ -2,18 +2,13 @@ import React from "react";
 import { Divider, Popover, Typography } from "@material-ui/core";
 import { makeStyles } from "@material-ui/core/styles";
 import { useAnalysisQuery } from "../../hooks";
-import { Analysis, Dataset } from "../../typings";
+import { Analysis } from "../../typings";
 
 interface AnalysisNotesProps {
     analysis: Analysis;
     anchorEl: HTMLButtonElement | null;
     open: boolean;
     onClose: () => void;
-}
-
-interface DatasetWithNotes extends Dataset {
-    participant_notes: string;
-    dataset_notes: string;
 }
 
 const useStyles = makeStyles(theme => ({
@@ -32,7 +27,7 @@ export default function AnalysisNotes(props: AnalysisNotesProps) {
     const classes = useStyles();
     const { data: analysisQueryResults } = useAnalysisQuery(props.analysis.analysis_id);
     const analysisWithNotes = (
-        (analysisQueryResults && (analysisQueryResults.datasets as DatasetWithNotes[])) ||
+        (analysisQueryResults && analysisQueryResults.datasets) ||
         []
     ).filter(dataset => dataset.notes || dataset.participant_notes);
 

--- a/react/src/Datasets/components/AnalysisRunnerDialog.tsx
+++ b/react/src/Datasets/components/AnalysisRunnerDialog.tsx
@@ -171,7 +171,7 @@ export default function AnalysisRunnerDialog({
                                     <TableCell>{dataset.dataset_type}</TableCell>
                                     <TableCell>{dataset.condition}</TableCell>
                                     <TableCell align="right">
-                                        {dataset.linked_files.join(", ")}
+                                        {dataset.linked_files.map(f => f.path).join(", ")}
                                     </TableCell>
                                 </TableRow>
                             ))}

--- a/react/src/Datasets/components/DatasetTable.tsx
+++ b/react/src/Datasets/components/DatasetTable.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useRef, useState } from "react";
+import { useMemo, useRef, useState } from "react";
 import { Column, EditComponentProps, MTableToolbar } from "@material-table/core";
 import { Chip, IconButton, makeStyles } from "@material-ui/core";
 import { Cancel, Delete, PlayArrow, Refresh, Visibility } from "@material-ui/icons";
@@ -117,7 +117,7 @@ export default function DatasetTable() {
 
     const [confirmDelete, setConfirmDelete] = useState(false);
 
-    const exportCsv = () => {
+    const exportCsv = () =>
         downloadCsv(transformMTQueryToCsvDownloadParams(MTRef.current?.state.query || {}));
 
     //setting to `any` b/c MTable typing doesn't include dataManager

--- a/react/src/Datasets/components/DatasetTable.tsx
+++ b/react/src/Datasets/components/DatasetTable.tsx
@@ -211,7 +211,8 @@ export default function DatasetTable() {
                 field: "vcf_available",
                 editable: "never",
                 sorting: false,
-                render: row => (isRNASeqDataset(row) ? row.vcf_available : "N/A"),
+                filtering: false,
+                render: row => (isRNASeqDataset(row) ? (row.vcf_available ? "Yes" : "No") : "N/A"),
             },
             {
                 title: "Sequencing ID",

--- a/react/src/Datasets/components/DatasetTable.tsx
+++ b/react/src/Datasets/components/DatasetTable.tsx
@@ -32,7 +32,7 @@ import {
     useUnlinkedFilesQuery,
 } from "../../hooks";
 import { transformMTQueryToCsvDownloadParams } from "../../hooks/utils";
-import { Dataset, LinkedFile } from "../../typings";
+import { Dataset, isRNASeqDataset, LinkedFile } from "../../typings";
 import AnalysisRunnerDialog from "./AnalysisRunnerDialog";
 import DatasetInfoDialog from "./DatasetInfoDialog";
 import LinkedFilesButton from "./LinkedFilesButton";
@@ -119,7 +119,6 @@ export default function DatasetTable() {
 
     const exportCsv = () => {
         downloadCsv(transformMTQueryToCsvDownloadParams(MTRef.current?.state.query || {}));
-    };
 
     //setting to `any` b/c MTable typing doesn't include dataManager
     const MTRef = useRef<any>();
@@ -189,6 +188,20 @@ export default function DatasetTable() {
                 editable: "never",
                 defaultFilter: paramID,
             },
+            {
+                title: "Candidate Genes",
+                field: "candidate_genes",
+                editable: "never",
+                sorting: false,
+                render: row => (isRNASeqDataset(row) ? <Note>{row.candidate_genes}</Note> : "N/A"),
+            },
+            {
+                title: "VCF Available",
+                field: "vcf_available",
+                editable: "never",
+                sorting: false,
+                render: row => (isRNASeqDataset(row) ? row.vcf_available : "N/A"),
+            },
         ];
         if (currentUser.is_admin || currentUser.groups.length > 1) {
             columns.push({
@@ -204,15 +217,16 @@ export default function DatasetTable() {
                 ),
             });
         }
+
         setInitialSorting(columns);
         setHiddenColumns(columns);
         return columns;
     }, [
         conditions,
+        currentUser,
         datasetTypes,
         paramID,
         tissueSampleTypes,
-        currentUser,
         setInitialSorting,
         setHiddenColumns,
     ]);

--- a/react/src/SearchVariants/components/GeneAutocomplete.tsx
+++ b/react/src/SearchVariants/components/GeneAutocomplete.tsx
@@ -97,9 +97,6 @@ const useStyles = makeStyles<Theme, GeneAutocompleteProps>(theme => ({
     adornment: {
         margin: theme.spacing(0, 1),
     },
-    // popper: {
-    //     display: props => (props.searchCategory !== "gene" ? "" : "none"),
-    // },
 }));
 
 // Return whether the provided search string is valid for the given category
@@ -237,7 +234,7 @@ const GeneAutocomplete: React.FC<GeneAutocompleteProps> = (props: GeneAutocomple
                 );
             }}
             //we have to control component in order to *prevent* selection persistence
-            value={selectedValue || undefined}
+            value={selectedValue}
         />
     );
 };

--- a/react/src/SearchVariants/components/SearchVariantsPage.tsx
+++ b/react/src/SearchVariants/components/SearchVariantsPage.tsx
@@ -15,8 +15,8 @@ import { QueryKey, useQueryClient } from "react-query";
 import { snakeCaseToTitle } from "../../functions";
 import { useDownloadCsv, useErrorSnackbar, useModalState } from "../../hooks";
 import { GeneAlias } from "../../typings";
-import GeneAutocomplete, { SearchCategory } from "./Autocomplete";
 import { CardButton } from "./CardButton";
+import GeneAutocomplete, { SearchCategory } from "./GeneAutocomplete";
 import { ReportColumnModal } from "./ReportColumnModal";
 
 interface SearchVariantsPageProps {}

--- a/react/src/components/AutocompleteMultiselect.tsx
+++ b/react/src/components/AutocompleteMultiselect.tsx
@@ -1,0 +1,76 @@
+import { useState } from "react";
+import { TextField } from "@material-ui/core";
+import {
+    Autocomplete,
+    AutocompleteClassKey,
+    AutocompleteProps,
+    createFilterOptions,
+} from "@material-ui/lab";
+import { StyledComponentProps } from "@material-ui/styles";
+
+interface AutocompleteMultiselectProps<T> {
+    inputLabel: string;
+    limit: number;
+    onInputChange?: (input: string) => void;
+    onSelect: (newValue: T[]) => void;
+    options: T[];
+    renderTags: AutocompleteProps<T, true, any, any>["renderTags"];
+    selectedValues: T[];
+    classes?: StyledComponentProps<AutocompleteClassKey>["classes"];
+    uniqueLabelPath: string;
+}
+
+export default function AutocompleteMultiselect<T extends Record<string, any>>({
+    classes = {},
+    inputLabel,
+    limit,
+    onInputChange,
+    onSelect,
+    options,
+    renderTags,
+    selectedValues,
+    uniqueLabelPath,
+}: AutocompleteMultiselectProps<T>) {
+    const [inputValue, setInputValue] = useState("");
+    return (
+        <Autocomplete
+            autoComplete
+            classes={classes}
+            inputValue={inputValue}
+            onInputChange={(_, value, reason) => {
+                if (reason === "input") {
+                    setInputValue(value);
+                }
+                if (onInputChange) {
+                    //if options are filtered dynamically
+                    onInputChange(value);
+                }
+            }}
+            disableClearable={true}
+            disableCloseOnSelect
+            onChange={(event, selectedOptions, reason) => {
+                //prevent keypress events from propagating to parent listeners
+                event.stopPropagation();
+                if (selectedOptions && ["select-option", "remove-option"].includes(reason)) {
+                    onSelect(selectedOptions);
+                    setInputValue("");
+                }
+            }}
+            renderOption={option => <span>{option[uniqueLabelPath]}</span>}
+            renderTags={renderTags}
+            getOptionSelected={(option, value) =>
+                option[uniqueLabelPath] === value[uniqueLabelPath]
+            }
+            options={options}
+            filterOptions={createFilterOptions({
+                limit,
+                stringify: o => o[uniqueLabelPath],
+            })}
+            filterSelectedOptions={true}
+            getOptionLabel={option => option[uniqueLabelPath]}
+            renderInput={params => <TextField {...params} label={inputLabel} variant="outlined" />}
+            multiple
+            value={selectedValues}
+        />
+    );
+}

--- a/react/src/components/FileLinkingComponent.tsx
+++ b/react/src/components/FileLinkingComponent.tsx
@@ -9,13 +9,11 @@ import {
     List,
     makeStyles,
     Popover,
-    TextField,
     Tooltip,
     Typography,
 } from "@material-ui/core";
 import { Description } from "@material-ui/icons";
-import { Autocomplete, createFilterOptions } from "@material-ui/lab";
-import { Note } from "../components";
+import { AutocompleteMultiselect, Note } from "../components";
 import { LinkedFile, UnlinkedFile } from "../typings";
 
 const useStyles = makeStyles(theme => ({
@@ -36,7 +34,11 @@ const useStyles = makeStyles(theme => ({
         wordBreak: "break-all",
         padding: 0,
     },
-    autocomplete: {
+}));
+
+/* eslint-disable mui-unused-classes/unused-classes */
+const useAutocompleteStyles = makeStyles(() => ({
+    root: {
         width: "400px",
         flexGrow: 1,
     },
@@ -50,9 +52,9 @@ const FileLinkingComponent: React.FC<{
     disabled?: boolean;
     disableTooltip?: boolean;
 }> = ({ values, options, onEdit, disabled, disableTooltip }) => {
+    const autocompleteClasses = useAutocompleteStyles();
     const classes = useStyles();
     const [anchorEl, setAnchorEl] = useState<HTMLButtonElement | null>(null);
-    const [inputValue, setInputValue] = useState("");
 
     const open = Boolean(anchorEl);
 
@@ -139,28 +141,12 @@ const FileLinkingComponent: React.FC<{
                             </Typography>
                         ) : (
                             <Grid container direction="column">
-                                <Autocomplete
-                                    autoComplete
-                                    className={classes.autocomplete}
-                                    inputValue={inputValue}
-                                    onInputChange={(_, value, reason) => {
-                                        if (reason === "input") {
-                                            setInputValue(value);
-                                        }
-                                    }}
-                                    disableClearable={true}
-                                    disableCloseOnSelect
-                                    onChange={(event, selectedOptions, reason) => {
-                                        //prevent keypress events from propagating to parent listeners
-                                        event.stopPropagation();
-                                        if (
-                                            selectedOptions &&
-                                            ["select-option", "remove-option"].includes(reason)
-                                        ) {
-                                            onEdit(selectedOptions);
-                                            setInputValue("");
-                                        }
-                                    }}
+                                <AutocompleteMultiselect
+                                    classes={autocompleteClasses}
+                                    inputLabel="Search Unlinked Files"
+                                    limit={25}
+                                    onSelect={onEdit}
+                                    options={options}
                                     renderTags={(tags, getTagProps) => (
                                         <>
                                             {tags.map((tag, i) => {
@@ -175,7 +161,7 @@ const FileLinkingComponent: React.FC<{
                                                         }))
                                                     );
                                                 };
-                                                const detail = (
+                                                const Detail = (
                                                     <Box margin={1}>
                                                         <FormControlLabel
                                                             label="Multiplexed?"
@@ -193,7 +179,7 @@ const FileLinkingComponent: React.FC<{
                                                         key={tag.path}
                                                         {...getTagProps({ index: i })}
                                                         label={
-                                                            <Note DetailComponent={detail}>
+                                                            <Note detailElement={Detail}>
                                                                 {tag.path}
                                                             </Note>
                                                         }
@@ -202,28 +188,8 @@ const FileLinkingComponent: React.FC<{
                                             })}
                                         </>
                                     )}
-                                    renderOption={option => (
-                                        <span className={classes.fileName}>{option.path}</span>
-                                    )}
-                                    getOptionSelected={(option, value) =>
-                                        option.path === value.path
-                                    }
-                                    options={options}
-                                    filterOptions={createFilterOptions({
-                                        limit: 25,
-                                        stringify: o => o.path,
-                                    })}
-                                    filterSelectedOptions={true}
-                                    getOptionLabel={option => option.path}
-                                    renderInput={params => (
-                                        <TextField
-                                            {...params}
-                                            label="Search Unlinked Files"
-                                            variant="outlined"
-                                        />
-                                    )}
-                                    multiple
-                                    value={values}
+                                    selectedValues={values}
+                                    uniqueLabelPath="path"
                                 />
                             </Grid>
                         )}

--- a/react/src/components/Note.tsx
+++ b/react/src/components/Note.tsx
@@ -25,7 +25,7 @@ const useStyles = makeStyles(theme => ({
  */
 export default function Note(props: {
     children: React.ReactNode;
-    DetailComponent?: React.ReactNode;
+    detailElement?: React.ReactNode;
 }) {
     const classes = useStyles();
     const [anchorEl, setAnchorEl] = useState<HTMLDivElement | null>(null);
@@ -45,7 +45,7 @@ export default function Note(props: {
                     <Grid item>
                         <Typography className={classes.typography}>{props.children}</Typography>
                     </Grid>
-                    {!!props.DetailComponent && <Grid item>{props.DetailComponent}</Grid>}
+                    {!!props.detailElement && <Grid item>{props.detailElement}</Grid>}
                 </Grid>
             </Popover>
         </>

--- a/react/src/components/Note.tsx
+++ b/react/src/components/Note.tsx
@@ -23,17 +23,14 @@ const useStyles = makeStyles(theme => ({
 /**
  * A style wrapper for strings of text that are really long.
  */
-export default function Note(props: {
-    children: React.ReactNode;
-    detailElement?: React.ReactNode;
-}) {
+const Note: React.FC<{ detailElement?: React.ReactNode }> = ({ children, detailElement }) => {
     const classes = useStyles();
     const [anchorEl, setAnchorEl] = useState<HTMLDivElement | null>(null);
 
     return (
         <>
             <div className={classes.notes} onClick={event => setAnchorEl(event.currentTarget)}>
-                {props.children}
+                {children}
             </div>
             <Popover
                 open={!!anchorEl}
@@ -43,11 +40,13 @@ export default function Note(props: {
             >
                 <Grid container direction="column">
                     <Grid item>
-                        <Typography className={classes.typography}>{props.children}</Typography>
+                        <Typography className={classes.typography}>{children}</Typography>
                     </Grid>
-                    {!!props.detailElement && <Grid item>{props.detailElement}</Grid>}
+                    {!!detailElement && <Grid item>{detailElement}</Grid>}
                 </Grid>
             </Popover>
         </>
     );
-}
+};
+
+export default Note;

--- a/react/src/components/index.tsx
+++ b/react/src/components/index.tsx
@@ -4,6 +4,7 @@
  * Generated with VSCode extension: https://marketplace.visualstudio.com/items?itemName=BrunoLM.export-index
  */
 export { default as AnalysisInfoDialog } from "./AnalysisInfoDialog";
+export { default as AutocompleteMultiselect } from "./AutocompleteMultiselect";
 export { default as BooleanDisplay } from "./BooleanDisplay";
 export { default as BooleanEditComponent } from "./BooleanEditComponent";
 export { default as BooleanFilter } from "./BooleanFilter";

--- a/react/src/functions.tsx
+++ b/react/src/functions.tsx
@@ -191,19 +191,6 @@ export function getDatasetInfoList(datasets: Dataset[]): Info[] {
 }
 
 /**
- * Set property of object at key to newValue. Return obj.
- *
- * @example
- * let obj = { a: 1, b: 2 };
- * setProp(obj, "a", 3);     // returns { a: 3, b: 2 }
- * obj.a === 3               // returns true
- */
-export function setProp<T, K extends keyof T>(obj: T, key: K, newValue: any) {
-    obj[key] = newValue;
-    return obj;
-}
-
-/**
  * Return an object containing all headers for DataEntryTable.
  */
 export function getDataEntryHeaders() {

--- a/react/src/functions.tsx
+++ b/react/src/functions.tsx
@@ -9,6 +9,7 @@ import {
     Field,
     FieldDisplayValueType,
     Info,
+    isRNASeqDataset,
     KeyValue,
     PipelineStatus,
     PseudoBoolean,
@@ -141,7 +142,7 @@ export function getDatasetFields(dataset: Dataset) {
  * Return the secondary titles and values (hidden in show more detail) of dataset detail as a Field object in dialogs
  */
 export function getSecDatasetFields(dataset: Dataset) {
-    return [
+    let fields = [
         createFieldObj("Batch ID", dataset.batch_id, "batch_id"),
         createFieldObj(
             "Linked Files",
@@ -161,6 +162,16 @@ export function getSecDatasetFields(dataset: Dataset) {
         createFieldObj("Read Length", dataset.read_length, "read_length"),
         createFieldObj("Read Type", dataset.read_type, "read_type"),
     ];
+
+    if (isRNASeqDataset(dataset)) {
+        fields = [
+            ...fields,
+            createFieldObj("VCF Available", dataset.vcf_available, "vcf_available"),
+            createFieldObj("Candidate Genes", dataset.candidate_genes, "candidate_genes"),
+        ];
+    }
+
+    return fields;
 }
 
 /**

--- a/react/src/functions.tsx
+++ b/react/src/functions.tsx
@@ -5,10 +5,6 @@ import utc from "dayjs/plugin/utc";
 import {
     Analysis,
     Counts,
-    DataEntryRow,
-    DataEntryRowBase,
-    DataEntryRowOptional,
-    DataEntryRowRNASeq,
     Dataset,
     Field,
     FieldDisplayValueType,
@@ -76,14 +72,6 @@ export function jsonToAnalyses(data: Array<any>): Analysis[] {
         return { ...row } as Analysis;
     });
     return rows;
-}
-
-/**
- * Get the index of a material-table row.
- * If a material-table row is not provided, return null.
- */
-export function getRowIndex(row: any): number | null {
-    return row.tableData?.id;
 }
 
 /**
@@ -191,17 +179,6 @@ export function getDatasetInfoList(datasets: Dataset[]): Info[] {
 }
 
 /**
- * Return an object containing all headers for DataEntryTable.
- */
-export function getDataEntryHeaders() {
-    return {
-        required: Object.keys(new DataEntryRowBase()) as Array<keyof DataEntryRowBase>,
-        optional: Object.keys(new DataEntryRowOptional()) as Array<keyof DataEntryRowOptional>,
-        RNASeq: Object.keys(new DataEntryRowRNASeq()) as Array<keyof DataEntryRowRNASeq>,
-    };
-}
-
-/**
  * Given a string in snake-case (eg. thing_name), returns the string
  * in spaced Title case (eg. Thing Name).
  *
@@ -231,6 +208,8 @@ export function createFieldObj(
         disableEdit,
     };
 }
+
+export const getKeys = <T extends object>(obj: T) => Object.keys(obj) as (keyof T)[];
 
 /**
  * Convert given table to CSV and downloads it to user.
@@ -267,24 +246,6 @@ export function exportCSV(columnDefs: any[], data: any[], filename: string) {
     });
 
     downloadCsv(filename, blob);
-}
-
-export function createEmptyRows(amount?: number): DataEntryRow[] {
-    if (!amount || amount < 1) amount = 1;
-
-    var arr = [];
-    for (let i = 0; i < amount; i++) {
-        arr.push({
-            family_codename: "",
-            participant_codename: "",
-            participant_type: "",
-            tissue_sample_type: "",
-            dataset_type: "",
-            condition: "GermLine",
-            sequencing_date: "",
-        });
-    }
-    return arr;
 }
 
 export function stringToBoolean(value: PseudoBoolean) {

--- a/react/src/hooks/bulk/useBulkCreateMutation.tsx
+++ b/react/src/hooks/bulk/useBulkCreateMutation.tsx
@@ -1,8 +1,8 @@
 import { useMutation, useQueryClient } from "react-query";
-import { DataEntryRow, Dataset } from "../../typings";
+import { DataEntryFields, Dataset } from "../../typings";
 
 interface DatasetSubmitParameters {
-    data: DataEntryRow[];
+    data: DataEntryFields[];
     asGroups: string[];
 }
 

--- a/react/src/hooks/genes/useGenesQuery.ts
+++ b/react/src/hooks/genes/useGenesQuery.ts
@@ -10,7 +10,7 @@ async function fetchGenes(params: Record<string, any>) {
  * Return result of GET /api/genes.
  *
  */
-export const useGenesQuery = (params: Record<string, any> = {}, enabled: boolean = true) =>
+export const useGenesQuery = (params: { search: string }, enabled: boolean = true) =>
     useQuery<{ data: GeneAlias[] }, Response>(
         ["genes", params],
         fetchGenes.bind(null, { ...params, limit: 25 }),

--- a/react/src/typings.tsx
+++ b/react/src/typings.tsx
@@ -146,7 +146,7 @@ export interface Analysis {
 }
 
 export interface AnalysisDetails {
-    datasets: Dataset[];
+    datasets: (Dataset & { participant_notes: string })[];
 }
 
 export type AnalysisDetailed = Analysis & AnalysisDetails;

--- a/react/src/typings.tsx
+++ b/react/src/typings.tsx
@@ -196,13 +196,8 @@ export class DataEntryRowOptional {
     institution?: string;
 }
 
-// Cannot enforce "RNASeq => these values are set" with types
 export class DataEntryRowRNASeq {
-    RIN?: string;
-    DV200?: string;
-    concentration?: string;
-    sequencer?: string;
-    spike_in?: string;
+    candidate_genes?: string;
 }
 
 export interface DataEntryRow extends DataEntryRowBase, DataEntryRowOptional, DataEntryRowRNASeq {

--- a/react/src/typings.tsx
+++ b/react/src/typings.tsx
@@ -193,13 +193,13 @@ export class DataEntryRowSharedRequired {
     participant_type!: string;
     tissue_sample_type!: string;
     dataset_type!: string;
-    linked_files!: LinkedFile[];
     condition!: string;
     sequencing_date!: string;
 }
 
 export class DataEntryRowSharedOptional {
     notes!: string;
+    linked_files!: LinkedFile[];
 }
 
 export class DataEntryRowDNAOptional {
@@ -218,12 +218,11 @@ export class DataEntryRowDNAOptional {
 }
 
 export class DataEntryRowDNARequired {}
-export class DataEntryRowRNARequired {
-    candidate_genes!: string;
-}
+export class DataEntryRowRNARequired {}
 
 export class DataEntryRowRNAOptional {
     vcf_available!: boolean;
+    candidate_genes!: string;
 }
 
 export interface DataEntryFields

--- a/react/src/typings.tsx
+++ b/react/src/typings.tsx
@@ -169,6 +169,7 @@ export interface Info {
 }
 
 // Define these as classes so that we can create an array of keys later
+
 export class DataEntryRowBase {
     family_codename!: string;
     participant_codename!: string;
@@ -177,37 +178,48 @@ export class DataEntryRowBase {
     dataset_type!: string;
     condition!: string;
     sequencing_date!: string;
+    notes!: string;
+    linked_files!: LinkedFile[];
 }
 
-export class DataEntryRowOptional {
-    sex?: string;
-    affected?: boolean;
-    solved?: boolean;
-    linked_files?: LinkedFile[];
-    notes?: string;
-    extraction_protocol?: string;
-    capture_kit?: string;
-    library_prep_method?: string;
-    read_length?: number;
-    read_type?: string;
-    sequencing_id?: string;
-    sequencing_centre?: string;
-    batch_id?: string;
-    institution?: string;
+export class DataEntryRowRNA {
+    candidate_genes!: string;
 }
 
-export class DataEntryRowRNASeq {
-    candidate_genes?: string;
+export class DataEntryRowDNAOptional {
+    sex!: string;
+    affected!: boolean;
+    solved!: boolean;
+    extraction_protocol!: string;
+    capture_kit!: string;
+    library_prep_method!: string;
+    read_length!: number;
+    read_type!: string;
+    sequencing_id!: string;
+    sequencing_centre!: string;
+    batch_id!: string;
+    institution!: string;
 }
 
-export interface DataEntryRow extends DataEntryRowBase, DataEntryRowOptional, DataEntryRowRNASeq {
-    participantColDisabled?: boolean;
+export interface DataEntryFields
+    extends DataEntryRowBase,
+        DataEntryRowDNAOptional,
+        DataEntryRowRNA {}
+
+export interface DataEntryRow {
+    meta: {
+        participantColumnsDisabled?: boolean;
+    };
+    fields: DataEntryFields;
 }
 
-export interface DataEntryHeader {
-    title: string;
-    field: keyof DataEntryRow;
+export type DataEntryField = keyof DataEntryFields;
+
+export interface DataEntryColumnConfig {
+    field: DataEntryField;
     hidden?: boolean;
+    required?: boolean;
+    title: string;
 }
 
 export interface NewUser {

--- a/react/src/typings.tsx
+++ b/react/src/typings.tsx
@@ -69,7 +69,7 @@ export interface LinkedFile extends UnlinkedFile {
     file_id: number;
 }
 
-export interface Dataset {
+export interface DNADataset {
     dataset_id: string;
     participant_codename: string;
     participant_aliases: string;
@@ -97,6 +97,22 @@ export interface Dataset {
     discriminator: string;
     group_code: string[];
 }
+
+interface RNASeqDataset extends DNADataset {
+    candidate_genes: string;
+    RIN: number;
+    DV200: number;
+    concentration: number;
+    sequencer: string;
+    spike_in: string;
+    vcf_available: string;
+}
+
+export type Dataset = RNASeqDataset | DNADataset;
+
+// dataset typeguard
+export const isRNASeqDataset = (dataset: RNASeqDataset | Dataset): dataset is RNASeqDataset =>
+    dataset.discriminator === "rnaseq_dataset";
 
 // Result from /api/datasets/:id
 export interface DatasetDetails {

--- a/react/src/typings.tsx
+++ b/react/src/typings.tsx
@@ -177,13 +177,16 @@ export class DataEntryRowSharedRequired {
     participant_type!: string;
     tissue_sample_type!: string;
     dataset_type!: string;
-    condition!: string;
-    sequencing_date!: string;
-    notes!: string;
     linked_files!: LinkedFile[];
+    sequencing_date!: string;
 }
 
 export class DataEntryRowSharedOptional {
+    notes!: string;
+}
+
+export class DataEntryRowDNAOptional {
+    sex!: string;
     affected!: boolean;
     solved!: boolean;
     extraction_protocol!: string;
@@ -196,14 +199,12 @@ export class DataEntryRowSharedOptional {
     batch_id!: string;
     institution!: string;
 }
+
+export class DataEntryRowDNARequired {
+    condition!: string;
+}
 export class DataEntryRowRNARequired {
     candidate_genes!: string;
-}
-
-export class DataEntryRowDNARequired {}
-
-export class DataEntryRowDNAOptional {
-    sex!: string;
 }
 
 export class DataEntryRowRNAOptional {}

--- a/react/src/typings.tsx
+++ b/react/src/typings.tsx
@@ -170,7 +170,8 @@ export interface Info {
 
 // Define these as classes so that we can create an array of keys later
 
-export class DataEntryRowBase {
+//note that these are in display order and should not alphabetized
+export class DataEntryRowSharedRequired {
     family_codename!: string;
     participant_codename!: string;
     participant_type!: string;
@@ -182,12 +183,7 @@ export class DataEntryRowBase {
     linked_files!: LinkedFile[];
 }
 
-export class DataEntryRowRNA {
-    candidate_genes!: string;
-}
-
-export class DataEntryRowDNAOptional {
-    sex!: string;
+export class DataEntryRowSharedOptional {
     affected!: boolean;
     solved!: boolean;
     extraction_protocol!: string;
@@ -200,11 +196,25 @@ export class DataEntryRowDNAOptional {
     batch_id!: string;
     institution!: string;
 }
+export class DataEntryRowRNARequired {
+    candidate_genes!: string;
+}
+
+export class DataEntryRowDNARequired {}
+
+export class DataEntryRowDNAOptional {
+    sex!: string;
+}
+
+export class DataEntryRowRNAOptional {}
 
 export interface DataEntryFields
-    extends DataEntryRowBase,
-        DataEntryRowDNAOptional,
-        DataEntryRowRNA {}
+    extends DataEntryRowSharedRequired,
+        DataEntryRowSharedOptional,
+        DataEntryRowRNARequired,
+        DataEntryRowRNAOptional,
+        DataEntryRowDNARequired,
+        DataEntryRowDNAOptional {}
 
 export interface DataEntryRow {
     meta: {

--- a/react/src/typings.tsx
+++ b/react/src/typings.tsx
@@ -178,6 +178,7 @@ export class DataEntryRowSharedRequired {
     tissue_sample_type!: string;
     dataset_type!: string;
     linked_files!: LinkedFile[];
+    condition!: string;
     sequencing_date!: string;
 }
 
@@ -200,14 +201,14 @@ export class DataEntryRowDNAOptional {
     institution!: string;
 }
 
-export class DataEntryRowDNARequired {
-    condition!: string;
-}
+export class DataEntryRowDNARequired {}
 export class DataEntryRowRNARequired {
     candidate_genes!: string;
 }
 
-export class DataEntryRowRNAOptional {}
+export class DataEntryRowRNAOptional {
+    vcf_available!: boolean;
+}
 
 export interface DataEntryFields
     extends DataEntryRowSharedRequired,


### PR DESCRIPTION
closes #796
- refactor AddDataset FE components
  - lift column state management functionality to top-level component
  - allow for mixed RNA/DNA seq entries on the input table
  - create candidate gene lookup control
  - remove unused code
- update datasets table and relevant modals to show RNAseq data
- add new RNAseq columns to DB and update name of RNAseq pipeline in migration
- update endpoints to handle RNAseq and mixed input and filter fields
- update tests 