### PR TITLE
React: Exact search toggle for family and participant codenames

### DIFF
--- a/react/src/Datasets/components/DatasetTable.tsx
+++ b/react/src/Datasets/components/DatasetTable.tsx
@@ -363,12 +363,6 @@ export default function DatasetTable() {
                                                         "dataset_type",
                                                         datasetTypes
                                                     );
-                                                    console.log(
-                                                        "UPDATINGGGG",
-                                                        MTRef,
-                                                        "dataset_type",
-                                                        datasetTypes
-                                                    );
                                                 }}
                                                 clickable
                                                 className={classes.chip}

--- a/react/src/Datasets/components/DatasetTable.tsx
+++ b/react/src/Datasets/components/DatasetTable.tsx
@@ -11,6 +11,7 @@ import {
     DateFilterComponent,
     DateTimeText,
     EditNotes,
+    ExactMatchFilterToggle,
     FileLinkingComponent,
     MaterialTablePrimary,
     Note,
@@ -138,8 +139,18 @@ export default function DatasetTable() {
 
     const columns = useMemo(() => {
         const columns: Column<Dataset>[] = [
-            { title: "Family", field: "family_codename", editable: "never" },
-            { title: "Participant", field: "participant_codename", editable: "never" },
+            {
+                title: "Family",
+                field: "family_codename",
+                editable: "never",
+                filterComponent: props => <ExactMatchFilterToggle MTRef={MTRef} {...props} />,
+            },
+            {
+                title: "Participant",
+                field: "participant_codename",
+                editable: "never",
+                filterComponent: props => <ExactMatchFilterToggle MTRef={MTRef} {...props} />,
+            },
             {
                 title: "Tissue Sample",
                 field: "tissue_sample_type",
@@ -346,13 +357,19 @@ export default function DatasetTable() {
                                             <Chip
                                                 key={metatype}
                                                 label={metatype}
-                                                onClick={() =>
+                                                onClick={() => {
                                                     updateTableFilter(
                                                         MTRef,
                                                         "dataset_type",
                                                         datasetTypes
-                                                    )
-                                                }
+                                                    );
+                                                    console.log(
+                                                        "UPDATINGGGG",
+                                                        MTRef,
+                                                        "dataset_type",
+                                                        datasetTypes
+                                                    );
+                                                }}
                                                 clickable
                                                 className={classes.chip}
                                             />

--- a/react/src/Participants/components/ParticipantTable.tsx
+++ b/react/src/Participants/components/ParticipantTable.tsx
@@ -10,6 +10,7 @@ import {
     DateFilterComponent,
     DateTimeText,
     EditNotes,
+    ExactMatchFilterToggle,
     MaterialTablePrimary,
     Note,
 } from "../../components";
@@ -81,11 +82,13 @@ export default function ParticipantTable() {
                 title: "Family Codename",
                 field: "family_codename",
                 editable: "never",
+                filterComponent: props => <ExactMatchFilterToggle MTRef={tableRef} {...props} />,
             },
             {
                 title: "Participant Codename",
                 field: "participant_codename",
                 defaultFilter: paramID,
+                filterComponent: props => <ExactMatchFilterToggle MTRef={tableRef} {...props} />,
             },
             {
                 title: "Participant Type",

--- a/react/src/components/DetailSection.tsx
+++ b/react/src/components/DetailSection.tsx
@@ -122,7 +122,6 @@ export default function DetailSection(props: DetailSectionProps) {
         });
         if (response.ok) {
             const data = await response.json();
-            console.log(data);
             if (props.dataInfo?.onUpdate) props.dataInfo!.onUpdate(props.dataInfo.ID, data);
             enqueueSnackbar(
                 `${props.dataInfo?.type.replace(/$(\w)/g, "$&".toUpperCase())} ${

--- a/react/src/components/ExactMatchFilterToggle.tsx
+++ b/react/src/components/ExactMatchFilterToggle.tsx
@@ -1,0 +1,70 @@
+import React, { useEffect, useState } from "react";
+import { Column } from "@material-table/core";
+import {
+    FormGroup,
+    FormHelperText,
+    InputAdornment,
+    makeStyles,
+    Switch,
+    TextField,
+} from "@material-ui/core";
+import { FilterList } from "@material-ui/icons";
+import { updateTableFilter } from "../functions";
+import { Dataset } from "../typings";
+
+const useStyles = makeStyles(theme => ({
+    root: {
+        marginBottom: theme.spacing(1.5),
+    },
+}));
+
+interface ExactMatchFilterToggleProps {
+    MTRef: React.MutableRefObject<any>;
+    columnDef: Column<Dataset>;
+    onFilterChanged: (rowId: string, value: any) => void;
+}
+
+export default function ExactMatchFilterToggle(props: ExactMatchFilterToggleProps) {
+    const classes = useStyles();
+    const [exactMatch, setExactMatch] = useState<boolean>(false);
+
+    useEffect(() => {
+        updateTableFilter(
+            props.MTRef,
+            `${props.columnDef.field}_exact_match`,
+            exactMatch.toString()
+        );
+    }, [props.MTRef, props.columnDef.field, exactMatch]);
+
+    return (
+        <>
+            <FormGroup className={classes.root}>
+                <FormHelperText>Exact match</FormHelperText>
+                <Switch size="small" onChange={event => setExactMatch(event.target.checked)} />
+            </FormGroup>
+            <TextField
+                id="input-with-icon-textfield"
+                onChange={event => {
+                    props.onFilterChanged(
+                        (props.columnDef as any).tableData.id,
+                        event.target.value
+                    );
+                }}
+                InputProps={{
+                    startAdornment: (
+                        <InputAdornment position="start">
+                            <FilterList />
+                        </InputAdornment>
+                    ),
+                }}
+                variant="standard"
+            />
+        </>
+    );
+}
+
+//   updateTableFilter(
+//     MTRef,
+//     "dataset_type",
+//     datasetTypes
+// )

--- a/react/src/components/ExactMatchFilterToggle.tsx
+++ b/react/src/components/ExactMatchFilterToggle.tsx
@@ -9,8 +9,8 @@ import {
     TextField,
 } from "@material-ui/core";
 import { FilterList } from "@material-ui/icons";
-import { updateTableFilter } from "../functions";
-import { Dataset } from "../typings";
+import { updateSearchTypeAndRequery } from "../functions";
+import { Dataset, Participant } from "../typings";
 
 const useStyles = makeStyles(theme => ({
     root: {
@@ -20,7 +20,7 @@ const useStyles = makeStyles(theme => ({
 
 interface ExactMatchFilterToggleProps {
     MTRef: React.MutableRefObject<any>;
-    columnDef: Column<Dataset>;
+    columnDef: Column<Participant> | Column<Dataset>;
     onFilterChanged: (rowId: string, value: any) => void;
 }
 
@@ -29,11 +29,12 @@ export default function ExactMatchFilterToggle(props: ExactMatchFilterToggleProp
     const [exactMatch, setExactMatch] = useState<boolean>(false);
 
     useEffect(() => {
-        updateTableFilter(
-            props.MTRef,
-            `${props.columnDef.field}_exact_match`,
-            exactMatch.toString()
-        );
+        if (props.columnDef.field) {
+            updateSearchTypeAndRequery(props.MTRef, {
+                column: props.columnDef.field,
+                exact: exactMatch,
+            });
+        }
     }, [props.MTRef, props.columnDef.field, exactMatch]);
 
     return (

--- a/react/src/components/ExactMatchFilterToggle.tsx
+++ b/react/src/components/ExactMatchFilterToggle.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from "react";
 import { Column } from "@material-table/core";
-import { InputAdornment, makeStyles, Switch, TextField, Tooltip } from "@material-ui/core";
+import { Checkbox, InputAdornment, makeStyles, TextField, Tooltip } from "@material-ui/core";
 import { FilterList } from "@material-ui/icons";
 import { updateSearchTypeAndRequery } from "../functions";
 import { Dataset, Participant } from "../typings";
@@ -11,13 +11,13 @@ interface ExactMatchFilterToggleProps {
     onFilterChanged: (rowId: string, value: any) => void;
 }
 
-const useStyles = makeStyles(theme => ({
+const useStyles = makeStyles(() => ({
     input: {
         "& .MuiInputBase-input": {
             width: 30,
             "&:focus": {
                 width: 120,
-                transition: "ease-in-out, width 0.35s ease-in-out",
+                transition: "width 0.35s ease-in-out",
             },
         },
     },
@@ -53,7 +53,7 @@ export default function ExactMatchFilterToggle(props: ExactMatchFilterToggleProp
                 ),
                 endAdornment: (
                     <Tooltip title="Only show exact match">
-                        <Switch
+                        <Checkbox
                             color="primary"
                             size="small"
                             onChange={event => setExactMatch(event.target.checked)}

--- a/react/src/components/ExactMatchFilterToggle.tsx
+++ b/react/src/components/ExactMatchFilterToggle.tsx
@@ -63,9 +63,3 @@ export default function ExactMatchFilterToggle(props: ExactMatchFilterToggleProp
         </>
     );
 }
-
-//   updateTableFilter(
-//     MTRef,
-//     "dataset_type",
-//     datasetTypes
-// )

--- a/react/src/components/ExactMatchFilterToggle.tsx
+++ b/react/src/components/ExactMatchFilterToggle.tsx
@@ -11,7 +11,20 @@ interface ExactMatchFilterToggleProps {
     onFilterChanged: (rowId: string, value: any) => void;
 }
 
+const useStyles = makeStyles(theme => ({
+    input: {
+        "& .MuiInputBase-input": {
+            width: 30,
+            "&:focus": {
+                width: 120,
+                transition: "ease-in-out, width 0.35s ease-in-out",
+            },
+        },
+    },
+}));
+
 export default function ExactMatchFilterToggle(props: ExactMatchFilterToggleProps) {
+    const classes = useStyles();
     const [exactMatch, setExactMatch] = useState<boolean>(false);
 
     useEffect(() => {
@@ -25,11 +38,14 @@ export default function ExactMatchFilterToggle(props: ExactMatchFilterToggleProp
 
     return (
         <TextField
+            autoFocus
+            className={classes.input}
             id="input-with-icon-textfield"
             onChange={event => {
                 props.onFilterChanged((props.columnDef as any).tableData.id, event.target.value);
             }}
             InputProps={{
+                autoFocus: true,
                 startAdornment: (
                     <InputAdornment position="start">
                         <FilterList />

--- a/react/src/components/ExactMatchFilterToggle.tsx
+++ b/react/src/components/ExactMatchFilterToggle.tsx
@@ -1,22 +1,9 @@
 import React, { useEffect, useState } from "react";
 import { Column } from "@material-table/core";
-import {
-    FormGroup,
-    FormHelperText,
-    InputAdornment,
-    makeStyles,
-    Switch,
-    TextField,
-} from "@material-ui/core";
+import { InputAdornment, makeStyles, Switch, TextField, Tooltip } from "@material-ui/core";
 import { FilterList } from "@material-ui/icons";
 import { updateSearchTypeAndRequery } from "../functions";
 import { Dataset, Participant } from "../typings";
-
-const useStyles = makeStyles(theme => ({
-    root: {
-        marginBottom: theme.spacing(1.5),
-    },
-}));
 
 interface ExactMatchFilterToggleProps {
     MTRef: React.MutableRefObject<any>;
@@ -25,7 +12,6 @@ interface ExactMatchFilterToggleProps {
 }
 
 export default function ExactMatchFilterToggle(props: ExactMatchFilterToggleProps) {
-    const classes = useStyles();
     const [exactMatch, setExactMatch] = useState<boolean>(false);
 
     useEffect(() => {
@@ -38,28 +24,28 @@ export default function ExactMatchFilterToggle(props: ExactMatchFilterToggleProp
     }, [props.MTRef, props.columnDef.field, exactMatch]);
 
     return (
-        <>
-            <FormGroup className={classes.root}>
-                <FormHelperText>Exact match</FormHelperText>
-                <Switch size="small" onChange={event => setExactMatch(event.target.checked)} />
-            </FormGroup>
-            <TextField
-                id="input-with-icon-textfield"
-                onChange={event => {
-                    props.onFilterChanged(
-                        (props.columnDef as any).tableData.id,
-                        event.target.value
-                    );
-                }}
-                InputProps={{
-                    startAdornment: (
-                        <InputAdornment position="start">
-                            <FilterList />
-                        </InputAdornment>
-                    ),
-                }}
-                variant="standard"
-            />
-        </>
+        <TextField
+            id="input-with-icon-textfield"
+            onChange={event => {
+                props.onFilterChanged((props.columnDef as any).tableData.id, event.target.value);
+            }}
+            InputProps={{
+                startAdornment: (
+                    <InputAdornment position="start">
+                        <FilterList />
+                    </InputAdornment>
+                ),
+                endAdornment: (
+                    <Tooltip title="Only show exact match">
+                        <Switch
+                            color="primary"
+                            size="small"
+                            onChange={event => setExactMatch(event.target.checked)}
+                        />
+                    </Tooltip>
+                ),
+            }}
+            variant="standard"
+        />
     );
 }

--- a/react/src/components/ExactMatchFilterToggle.tsx
+++ b/react/src/components/ExactMatchFilterToggle.tsx
@@ -1,7 +1,6 @@
 import React, { useEffect, useState } from "react";
 import { Column } from "@material-table/core";
-import { Checkbox, InputAdornment, makeStyles, TextField, Tooltip } from "@material-ui/core";
-import { FilterList } from "@material-ui/icons";
+import { Checkbox, makeStyles, TextField, Tooltip } from "@material-ui/core";
 import { updateSearchTypeAndRequery } from "../functions";
 import { Dataset, Participant } from "../typings";
 
@@ -14,7 +13,7 @@ interface ExactMatchFilterToggleProps {
 const useStyles = makeStyles(() => ({
     input: {
         "& .MuiInputBase-input": {
-            width: 30,
+            width: 60,
             "&:focus": {
                 width: 120,
                 transition: "width 0.35s ease-in-out",
@@ -38,20 +37,13 @@ export default function ExactMatchFilterToggle(props: ExactMatchFilterToggleProp
 
     return (
         <TextField
-            autoFocus
             className={classes.input}
             id="input-with-icon-textfield"
             onChange={event => {
                 props.onFilterChanged((props.columnDef as any).tableData.id, event.target.value);
             }}
             InputProps={{
-                autoFocus: true,
                 startAdornment: (
-                    <InputAdornment position="start">
-                        <FilterList />
-                    </InputAdornment>
-                ),
-                endAdornment: (
                     <Tooltip title="Only show exact match">
                         <Checkbox
                             color="primary"

--- a/react/src/components/index.tsx
+++ b/react/src/components/index.tsx
@@ -17,6 +17,7 @@ export { default as DateTimeText } from "./DateTimeText";
 export { default as DetailSection } from "./DetailSection";
 export { default as DialogHeader } from "./DialogHeader";
 export { default as EditNotes } from "./EditNotes";
+export { default as ExactMatchFilterToggle } from "./ExactMatchFilterToggle";
 export { default as FieldDisplay } from "./FieldDisplay";
 export { default as FieldDisplayEditable } from "./FieldDisplayEditable";
 export { default as GridFieldsDisplay } from "./GridFieldsDisplay";

--- a/react/src/functions.tsx
+++ b/react/src/functions.tsx
@@ -401,9 +401,6 @@ export const updateSearchTypeAndRequery = (
     searchTypeOptions: SearchType
 ) => {
     const oldQuery = tableRef.current.state.query;
-    if (oldQuery.searchType) {
-        tableRef.current.state.query.searchType.push(searchTypeOptions);
-    }
     tableRef.current.state.query = { ...oldQuery, searchType: [searchTypeOptions] };
     tableRef.current.onQueryChange();
 };

--- a/react/src/functions.tsx
+++ b/react/src/functions.tsx
@@ -17,6 +17,7 @@ import {
     PipelineStatus,
     PseudoBoolean,
     PseudoBooleanReadableMap,
+    SearchType,
 } from "./typings";
 
 dayjs.extend(utc);
@@ -366,12 +367,8 @@ export const updateTableFilter = (
     column: string,
     filterVal: string | string[]
 ) => {
-    console.log("hiiiii");
-    console.log(tableRef, column, filterVal);
     if (tableRef.current) {
-        console.log(tableRef.current);
         const col = tableRef.current.dataManager.columns.find((c: any) => c.field === column);
-        console.log(col);
         if (col) {
             col.tableData.filterValue = filterVal;
             updateFiltersAndRequery(tableRef);
@@ -391,6 +388,27 @@ export const updateFiltersAndRequery = (tableRef: React.MutableRefObject<any>) =
     // sometimes with lots of filters we see timing issues, maybe b/c of mt's internal callbacks?
     // if we move the requery step to the next tick the issues seem to go away
     setTimeout(() => tableRef.current.onQueryChange);
+};
+
+/**
+ * Material Table has a state that stores a query object (See MTQuery)
+ * We want to add an extra property to this object (searchType: [{
+ *  field: "participant_codename"
+ * exactSearch: true
+ * }])
+ * @param tableRef
+ */
+
+export const updateSearchTypeAndRequery = (
+    tableRef: React.MutableRefObject<any>,
+    searchTypeOptions: SearchType
+) => {
+    const oldQuery = tableRef.current.state.query;
+    if (oldQuery.searchType) {
+        tableRef.current.state.query.searchType.push(searchTypeOptions);
+    }
+    tableRef.current.state.query = { ...oldQuery, searchType: [searchTypeOptions] };
+    tableRef.current.onQueryChange();
 };
 
 /**

--- a/react/src/functions.tsx
+++ b/react/src/functions.tsx
@@ -391,12 +391,9 @@ export const updateFiltersAndRequery = (tableRef: React.MutableRefObject<any>) =
 };
 
 /**
- * Material Table has a state that stores a query object (See MTQuery)
- * We want to add an extra property to this object (searchType: [{
- *  field: "participant_codename"
- * exactSearch: true
- * }])
- * @param tableRef
+ * Update a material-table query from outside the table
+ * Material Table has its own state that stores a query object.
+ * We want to add an extra property to this object to enable exact match query for participant and family codename.
  */
 
 export const updateSearchTypeAndRequery = (

--- a/react/src/functions.tsx
+++ b/react/src/functions.tsx
@@ -366,8 +366,12 @@ export const updateTableFilter = (
     column: string,
     filterVal: string | string[]
 ) => {
+    console.log("hiiiii");
+    console.log(tableRef, column, filterVal);
     if (tableRef.current) {
+        console.log(tableRef.current);
         const col = tableRef.current.dataManager.columns.find((c: any) => c.field === column);
+        console.log(col);
         if (col) {
             col.tableData.filterValue = filterVal;
             updateFiltersAndRequery(tableRef);

--- a/react/src/hooks/datasets/useDatasetsPage.tsx
+++ b/react/src/hooks/datasets/useDatasetsPage.tsx
@@ -7,6 +7,7 @@ import { queryTableData } from "../utils";
 export const GET_DATASETS_URL = "/api/datasets";
 
 async function fetchDatasets(query: Query<Dataset>) {
+    console.log("QUERY", query);
     const queryResult = await queryTableData(query, GET_DATASETS_URL);
     return queryResult;
 }
@@ -18,7 +19,6 @@ async function fetchDatasets(query: Query<Dataset>) {
  */
 export function useDatasetsPage() {
     const queryClient = useQueryClient();
-
     return async (query: Query<Dataset>) => {
         return await queryClient.fetchQuery<QueryResult<Dataset>, Error>(["datasets", query], () =>
             fetchDatasets(query)

--- a/react/src/hooks/datasets/useDatasetsPage.tsx
+++ b/react/src/hooks/datasets/useDatasetsPage.tsx
@@ -1,13 +1,12 @@
-import { Query, QueryResult } from "@material-table/core";
+import { QueryResult } from "@material-table/core";
 import { useQueryClient } from "react-query";
-import { Dataset } from "../../typings";
+import { Dataset, QueryWithSearchOptions } from "../../typings";
 
 import { queryTableData } from "../utils";
 
 export const GET_DATASETS_URL = "/api/datasets";
 
-async function fetchDatasets(query: Query<Dataset>) {
-    console.log("QUERY", query);
+async function fetchDatasets(query: QueryWithSearchOptions<Dataset>) {
     const queryResult = await queryTableData(query, GET_DATASETS_URL);
     return queryResult;
 }
@@ -19,7 +18,7 @@ async function fetchDatasets(query: Query<Dataset>) {
  */
 export function useDatasetsPage() {
     const queryClient = useQueryClient();
-    return async (query: Query<Dataset>) => {
+    return async (query: QueryWithSearchOptions<Dataset>) => {
         return await queryClient.fetchQuery<QueryResult<Dataset>, Error>(["datasets", query], () =>
             fetchDatasets(query)
         );

--- a/react/src/hooks/utils.tsx
+++ b/react/src/hooks/utils.tsx
@@ -75,6 +75,7 @@ export async function queryTableData<RowData extends object>(
     url: string
 ): Promise<QueryResult<RowData>> {
     const searchParams = new URLSearchParams(getSearchParamsFromMaterialTableQuery(query));
+    console.log("SEARCH PARAMS", searchParams);
     const response = await fetch(url + "?" + searchParams.toString());
     if (response.ok) {
         const result = await response.json();
@@ -130,7 +131,7 @@ export const getSearchParamsFromMaterialTableQuery = <RowData extends object>(
     if (search) {
         searchParams.search = search;
     }
-
+    console.log("PARAMSSS", searchParams);
     return searchParams;
 };
 

--- a/react/src/typings.tsx
+++ b/react/src/typings.tsx
@@ -1,3 +1,5 @@
+import { Column, ErrorState, Filter } from "@material-table/core";
+
 /*****   TYPES   *****/
 export type Counts = { [key: string]: number };
 export type KeyValue = { [key: string]: string };
@@ -281,6 +283,23 @@ export interface Option {
     origin?: string;
     disabled?: boolean;
     selected?: boolean;
+}
+
+export interface SearchType {
+    column: string;
+    exact: boolean;
+}
+
+export interface QueryWithSearchOptions<RowData extends object> {
+    filters: Filter<RowData>[];
+    page: number;
+    pageSize: number;
+    totalCount: number;
+    search: string;
+    orderBy: Column<RowData>;
+    orderDirection: "asc" | "desc";
+    error?: ErrorState;
+    searchType?: SearchType[];
 }
 
 export interface GeneAlias {

--- a/react/src/typings.tsx
+++ b/react/src/typings.tsx
@@ -1,5 +1,4 @@
-import { Column, ErrorState, Filter } from "@material-table/core";
-
+import { Query } from "@material-table/core";
 /*****   TYPES   *****/
 export type Counts = { [key: string]: number };
 export type KeyValue = { [key: string]: string };
@@ -290,15 +289,7 @@ export interface SearchType {
     exact: boolean;
 }
 
-export interface QueryWithSearchOptions<RowData extends object> {
-    filters: Filter<RowData>[];
-    page: number;
-    pageSize: number;
-    totalCount: number;
-    search: string;
-    orderBy: Column<RowData>;
-    orderDirection: "asc" | "desc";
-    error?: ErrorState;
+export interface QueryWithSearchOptions<RowData extends object> extends Query<RowData> {
     searchType?: SearchType[];
 }
 


### PR DESCRIPTION
- material-table stores an internal query object in its state (source code [here](https://github.com/mbrn/material-table/blob/42d966eacdbe47cd176f9c5c68e3d97b126b489e/src/material-table.js#L28)). This query object is internally updated by material-table whenever table properties are changed, such as when the user is filtering. 
- The approach I took was to add an additional property to this query object called `searchType` to programmatically enable exact match search when user toggles a switch. When the state of the switch changes, `onQueryChange()` is called on the table ref to requery. 