### PR TITLE
React/Flask: Fix datasets editing modal (#814)

### DIFF
--- a/flask/app/datasets.py
+++ b/flask/app/datasets.py
@@ -1,6 +1,5 @@
 from dataclasses import asdict
 from typing import List
-
 from flask import (
     Blueprint,
     Response,
@@ -9,11 +8,9 @@ from flask import (
     jsonify,
     request,
 )
-from sqlalchemy.sql.expression import update
 from flask_login import current_user, login_required
 from sqlalchemy import distinct, func
-from sqlalchemy.orm import contains_eager, joinedload, selectinload, with_polymorphic
-
+from sqlalchemy.orm import contains_eager, joinedload, selectinload
 from . import models
 from .extensions import db
 from .utils import (

--- a/flask/app/datasets.py
+++ b/flask/app/datasets.py
@@ -9,6 +9,7 @@ from flask import (
     jsonify,
     request,
 )
+from sqlalchemy.sql.expression import update
 from flask_login import current_user, login_required
 from sqlalchemy import distinct, func
 from sqlalchemy.orm import contains_eager, joinedload, selectinload, with_polymorphic
@@ -48,7 +49,6 @@ EDITABLE_COLUMNS = [
     "sequencing_date",
     "sequencing_centre",
     "batch_id",
-    "discriminator",
 ]
 
 datasets_blueprint = Blueprint(
@@ -461,7 +461,6 @@ def create_dataset():
             "batch_id": request.json.get("batch_id"),
             "created_by_id": created_by_id,
             "updated_by_id": updated_by_id,
-            "discriminator": request.json.get("discriminator"),
         }
     )
     # TODO: add stricter checks?

--- a/react/src/components/DetailSection.tsx
+++ b/react/src/components/DetailSection.tsx
@@ -156,7 +156,8 @@ export default function DetailSection(props: DetailSectionProps) {
             const data = await response.json();
             if (props.dataInfo?.onUpdate) props.dataInfo!.onUpdate(props.dataInfo.ID, data);
             enqueueSnackbar(
-                `${props.dataInfo?.type.replace(/$(\w)/g, "$&".toUpperCase())} ${props.dataInfo?.identifier
+                `${props.dataInfo?.type.replace(/$(\w)/g, "$&".toUpperCase())} ${
+                    props.dataInfo?.identifier
                 } updated successfully`,
                 {
                     variant: "success",

--- a/react/src/components/DetailSection.tsx
+++ b/react/src/components/DetailSection.tsx
@@ -98,11 +98,8 @@ export default function DetailSection(props: DetailSectionProps) {
             const field = fieldsOnEdit.find(element => element.fieldName === fieldName);
             if (!field) return;
 
-            if (field.fieldName === "read_length" && value === null) {
-                field.entryError = false;
-            } else if (field.fieldName === "read_length" && value.match(/^[0-9]+$/) != null) {
-                field.entryError = false;
-            } else if (field.fieldName === "read_length") {
+            field.entryError = false;
+            if (field.fieldName === "read_length" && value && value.match(/^[0-9]+$/) == null) {
                 field.entryError = true;
             }
 
@@ -159,8 +156,7 @@ export default function DetailSection(props: DetailSectionProps) {
             const data = await response.json();
             if (props.dataInfo?.onUpdate) props.dataInfo!.onUpdate(props.dataInfo.ID, data);
             enqueueSnackbar(
-                `${props.dataInfo?.type.replace(/$(\w)/g, "$&".toUpperCase())} ${
-                    props.dataInfo?.identifier
+                `${props.dataInfo?.type.replace(/$(\w)/g, "$&".toUpperCase())} ${props.dataInfo?.identifier
                 } updated successfully`,
                 {
                     variant: "success",

--- a/react/src/components/DetailSection.tsx
+++ b/react/src/components/DetailSection.tsx
@@ -10,15 +10,12 @@ import {
     Typography,
 } from "@material-ui/core";
 import { Check } from "@material-ui/icons";
-
 import dayjs from "dayjs";
 import customParseFormat from "dayjs/plugin/customParseFormat";
-
 import { useSnackbar } from "notistack";
 import { useErrorSnackbar } from "../hooks";
 import { Field } from "../typings";
 import GridFieldsDisplay, { Width } from "./GridFieldsDisplay";
-
 dayjs.extend(customParseFormat);
 
 const gridSpacing = 2;
@@ -156,8 +153,7 @@ export default function DetailSection(props: DetailSectionProps) {
             const data = await response.json();
             if (props.dataInfo?.onUpdate) props.dataInfo!.onUpdate(props.dataInfo.ID, data);
             enqueueSnackbar(
-                `${props.dataInfo?.type.replace(/$(\w)/g, "$&".toUpperCase())} ${
-                    props.dataInfo?.identifier
+                `${props.dataInfo?.type.replace(/$(\w)/g, "$&".toUpperCase())} ${props.dataInfo?.identifier
                 } updated successfully`,
                 {
                     variant: "success",

--- a/react/src/components/DetailSection.tsx
+++ b/react/src/components/DetailSection.tsx
@@ -130,9 +130,16 @@ export default function DetailSection(props: DetailSectionProps) {
                 // Due to the inconsistent refreshing/data update issue (#842),
                 // sometimes field.value is in ISO format -> else clause,
                 // sometimes field.value is in human readable format (eg: Wednesday, September 22, 2021 8:00 PM) -> if clause.
-                if (field.fieldName === "library_prep_date" && field.value != null && typeof field.value === "string" && (/[A-Z]/).test(field.value[0])) {
-                    field.value = field.value.substring(field.value.indexOf(',') + 2);
-                    newData[field.fieldName] = dayjs(field.value, 'MMMM D, YYYY h:mm A').format('YYYY-MM-D');
+                if (
+                    field.fieldName === "library_prep_date" &&
+                    field.value != null &&
+                    typeof field.value === "string" &&
+                    /[A-Z]/.test(field.value[0])
+                ) {
+                    field.value = field.value.substring(field.value.indexOf(",") + 2);
+                    newData[field.fieldName] = dayjs(field.value, "MMMM D, YYYY h:mm A").format(
+                        "YYYY-MM-D"
+                    );
                 } else {
                     newData[field.fieldName] = field.value;
                 }
@@ -147,7 +154,8 @@ export default function DetailSection(props: DetailSectionProps) {
             const data = await response.json();
             if (props.dataInfo?.onUpdate) props.dataInfo!.onUpdate(props.dataInfo.ID, data);
             enqueueSnackbar(
-                `${props.dataInfo?.type.replace(/$(\w)/g, "$&".toUpperCase())} ${props.dataInfo?.identifier
+                `${props.dataInfo?.type.replace(/$(\w)/g, "$&".toUpperCase())} ${
+                    props.dataInfo?.identifier
                 } updated successfully`,
                 {
                     variant: "success",

--- a/react/src/components/DetailSection.tsx
+++ b/react/src/components/DetailSection.tsx
@@ -127,7 +127,6 @@ export default function DetailSection(props: DetailSectionProps) {
         const newData: { [key: string]: any } = {};
         primaryFields.concat(secondaryFields).forEach(field => {
             if (field.fieldName && !field.disableEdit) {
-
                 // This is a temporary fix for 500 Server Error invoked when library_prep_date
                 // is sent to the backend. This is probably because library_prep_date
                 // is  stored in a non-ISO string format, although it should. This fix needs to be
@@ -160,7 +159,8 @@ export default function DetailSection(props: DetailSectionProps) {
             const data = await response.json();
             if (props.dataInfo?.onUpdate) props.dataInfo!.onUpdate(props.dataInfo.ID, data);
             enqueueSnackbar(
-                `${props.dataInfo?.type.replace(/$(\w)/g, "$&".toUpperCase())} ${props.dataInfo?.identifier
+                `${props.dataInfo?.type.replace(/$(\w)/g, "$&".toUpperCase())} ${
+                    props.dataInfo?.identifier
                 } updated successfully`,
                 {
                     variant: "success",

--- a/react/src/components/DetailSection.tsx
+++ b/react/src/components/DetailSection.tsx
@@ -127,6 +127,12 @@ export default function DetailSection(props: DetailSectionProps) {
         const newData: { [key: string]: any } = {};
         primaryFields.concat(secondaryFields).forEach(field => {
             if (field.fieldName && !field.disableEdit) {
+
+                // This is a temporary fix for 500 Server Error invoked when library_prep_date
+                // is sent to the backend. This is probably because library_prep_date
+                // is  stored in a non-ISO string format, although it should. This fix needs to be
+                // revisited after fixing the table non-refreshing issue (#842)
+
                 // Due to the inconsistent refreshing/data update issue (#842),
                 // sometimes field.value is in ISO format -> else clause,
                 // sometimes field.value is in human readable format (eg: Wednesday, September 22, 2021 8:00 PM) -> if clause.
@@ -154,8 +160,7 @@ export default function DetailSection(props: DetailSectionProps) {
             const data = await response.json();
             if (props.dataInfo?.onUpdate) props.dataInfo!.onUpdate(props.dataInfo.ID, data);
             enqueueSnackbar(
-                `${props.dataInfo?.type.replace(/$(\w)/g, "$&".toUpperCase())} ${
-                    props.dataInfo?.identifier
+                `${props.dataInfo?.type.replace(/$(\w)/g, "$&".toUpperCase())} ${props.dataInfo?.identifier
                 } updated successfully`,
                 {
                     variant: "success",

--- a/react/src/components/DetailSection.tsx
+++ b/react/src/components/DetailSection.tsx
@@ -153,7 +153,8 @@ export default function DetailSection(props: DetailSectionProps) {
             const data = await response.json();
             if (props.dataInfo?.onUpdate) props.dataInfo!.onUpdate(props.dataInfo.ID, data);
             enqueueSnackbar(
-                `${props.dataInfo?.type.replace(/$(\w)/g, "$&".toUpperCase())} ${props.dataInfo?.identifier
+                `${props.dataInfo?.type.replace(/$(\w)/g, "$&".toUpperCase())} ${
+                    props.dataInfo?.identifier
                 } updated successfully`,
                 {
                     variant: "success",

--- a/react/src/components/DetailSection.tsx
+++ b/react/src/components/DetailSection.tsx
@@ -91,6 +91,15 @@ export default function DetailSection(props: DetailSectionProps) {
 
             const field = fieldsOnEdit.find(element => element.fieldName === fieldName);
             if (!field) return;
+
+            if (field.fieldName === "read_length" && value === null) {
+                field.entryError = false;
+            } else if (field.fieldName === "read_length" && value.match(/^[0-9]+$/) != null) {
+                field.entryError = false;
+            } else if (field.fieldName === "read_length") {
+                field.entryError = true;
+            }
+
             const newField = {
                 ...field,
                 value: value,
@@ -124,8 +133,7 @@ export default function DetailSection(props: DetailSectionProps) {
             const data = await response.json();
             if (props.dataInfo?.onUpdate) props.dataInfo!.onUpdate(props.dataInfo.ID, data);
             enqueueSnackbar(
-                `${props.dataInfo?.type.replace(/$(\w)/g, "$&".toUpperCase())} ${
-                    props.dataInfo?.identifier
+                `${props.dataInfo?.type.replace(/$(\w)/g, "$&".toUpperCase())} ${props.dataInfo?.identifier
                 } updated successfully`,
                 {
                     variant: "success",

--- a/react/src/components/FieldDisplayEditable.tsx
+++ b/react/src/components/FieldDisplayEditable.tsx
@@ -63,6 +63,9 @@ function EnhancedTextField({
 
     // Props common to all variants
     const textFieldProps: TextFieldProps = {
+        error: field.entryError,
+        id: "standard-error",
+        helperText: field.entryError ? "Incorrect entry" : " ",
         className: classes.textField,
         fullWidth: true,
         margin: "dense",

--- a/react/src/components/FieldDisplayEditable.tsx
+++ b/react/src/components/FieldDisplayEditable.tsx
@@ -71,6 +71,7 @@ function EnhancedTextField({
         required: nonNullableFields.includes(field.fieldName),
         disabled: field.disableEdit,
         onChange: (e: TextFieldEvent) => onEdit(field.fieldName, e.target.value), // default
+        inputProps: { maxLength: field.maxLength },
     };
 
     // Props specific to each variant

--- a/react/src/functions.tsx
+++ b/react/src/functions.tsx
@@ -123,14 +123,31 @@ export function getDatasetFields(dataset: Dataset) {
         createFieldObj(
             "Participant Codename",
             dataset.participant_codename,
-            "participant_codename", true
+            "participant_codename",
+            true
         ),
-        createFieldObj("Participant Aliases", dataset.participant_aliases, "participant_aliases", true),
+        createFieldObj(
+            "Participant Aliases",
+            dataset.participant_aliases,
+            "participant_aliases",
+            true
+        ),
         createFieldObj("Family Codename", dataset.family_codename, "family_codename", true),
         createFieldObj("Family Aliases", dataset.family_aliases, "family_aliases", true),
         createFieldObj("Permission Groups", dataset.group_code.join(", "), "group_codes", true),
-        createFieldObj("Tissue Sample Type", dataset.tissue_sample_type, "tissue_sample_type", true),
-        createFieldObj("Sequencing Centre", dataset.sequencing_centre, "sequencing_centre", false, 100),
+        createFieldObj(
+            "Tissue Sample Type",
+            dataset.tissue_sample_type,
+            "tissue_sample_type",
+            true
+        ),
+        createFieldObj(
+            "Sequencing Centre",
+            dataset.sequencing_centre,
+            "sequencing_centre",
+            false,
+            100
+        ),
         createFieldObj("Notes", dataset.notes, "notes"),
         createFieldObj("Created", formatDateString(dataset.created), "created", true),
         createFieldObj("Created By", dataset.created_by, "created_by", true),
@@ -151,9 +168,21 @@ export function getSecDatasetFields(dataset: Dataset) {
             "linked_files"
         ),
         createFieldObj("Condition", dataset.condition, "condition"),
-        createFieldObj("Extraction Protocol", dataset.extraction_protocol, "extraction_protocol", false, 100),
+        createFieldObj(
+            "Extraction Protocol",
+            dataset.extraction_protocol,
+            "extraction_protocol",
+            false,
+            100
+        ),
         createFieldObj("Capture Kit", dataset.capture_kit, "capture_kit", false, 50),
-        createFieldObj("Library Prep Method", dataset.library_prep_method, "library_prep_method", false, 50),
+        createFieldObj(
+            "Library Prep Method",
+            dataset.library_prep_method,
+            "library_prep_method",
+            false,
+            50
+        ),
         createFieldObj(
             "Library Prep Date",
             formatDateString(dataset.library_prep_date),
@@ -212,7 +241,7 @@ export function createFieldObj(
     fieldName?: string,
     disableEdit?: boolean,
     maxLength?: number,
-    entryError?: boolean,
+    entryError?: boolean
 ): Field {
     return {
         title,

--- a/react/src/functions.tsx
+++ b/react/src/functions.tsx
@@ -165,7 +165,8 @@ export function getSecDatasetFields(dataset: Dataset) {
         createFieldObj(
             "Linked Files",
             dataset.linked_files.map(f => f.path),
-            "linked_files"
+            "linked_files",
+            true
         ),
         createFieldObj("Condition", dataset.condition, "condition"),
         createFieldObj(

--- a/react/src/functions.tsx
+++ b/react/src/functions.tsx
@@ -153,7 +153,6 @@ export function getSecDatasetFields(dataset: Dataset) {
         createFieldObj("Condition", dataset.condition, "condition"),
         createFieldObj("Extraction Protocol", dataset.extraction_protocol, "extraction_protocol"),
         createFieldObj("Capture Kit", dataset.capture_kit, "capture_kit"),
-        createFieldObj("Discriminator", dataset.discriminator, "discriminator"),
         createFieldObj("Library Prep Method", dataset.library_prep_method, "library_prep_method"),
         createFieldObj(
             "Library Prep Date",

--- a/react/src/functions.tsx
+++ b/react/src/functions.tsx
@@ -43,7 +43,7 @@ export function toKeyValue(items: string[]) {
  */
 export function formatDateString(date: string) {
     const datetime = dayjs.utc(date);
-    return datetime.isValid() ? datetime.local().format("LLLL") : null;
+    return datetime.isValid() ? datetime.format("LLLL") : null;
 }
 
 /**

--- a/react/src/functions.tsx
+++ b/react/src/functions.tsx
@@ -211,7 +211,8 @@ export function createFieldObj(
     value: FieldDisplayValueType,
     fieldName?: string,
     disableEdit?: boolean,
-    maxLength?: number
+    maxLength?: number,
+    entryError?: boolean,
 ): Field {
     return {
         title,
@@ -219,6 +220,7 @@ export function createFieldObj(
         fieldName,
         disableEdit,
         maxLength,
+        entryError,
     };
 }
 

--- a/react/src/functions.tsx
+++ b/react/src/functions.tsx
@@ -130,7 +130,7 @@ export function getDatasetFields(dataset: Dataset) {
         createFieldObj("Family Aliases", dataset.family_aliases, "family_aliases", true),
         createFieldObj("Permission Groups", dataset.group_code.join(", "), "group_codes", true),
         createFieldObj("Tissue Sample Type", dataset.tissue_sample_type, "tissue_sample_type", true),
-        createFieldObj("Sequencing Centre", dataset.sequencing_centre, "sequencing_centre"),
+        createFieldObj("Sequencing Centre", dataset.sequencing_centre, "sequencing_centre", false, 100),
         createFieldObj("Notes", dataset.notes, "notes"),
         createFieldObj("Created", formatDateString(dataset.created), "created", true),
         createFieldObj("Created By", dataset.created_by, "created_by", true),
@@ -144,22 +144,22 @@ export function getDatasetFields(dataset: Dataset) {
  */
 export function getSecDatasetFields(dataset: Dataset) {
     let fields = [
-        createFieldObj("Batch ID", dataset.batch_id, "batch_id"),
+        createFieldObj("Batch ID", dataset.batch_id, "batch_id", false, 50),
         createFieldObj(
             "Linked Files",
             dataset.linked_files.map(f => f.path),
             "linked_files"
         ),
         createFieldObj("Condition", dataset.condition, "condition"),
-        createFieldObj("Extraction Protocol", dataset.extraction_protocol, "extraction_protocol"),
-        createFieldObj("Capture Kit", dataset.capture_kit, "capture_kit"),
-        createFieldObj("Library Prep Method", dataset.library_prep_method, "library_prep_method"),
+        createFieldObj("Extraction Protocol", dataset.extraction_protocol, "extraction_protocol", false, 100),
+        createFieldObj("Capture Kit", dataset.capture_kit, "capture_kit", false, 50),
+        createFieldObj("Library Prep Method", dataset.library_prep_method, "library_prep_method", false, 50),
         createFieldObj(
             "Library Prep Date",
             formatDateString(dataset.library_prep_date),
             "library_prep_date"
         ),
-        createFieldObj("Read Length", dataset.read_length, "read_length"),
+        createFieldObj("Read Length", dataset.read_length, "read_length", false, 10),
         createFieldObj("Read Type", dataset.read_type, "read_type"),
     ];
 
@@ -210,13 +210,15 @@ export function createFieldObj(
     title: string,
     value: FieldDisplayValueType,
     fieldName?: string,
-    disableEdit?: boolean
+    disableEdit?: boolean,
+    maxLength?: number
 ): Field {
     return {
         title,
         value,
         fieldName,
         disableEdit,
+        maxLength,
     };
 }
 

--- a/react/src/functions.tsx
+++ b/react/src/functions.tsx
@@ -43,7 +43,7 @@ export function toKeyValue(items: string[]) {
  */
 export function formatDateString(date: string) {
     const datetime = dayjs.utc(date);
-    return datetime.isValid() ? datetime.local().format("LLLL") : "";
+    return datetime.isValid() ? datetime.local().format("LLLL") : null;
 }
 
 /**
@@ -123,19 +123,19 @@ export function getDatasetFields(dataset: Dataset) {
         createFieldObj(
             "Participant Codename",
             dataset.participant_codename,
-            "participant_codename"
+            "participant_codename", true
         ),
-        createFieldObj("Participant Aliases", dataset.participant_aliases, "participant_aliases"),
-        createFieldObj("Family Codename", dataset.family_codename, "family_codename"),
-        createFieldObj("Family Aliases", dataset.family_aliases, "family_aliases"),
+        createFieldObj("Participant Aliases", dataset.participant_aliases, "participant_aliases", true),
+        createFieldObj("Family Codename", dataset.family_codename, "family_codename", true),
+        createFieldObj("Family Aliases", dataset.family_aliases, "family_aliases", true),
         createFieldObj("Permission Groups", dataset.group_code.join(", "), "group_codes", true),
-        createFieldObj("Tissue Sample Type", dataset.tissue_sample_type, "tissue_sample_type"),
+        createFieldObj("Tissue Sample Type", dataset.tissue_sample_type, "tissue_sample_type", true),
         createFieldObj("Sequencing Centre", dataset.sequencing_centre, "sequencing_centre"),
         createFieldObj("Notes", dataset.notes, "notes"),
-        createFieldObj("Created", formatDateString(dataset.created), "created"),
-        createFieldObj("Created By", dataset.created_by, "created_by"),
-        createFieldObj("Updated", formatDateString(dataset.updated), "updated"),
-        createFieldObj("Updated By", dataset.updated_by, "updated_by"),
+        createFieldObj("Created", formatDateString(dataset.created), "created", true),
+        createFieldObj("Created By", dataset.created_by, "created_by", true),
+        createFieldObj("Updated", formatDateString(dataset.updated), "updated", true),
+        createFieldObj("Updated By", dataset.updated_by, "updated_by", true),
     ];
 }
 

--- a/react/src/typings.tsx
+++ b/react/src/typings.tsx
@@ -292,6 +292,7 @@ export interface Field {
     fieldName?: string;
     fullWidth?: boolean;
     disableEdit?: boolean;
+    maxLength?: number;
 }
 
 export type PseudoBoolean = "true" | "false" | "null";

--- a/react/src/typings.tsx
+++ b/react/src/typings.tsx
@@ -293,6 +293,7 @@ export interface Field {
     fullWidth?: boolean;
     disableEdit?: boolean;
     maxLength?: number;
+    entryError?: boolean;
 }
 
 export type PseudoBoolean = "true" | "false" | "null";


### PR DESCRIPTION
Subtask 4: For the following fields, when the limit is hit, the user cannot type into the field anymore. Sequencing Center (string max len 100) 
Batch ID (string max len 50) 
Extraction Protocol (string max len 100) 
Capture Kit (string max len 50) 
Library Prep Method (string max len 50) 
Read length (string max len 10, length of the maximum integer)

( Notes (TEXT object, do not have a length limit).) 

Subtask 5: Implement type validation for `read_length` only, `read_length` must only contain digits, as other fields are either objects or can be alphanumeric. My only concern is if making the type validation in `onChange()` would slow down the rendering. I hypothesize that this is not an issue because `error` and `helperText` are props for TextField in Material UI, so they should be already optimized. 

Subtask 6: `onUpdate() ` is a function that we want to refactor in this sprint. I think that the way we want to send `library_prep_date` to the backend may be different after refactoring `onUpdate() `. The code added may or may not be useful in the future. 