### PR TITLE
React: Added aggregate notes popover on Analysis page

### DIFF
--- a/flask/app/analyses.py
+++ b/flask/app/analyses.py
@@ -338,7 +338,6 @@ def get_analysis(id: int):
                     "family_codename": dataset.tissue_sample.participant.family.family_codename,
                     "updated_by": dataset.tissue_sample.updated_by.username,
                     "created_by": dataset.tissue_sample.created_by.username,
-                    "dataset_notes": dataset.notes,
                     "participant_notes": dataset.tissue_sample.participant.notes,
                 }
                 for dataset in analysis.datasets

--- a/flask/app/analyses.py
+++ b/flask/app/analyses.py
@@ -314,7 +314,7 @@ def get_analysis(id: int):
 
     app.logger.debug("Query successful returning JSON..")
 
-    result = jsonify(
+    return jsonify(
         {
             **asdict(analysis),
             "requester": analysis.requester_id and analysis.requester.username,
@@ -344,10 +344,6 @@ def get_analysis(id: int):
             ],
         }
     )
-
-    app.logger.debug("hello123")
-    app.logger.info(result)
-    return result
 
 
 @analyses_blueprint.route("/api/analyses", methods=["POST"])

--- a/flask/app/analyses.py
+++ b/flask/app/analyses.py
@@ -314,7 +314,7 @@ def get_analysis(id: int):
 
     app.logger.debug("Query successful returning JSON..")
 
-    return jsonify(
+    result = jsonify(
         {
             **asdict(analysis),
             "requester": analysis.requester_id and analysis.requester.username,
@@ -338,11 +338,17 @@ def get_analysis(id: int):
                     "family_codename": dataset.tissue_sample.participant.family.family_codename,
                     "updated_by": dataset.tissue_sample.updated_by.username,
                     "created_by": dataset.tissue_sample.created_by.username,
+                    "dataset_notes": dataset.notes,
+                    "participant_notes": dataset.tissue_sample.participant.notes,
                 }
                 for dataset in analysis.datasets
             ],
         }
     )
+
+    app.logger.debug("hello123")
+    app.logger.info(result)
+    return result
 
 
 @analyses_blueprint.route("/api/analyses", methods=["POST"])

