### PR TITLE
React/Flask: Added sequencing ID field in Dataset table

### DIFF
--- a/flask/app/datasets.py
+++ b/flask/app/datasets.py
@@ -124,7 +124,6 @@ def list_datasets(page: int, limit: int) -> Response:
     if dataset_id:
         filters.append(models.Dataset.dataset_id == dataset_id)
 
-    # sequencing ID.
     sequencing_id = request.args.get("sequencing_id", type=str)
     if sequencing_id:
         filters.append(func.instr(models.Dataset.sequencing_id, sequencing_id))

--- a/flask/app/datasets.py
+++ b/flask/app/datasets.py
@@ -77,6 +77,7 @@ def list_datasets(page: int, limit: int) -> Response:
         "participant_codename",
         "family_codename",
         "dataset_id",
+        "sequencing_id",
     ]
     if order_by is None:
         order = None  # system default, likely dataset_id
@@ -94,6 +95,8 @@ def list_datasets(page: int, limit: int) -> Response:
         # Since this is an elif clause, we know special cases are already handled above.
         # order_by has been restricted to a known list, so we can safely use getattr
         order = getattr(models.Dataset, order_by)
+    elif order_by == "sequencing_id":
+        order = models.Dataset.sequencing_id
     else:
         abort(400, description=f"order_by must be one of {allowed_columns}")
 
@@ -120,6 +123,11 @@ def list_datasets(page: int, limit: int) -> Response:
     dataset_id = request.args.get("dataset_id", type=str)
     if dataset_id:
         filters.append(models.Dataset.dataset_id == dataset_id)
+
+    # sequencing ID.
+    sequencing_id = request.args.get("sequencing_id", type=str)
+    if sequencing_id:
+        filters.append(func.instr(models.Dataset.sequencing_id, sequencing_id))
 
     participant_codename = request.args.get("participant_codename", type=str)
     participant_codename_exact_match = request.args.get(

--- a/flask/app/datasets.py
+++ b/flask/app/datasets.py
@@ -95,8 +95,6 @@ def list_datasets(page: int, limit: int) -> Response:
         # Since this is an elif clause, we know special cases are already handled above.
         # order_by has been restricted to a known list, so we can safely use getattr
         order = getattr(models.Dataset, order_by)
-    elif order_by == "sequencing_id":
-        order = models.Dataset.sequencing_id
     else:
         abort(400, description=f"order_by must be one of {allowed_columns}")
 

--- a/flask/tests/conftest.py
+++ b/flask/tests/conftest.py
@@ -218,6 +218,7 @@ def test_database(client):
         condition=DatasetCondition.Somatic,
         created_by_id=admin.user_id,
         updated_by_id=admin.user_id,
+        sequencing_id=5,
     )
     sample_1.datasets.append(dataset_1)
 
@@ -227,6 +228,7 @@ def test_database(client):
         condition=DatasetCondition.Somatic,
         created_by_id=admin.user_id,
         updated_by_id=admin.user_id,
+        sequencing_id=4,
     )
     dataset_2.groups.append(group)
     sample_1.datasets.append(dataset_2)
@@ -256,6 +258,7 @@ def test_database(client):
         condition=DatasetCondition.Somatic,
         created_by_id=admin.user_id,
         updated_by_id=admin.user_id,
+        sequencing_id=3,
     )
     dataset_3.groups.append(group)
     sample_2.datasets.append(dataset_3)
@@ -322,6 +325,7 @@ def test_database(client):
         condition=DatasetCondition.Somatic,
         created_by_id=admin.user_id,
         updated_by_id=admin.user_id,
+        sequencing_id=2,
     )
     sample_3.datasets.append(dataset_4)
 

--- a/flask/tests/conftest.py
+++ b/flask/tests/conftest.py
@@ -218,7 +218,7 @@ def test_database(client):
         condition=DatasetCondition.Somatic,
         created_by_id=admin.user_id,
         updated_by_id=admin.user_id,
