### PR TITLE
Flask: fix sequencing_id in _bulk and GET analyses

### DIFF
--- a/flask/app/analyses.py
+++ b/flask/app/analyses.py
@@ -246,6 +246,7 @@ def list_analyses(page: int, limit: int) -> Response:
     results = [
         {
             **asdict(analysis),
+            "sequencing_id": [d.sequencing_id for d in analysis.datasets],
             "participant_codenames": [
                 d.tissue_sample.participant.participant_codename
                 for d in analysis.datasets
@@ -288,6 +289,7 @@ def list_analyses(page: int, limit: int) -> Response:
                 "result_path",
                 "notes",
                 "analysis_id",
+                "sequencing_id",
             ],
         )
 

--- a/flask/app/routes.py
+++ b/flask/app/routes.py
@@ -289,9 +289,11 @@ def bulk_update():
         try:
             app.logger.debug("Reading in csv and converted to a dictionary..")
             dat = pd.read_csv(StringIO(request.data.decode("utf-8")))
+            app.logger.debug(dat)
             dat = dat.dropna(how="all")  # remove empty rows
             dat = dat.replace({np.nan: None})
             dat = dat.to_dict(orient="records")
+
         except Exception as err:
             app.logger.error(
                 "CSV failed to be read in. Please verify the file is a properly formatted csv."
@@ -547,6 +549,7 @@ def bulk_update():
             "read_type": row.get("read_type"),
             "sequencing_centre": row.get("sequencing_centre"),
             "sequencing_date": row.get("sequencing_date"),
+            "sequencing_id": row.get("sequencing_id"),
             "tissue_sample_id": tissue_sample.tissue_sample_id,
             "updated_by_id": updated_by_id,
         }

--- a/flask/app/routes.py
+++ b/flask/app/routes.py
@@ -289,7 +289,6 @@ def bulk_update():
         try:
             app.logger.debug("Reading in csv and converted to a dictionary..")
             dat = pd.read_csv(StringIO(request.data.decode("utf-8")))
-            app.logger.debug(dat)
             dat = dat.dropna(how="all")  # remove empty rows
             dat = dat.replace({np.nan: None})
             dat = dat.to_dict(orient="records")


### PR DESCRIPTION
closes #846 and #847 

I didn't think it was necessary to update tests, but as a sanity check for both:

- GET analyses (csv) will return `sequencing_id` : ```curl -H "Accept: text/csv" localhost:5000/api/analyses\?user=1```
- _bulk now inserts `sequencing_id` into the database and returns it in the json : ```curl -XPOST -H 'Content-Type: text/csv' --data-binary @flask/tests/samplecsv.csv localhost:5000/api/_bulk\?user=1\&groups=cheo```