--- a/react/src/Analyses/components/AnalysisNotes.tsx
+++ b/react/src/Analyses/components/AnalysisNotes.tsx
@@ -53,10 +53,12 @@ export default function AnalysisNotes(props: AnalysisNotesProps) {
                     {analysisWithNotes.map(dataset => (
                         <>
                             <Divider className={classes.divider} />
-                            <Typography className={classes.comment}>
-                                Comment by {dataset.updated_by} for dataset{" "}
-                                {dataset.participant_codename}/{dataset.tissue_sample_type}/
-                                {dataset.dataset_type}
+                            <Typography className={classes.comment} gutterBottom>
+                                Last updated {dataset.updated} by {dataset.updated_by}
+                            </Typography>
+                            <Typography variant="button">
+                                Dataset: {dataset.participant_codename}/{dataset.tissue_sample_type}
+                                /{dataset.dataset_type}
                             </Typography>
                             {dataset.participant_notes && (
                                 <Typography variant="body1">

--- a/react/src/Analyses/components/AnalysisNotes.tsx
+++ b/react/src/Analyses/components/AnalysisNotes.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo } from "react";
-import { Popover, Typography } from "@material-ui/core";
+import { Divider, Popover, Typography } from "@material-ui/core";
 import { makeStyles } from "@material-ui/core/styles";
 import { useAnalysisQuery } from "../../hooks";
 import { Analysis, Dataset } from "../../typings";
@@ -21,6 +21,9 @@ const useStyles = makeStyles(theme => ({
         padding: theme.spacing(2),
         background: theme.palette.warning.main,
     },
+    divider: {
+        margin: theme.spacing(1, 0),
+    },
 }));
 
 export default function AnalysisNotes(props: AnalysisNotesProps) {
@@ -30,8 +33,9 @@ export default function AnalysisNotes(props: AnalysisNotesProps) {
         () => (analysisQuery.isSuccess ? analysisQuery.data.datasets || [] : []),
         [analysisQuery]
     ) as DatasetWithNotes[];
+    const datasetsWithNotes = datasets.filter(d => d.dataset_notes && d.participant_notes);
 
-    return datasets.length > 0 ? (
+    return (
         <Popover
             PaperProps={{ className: classes.paper }}
             open={props.open}
@@ -42,12 +46,29 @@ export default function AnalysisNotes(props: AnalysisNotesProps) {
                 horizontal: "left",
             }}
         >
-            {datasets.map(dataset => (
+            {datasetsWithNotes.length > 0 ? (
                 <>
-                    <Typography>Participant: {dataset.participant_notes}</Typography>
-                    <Typography>Dataset: {dataset.dataset_notes}</Typography>
+                    <Typography variant="h6">Notes</Typography>
+                    {datasetsWithNotes.map(dataset => (
+                        <>
+                            <Divider className={classes.divider} />
+                            <Typography variant="subtitle1">
+                                Dataset {dataset.dataset_id}
+                            </Typography>
+                            <Typography variant="body1">
+                                Participant: {dataset.participant_notes}
+                            </Typography>
+                            <Typography variant="body1">
+                                Dataset: {dataset.dataset_notes}
+                            </Typography>
+                        </>
+                    ))}
                 </>
-            ))}
+            ) : (
+                <Typography>
+                    There are no additional notes from the associated datasets and participants.
+                </Typography>
+            )}
         </Popover>
-    ) : null;
+    );
 }

--- a/react/src/Analyses/components/AnalysisNotes.tsx
+++ b/react/src/Analyses/components/AnalysisNotes.tsx
@@ -1,0 +1,53 @@
+import React, { useMemo } from "react";
+import { Popover, Typography } from "@material-ui/core";
+import { makeStyles } from "@material-ui/core/styles";
+import { useAnalysisQuery } from "../../hooks";
+import { Analysis, Dataset } from "../../typings";
+
+interface AnalysisNotesProps {
+    analysis: Analysis;
+    anchorEl: HTMLButtonElement | null;
+    open: boolean;
+    onClose: () => void;
+}
+
+interface DatasetWithNotes extends Dataset {
+    participant_notes: string;
+    dataset_notes: string;
+}
+
+const useStyles = makeStyles(theme => ({
+    paper: {
+        padding: theme.spacing(2),
+        background: theme.palette.warning.main,
+    },
+}));
+
+export default function AnalysisNotes(props: AnalysisNotesProps) {
+    const classes = useStyles();
+    const analysisQuery = useAnalysisQuery(props.analysis.analysis_id);
+    const datasets = useMemo(
+        () => (analysisQuery.isSuccess ? analysisQuery.data.datasets || [] : []),
+        [analysisQuery]
+    ) as DatasetWithNotes[];
+
+    return datasets.length > 0 ? (
+        <Popover
+            PaperProps={{ className: classes.paper }}
+            open={props.open}
+            anchorEl={props.anchorEl}
+            onClose={props.onClose}
+            anchorOrigin={{
+                vertical: "bottom",
+                horizontal: "left",
+            }}
+        >
+            {datasets.map(dataset => (
+                <>
+                    <Typography>Participant: {dataset.participant_notes}</Typography>
+                    <Typography>Dataset: {dataset.dataset_notes}</Typography>
+                </>
+            ))}
+        </Popover>
+    ) : null;
+}

--- a/react/src/Analyses/components/AnalysisNotes.tsx
+++ b/react/src/Analyses/components/AnalysisNotes.tsx
@@ -19,7 +19,6 @@ interface DatasetWithNotes extends Dataset {
 const useStyles = makeStyles(theme => ({
     paper: {
         padding: theme.spacing(2),
-        background: theme.palette.warning.main,
     },
     divider: {
         margin: theme.spacing(1, 0),
@@ -34,6 +33,7 @@ export default function AnalysisNotes(props: AnalysisNotesProps) {
         [analysisQuery]
     ) as DatasetWithNotes[];
     const datasetsWithNotes = datasets.filter(d => d.dataset_notes && d.participant_notes);
+    console.log(datasets);
 
     return (
         <Popover
@@ -52,6 +52,9 @@ export default function AnalysisNotes(props: AnalysisNotesProps) {
                     {datasetsWithNotes.map(dataset => (
                         <>
                             <Divider className={classes.divider} />
+                            <Typography>
+                                Comment by {dataset.updated_by} at {dataset.updated}
+                            </Typography>
                             <Typography variant="subtitle1">
                                 Dataset {dataset.dataset_id}
                             </Typography>

--- a/react/src/Analyses/components/AnalysisNotes.tsx
+++ b/react/src/Analyses/components/AnalysisNotes.tsx
@@ -54,10 +54,9 @@ export default function AnalysisNotes(props: AnalysisNotesProps) {
                         <>
                             <Divider className={classes.divider} />
                             <Typography className={classes.comment}>
-                                Comment by {dataset.updated_by} at {dataset.updated}
-                            </Typography>
-                            <Typography variant="subtitle1">
-                                Dataset {dataset.dataset_id}
+                                Comment by {dataset.updated_by} for dataset{" "}
+                                {dataset.participant_codename}/{dataset.tissue_sample_type}/
+                                {dataset.dataset_type}
                             </Typography>
                             {dataset.participant_notes && (
                                 <Typography variant="body1">

--- a/react/src/Analyses/components/AnalysisNotes.tsx
+++ b/react/src/Analyses/components/AnalysisNotes.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from "react";
+import React from "react";
 import { Divider, Popover, Typography } from "@material-ui/core";
 import { makeStyles } from "@material-ui/core/styles";
 import { useAnalysisQuery } from "../../hooks";
@@ -23,17 +23,18 @@ const useStyles = makeStyles(theme => ({
     divider: {
         margin: theme.spacing(1, 0),
     },
+    comment: {
+        fontWeight: 500,
+    },
 }));
 
 export default function AnalysisNotes(props: AnalysisNotesProps) {
     const classes = useStyles();
-    const analysisQuery = useAnalysisQuery(props.analysis.analysis_id);
-    const datasets = useMemo(
-        () => (analysisQuery.isSuccess ? analysisQuery.data.datasets || [] : []),
-        [analysisQuery]
-    ) as DatasetWithNotes[];
-    const datasetsWithNotes = datasets.filter(d => d.dataset_notes && d.participant_notes);
-    console.log(datasets);
+    const { data: analysisQueryResults } = useAnalysisQuery(props.analysis.analysis_id);
+    const analysisWithNotes = (
+        (analysisQueryResults && (analysisQueryResults.datasets as DatasetWithNotes[])) ||
+        []
+    ).filter(dataset => dataset.notes || dataset.participant_notes);
 
     return (
         <Popover
@@ -46,24 +47,26 @@ export default function AnalysisNotes(props: AnalysisNotesProps) {
                 horizontal: "left",
             }}
         >
-            {datasetsWithNotes.length > 0 ? (
+            {analysisWithNotes.length > 0 ? (
                 <>
                     <Typography variant="h6">Notes</Typography>
-                    {datasetsWithNotes.map(dataset => (
+                    {analysisWithNotes.map(dataset => (
                         <>
                             <Divider className={classes.divider} />
-                            <Typography>
+                            <Typography className={classes.comment}>
                                 Comment by {dataset.updated_by} at {dataset.updated}
                             </Typography>
                             <Typography variant="subtitle1">
                                 Dataset {dataset.dataset_id}
                             </Typography>
-                            <Typography variant="body1">
-                                Participant: {dataset.participant_notes}
-                            </Typography>
-                            <Typography variant="body1">
-                                Dataset: {dataset.dataset_notes}
-                            </Typography>
+                            {dataset.participant_notes && (
+                                <Typography variant="body1">
+                                    Participant: {dataset.participant_notes}
+                                </Typography>
+                            )}
+                            {dataset.notes && (
+                                <Typography variant="body1">Dataset: {dataset.notes}</Typography>
+                            )}
                         </>
                     ))}
                 </>

--- a/react/src/Analyses/index.tsx
+++ b/react/src/Analyses/index.tsx
@@ -7,6 +7,7 @@ import {
     AssignmentTurnedIn,
     Cancel,
     Error,
+    Info,
     PersonPin,
     PlayArrow,
     Refresh,
@@ -44,6 +45,7 @@ import {
 import { transformMTQueryToCsvDownloadParams } from "../hooks/utils";
 import { Analysis, AnalysisPriority, PipelineStatus } from "../typings";
 import AddAnalysisAlert from "./components/AddAnalysisAlert";
+import AnalysisNotes from "./components/AnalysisNotes";
 import CancelAnalysisDialog from "./components/CancelAnalysisDialog";
 import PipelineFilter from "./components/PipelineFilter";
 import SelectPipelineStatus from "./components/SelectPipelineStatus";
@@ -141,6 +143,9 @@ export default function Analyses() {
     const [cancel, setCancel] = useState(false); // for cancel dialog
     const [direct, setDirect] = useState(false); // for add analysis dialog (re-direct)
     const [assignment, setAssignment] = useState(false); // for set assignee dialog
+    const [comments, setComments] = useState(false); // for comments/ notes from associated participants and datasets
+
+    const [anchorEl, setAnchorEl] = React.useState<HTMLButtonElement | null>(null); // anchor element for notes popover
 
     const dataFetch = useAnalysesPage();
 
@@ -381,6 +386,18 @@ export default function Analyses() {
                 />
             )}
 
+            {activeRows.length > 0 && (
+                <AnalysisNotes
+                    open={comments}
+                    anchorEl={anchorEl}
+                    onClose={() => {
+                        setAnchorEl(null);
+                        setComments(false);
+                    }}
+                    analysis={activeRows[0]}
+                />
+            )}
+
             <AddAnalysisAlert
                 open={direct}
                 onClose={() => {
@@ -451,6 +468,16 @@ export default function Analyses() {
                         search: true,
                     }}
                     actions={[
+                        {
+                            icon: Info,
+                            tooltip: "View Comments",
+                            position: "row",
+                            onClick: (event, rowData) => {
+                                setActiveRows([rowData as Analysis]);
+                                setComments(true);
+                                setAnchorEl(event.currentTarget);
+                            },
+                        },
                         {
                             icon: Visibility,
                             tooltip: "View analysis details",


### PR DESCRIPTION
- There was no way to see notes from other tabs (such as Participants or Datasets) on the Analysis page. 
- I added an Info icon in the `actions` property of the table and attached a popover that displays the notes (if there are any). 
- Modified the `get_analyses` code in `analyses.py` to also return notes from the participants tab.