### PR TITLE
CI: rewrite frontend workflow to use separate environments for security

### DIFF
--- a/.github/workflows/react.yml
+++ b/.github/workflows/react.yml
@@ -1,4 +1,25 @@
 name: Build, lint, and deploy frontend
+description: |
+  Runs package scripts on pull requests and commits to master affecting the frontend
+  or this workflow itself. Dependencies are cached in Actions to reduce runtime.
+  Frontend tests may optionally be added.
+
+  Commits to master can access secrets stored in GitHub Environments on this repository
+  to deploy into a MinIO bucket. This is a self-hosted solution equivalent to static sites
+  hosted out of Amazon S3. For this deploy job to start, a reviewer must further approve
+  the deployment for the workflow run under the Actions tab.
+  
+  Environments can be managed in the Settings tab (https://github.com/ccmbioinfo/stager/settings/environments)
+  To add a new environment or rotate secrets for an existing one:
+  - create a bucket to host the built static files
+  - set an anonymous read access policy on the bucket
+  - create an IAM policy that can read and write to the bucket
+  - create a machine user with a securely-generated password and apply the above policy
+  - set environment secret DEPLOY_MINIO_BUCKET to the name of the designated bucket
+  - set environment secret DEPLOY_MC_HOST to https://MACHINE_USER_ACCESS_KEY:GENERATED_SECRET_KEY@minio.domain
+  
+  The REACT_APP_EMAIL and REACT_APP_MINIO_URL may or may not vary by environment,
+  but they are just build parameters.
 on:
   push:
     branches:
@@ -50,7 +71,7 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     needs: build
-    # if: github.event_name == 'push'
+    if: github.event_name == 'push'
     strategy:
       matrix:
         environment:
@@ -79,8 +100,7 @@ jobs:
     - run: yarn install # should never happen due to build job
       if: steps.restore.outputs.cache-hit != 'true'
     # End setup
-    - name: Build
-      run: yarn build
+    - run: yarn build
       env:
         REACT_APP_NAME: Stager
         REACT_APP_EMAIL: ${{ secrets.REACT_APP_EMAIL }}

--- a/.github/workflows/react.yml
+++ b/.github/workflows/react.yml
@@ -50,7 +50,7 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     needs: build
-    if: github.event_name == 'push'
+    # if: github.event_name == 'push'
     strategy:
       matrix:
         environment:
@@ -87,8 +87,8 @@ jobs:
         REACT_APP_MINIO_URL: ${{ secrets.REACT_APP_MINIO_URL }}
     - name: Deploy
       env:
-        MC_HOST_minio: ${{ secrets.MC_HOST }}
+        MC_HOST_minio: ${{ secrets.DEPLOY_MC_HOST }}
       run: |
         sudo curl --output /usr/local/bin/mc https://dl.min.io/client/mc/release/linux-amd64/mc
         sudo chmod +x /usr/local/bin/mc
-        ./deploy.sh minio ${{ secrets.MINIO_BUCKET }}
+        ./deploy.sh minio ${{ secrets.DEPLOY_MINIO_BUCKET }}

--- a/.github/workflows/react.yml
+++ b/.github/workflows/react.yml
@@ -1,25 +1,24 @@
 name: Build, lint, and deploy frontend
-description: |
-  Runs package scripts on pull requests and commits to master affecting the frontend
-  or this workflow itself. Dependencies are cached in Actions to reduce runtime.
-  Frontend tests may optionally be added.
-
-  Commits to master can access secrets stored in GitHub Environments on this repository
-  to deploy into a MinIO bucket. This is a self-hosted solution equivalent to static sites
-  hosted out of Amazon S3. For this deploy job to start, a reviewer must further approve
-  the deployment for the workflow run under the Actions tab.
-  
-  Environments can be managed in the Settings tab (https://github.com/ccmbioinfo/stager/settings/environments)
-  To add a new environment or rotate secrets for an existing one:
-  - create a bucket to host the built static files
-  - set an anonymous read access policy on the bucket
-  - create an IAM policy that can read and write to the bucket
-  - create a machine user with a securely-generated password and apply the above policy
-  - set environment secret DEPLOY_MINIO_BUCKET to the name of the designated bucket
-  - set environment secret DEPLOY_MC_HOST to https://MACHINE_USER_ACCESS_KEY:GENERATED_SECRET_KEY@minio.domain
-  
-  The REACT_APP_EMAIL and REACT_APP_MINIO_URL may or may not vary by environment,
-  but they are just build parameters.
+# Runs package scripts on pull requests and commits to master affecting the frontend
+# or this workflow itself. Dependencies are cached in Actions to reduce runtime.
+# Frontend tests may optionally be added.
+#
+# Commits to master can access secrets stored in GitHub Environments on this repository
+# to deploy into a MinIO bucket. This is a self-hosted solution equivalent to static sites
+# hosted out of Amazon S3. For this deploy job to start, a reviewer must further approve
+# the deployment for the workflow run under the Actions tab.
+# 
+# Environments can be managed in the Settings tab (https://github.com/ccmbioinfo/stager/settings/environments)
+# To add a new environment or rotate secrets for an existing one:
+# - create a bucket to host the built static files
+# - set an anonymous read access policy on the bucket
+# - create an IAM policy that can read and write to the bucket
+# - create a machine user with a securely-generated password and apply the above policy
+# - set environment secret DEPLOY_MINIO_BUCKET to the name of the designated bucket
+# - set environment secret DEPLOY_MC_HOST to https://MACHINE_USER_ACCESS_KEY:GENERATED_SECRET_KEY@minio.domain
+# 
+# The REACT_APP_EMAIL and REACT_APP_MINIO_URL may or may not vary by environment,
+# but they are just build parameters.
 on:
   push:
     branches:

--- a/.github/workflows/react.yml
+++ b/.github/workflows/react.yml
@@ -1,4 +1,4 @@
-name: Compile and lint frontend
+name: Build, lint, and deploy frontend
 on:
   push:
     branches:
@@ -12,13 +12,14 @@ on:
     paths:
       - .github/workflows/react.yml
       - react/**/*
+defaults:
+  runs-on: ubuntu-latest
+  run:
+    working-directory: react
 jobs:
   build:
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: react
     steps:
+    # Identical setup steps between jobs
     - uses: actions/checkout@v2
     - uses: actions/setup-node@v2
       with:
@@ -37,32 +38,56 @@ jobs:
           ${{ runner.os }}-yarn-
     - run: yarn install
       if: steps.restore.outputs.cache-hit != 'true'
-    - name: Build (CCM-DEV)
+    # End setup
+    - run: yarn build
+      env:
+        REACT_APP_NAME: Stager
+        REACT_APP_EMAIL: placeholder@example.ca
+        REACT_APP_MINIO_URL: https://minio.example.ca/
+    - run: yarn lint
+    - run: yarn check-format
+    # - run: yarn test --coverage
+  deploy:
+    needs: build
+    if: github.event_name == 'push'
+    strategy:
+      matrix:
+        environment:
+        - CCM-DEV
+        - CHEO-RI
+    environment: ${{ matrix.environment }}
+    concurrency: ${{ matrix.environment }}
+    steps:
+    # Identical setup steps between jobs
+    - uses: actions/checkout@v2
+    - uses: actions/setup-node@v2
+      with:
+        node-version: 14
+    - name: Get yarn cache path
+      id: yarn-cache-path
+      run: echo "::set-output name=dir::$(yarn cache dir)"
+    - uses: actions/cache@v2
+      id: restore
+      with:
+        path: |
+          ${{ steps.yarn-cache-path.outputs.dir }}
+          react/node_modules
+        key: ${{ runner.os }}-yarn-${{ hashFiles('react/yarn.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-yarn-
+    - run: yarn install # should never happen due to build job
+      if: steps.restore.outputs.cache-hit != 'true'
+    # End setup
+    - name: Build
       run: yarn build
       env:
         REACT_APP_NAME: Stager
         REACT_APP_EMAIL: ${{ secrets.REACT_APP_EMAIL }}
-        REACT_APP_MINIO_URL: ${{ secrets.CCM_DEV_REACT_APP_MINIO_URL }}
-    - run: yarn lint
-    - run: yarn check-format
-    # - run: yarn test -- --coverage
-    - name: Deploy (CCM-DEV)
-      if: github.event_name == 'push'
+        REACT_APP_MINIO_URL: ${{ secrets.REACT_APP_MINIO_URL }}
+    - name: Deploy
       env:
-        MC_HOST_minio: ${{ secrets.CCM_DEV_MC_HOST }}
+        MC_HOST_minio: ${{ secrets.MC_HOST }}
       run: |
         sudo curl --output /usr/local/bin/mc https://dl.min.io/client/mc/release/linux-amd64/mc
         sudo chmod +x /usr/local/bin/mc
-        ./deploy.sh minio ${{ secrets.CCM_DEV_MINIO_BUCKET }}
-    - name: Build (CHEO-RI)
-      if: github.event_name == 'push'
-      run: yarn build
-      env:
-        REACT_APP_NAME: Stager
-        REACT_APP_EMAIL: ${{ secrets.REACT_APP_EMAIL }}
-        REACT_APP_MINIO_URL: ${{ secrets.CHEO_RI_REACT_APP_MINIO_URL }}
-    - name: Deploy (CHEO-RI)
-      if: github.event_name == 'push'
-      env:
-        MC_HOST_minio: ${{ secrets.CHEO_RI_MC_HOST }}
-      run: ./deploy.sh minio ${{ secrets.CHEO_RI_MINIO_BUCKET }}
+        ./deploy.sh minio ${{ secrets.MINIO_BUCKET }}

--- a/.github/workflows/react.yml
+++ b/.github/workflows/react.yml
@@ -13,11 +13,11 @@ on:
       - .github/workflows/react.yml
       - react/**/*
 defaults:
-  runs-on: ubuntu-latest
   run:
     working-directory: react
 jobs:
   build:
+    runs-on: ubuntu-latest
     steps:
     # Identical setup steps between jobs
     - uses: actions/checkout@v2
@@ -48,6 +48,7 @@ jobs:
     - run: yarn check-format
     # - run: yarn test --coverage
   deploy:
+    runs-on: ubuntu-latest
     needs: build
     if: github.event_name == 'push'
     strategy:


### PR DESCRIPTION
I specifically added a branch protection rule to this branch to allow the deployment. When merged, we will need to change production to reverse proxy the new buckets and remove the old secrets and accounts.

For #835 