-        sequencing_id=5,
+        sequencing_id="5",
     )
     sample_1.datasets.append(dataset_1)
 
@@ -228,7 +228,7 @@ def test_database(client):
         condition=DatasetCondition.Somatic,
         created_by_id=admin.user_id,
         updated_by_id=admin.user_id,
-        sequencing_id=4,
+        sequencing_id="4",
     )
     dataset_2.groups.append(group)
     sample_1.datasets.append(dataset_2)
@@ -258,7 +258,7 @@ def test_database(client):
         condition=DatasetCondition.Somatic,
         created_by_id=admin.user_id,
         updated_by_id=admin.user_id,
-        sequencing_id=3,
+        sequencing_id="3",
     )
     dataset_3.groups.append(group)
     sample_2.datasets.append(dataset_3)
@@ -325,7 +325,7 @@ def test_database(client):
         condition=DatasetCondition.Somatic,
         created_by_id=admin.user_id,
         updated_by_id=admin.user_id,
-        sequencing_id=2,
+        sequencing_id="2",
     )
     sample_3.datasets.append(dataset_4)
 

--- a/flask/tests/test_datasets.py
+++ b/flask/tests/test_datasets.py
@@ -444,6 +444,7 @@ def dataset_relationships(test_database):
         "created_by_id": user.user_id,
         "updated_by_id": user.user_id,
         "notes": "test_dataset_counts",
+        "sequencing_id": "2",
     }
 
     dataset_1 = models.Dataset(**dataset_fields)
@@ -505,6 +506,14 @@ def test_dataset_filter_on_dataset_column(
     assert len(response.get_json()["data"]) == 2
 
     response = client.get("/api/datasets?notes=test_dataset_counts&dataset_type=RES")
+    assert response.status_code == 200
+    assert len(response.get_json()["data"]) == 0
+
+    response = client.get("api/datasets?notes=test_dataset_counts&sequencing_id=2")
+    assert response.status_code == 200
+    assert len(response.get_json()["data"]) == 2
+
+    response = client.get("api/datasets?notes=test_dataset_counts&sequencing_id=1")
     assert response.status_code == 200
     assert len(response.get_json()["data"]) == 0
 
@@ -576,6 +585,19 @@ def test_dataset_order_by_dataset_column(client, test_database, login_as):
     body = response.get_json()
     assert len(body["data"]) == 5
     assert body["data"][0]["dataset_type"] == body["data"][1]["dataset_type"] == "WGS"
+
+    response = client.get("/api/datasets?order_by=sequencing_id&order_dir=asc")
+    assert response.status_code == 200
+    body = response.get_json()
+    assert len(body["data"]) == 5
+    assert body["data"][0]["sequencing_id"] == None
+    assert body["data"][1]["sequencing_id"] == "2"
+
+    response = client.get("/api/datasets?order_by=sequencing_id&order_dir=desc")
+    assert response.status_code == 200
+    body = response.get_json()
+    assert len(body["data"]) == 5
+    assert body["data"][0]["sequencing_id"] == "5"
 
 
 def test_dataset_order_by_related_column(client, test_database, login_as):

--- a/react/src/Datasets/components/DatasetTable.tsx
+++ b/react/src/Datasets/components/DatasetTable.tsx
@@ -189,6 +189,10 @@ export default function DatasetTable() {
                 editable: "never",
                 defaultFilter: paramID,
             },
+            {
+                title: "Sequencing ID",
+                field: "sequencing_id",
+            },
         ];
         if (currentUser.is_admin || currentUser.groups.length > 1) {
             columns.push({


### PR DESCRIPTION
Added a column `sequencing_id` to the dataset table. The column can be sorted and filtered. Added test cases in test_datasets.py. Added field `sequencing_id` to the global test cases in conftest.py. 

Comment: Currently, only 4 datasets for pytest are documented in flask.md, should we update flask.md? There are 5 datasets in conftest.py. 