### PR TITLE
React: Prevent display of duplicate files in data entry rows

### DIFF
--- a/react/src/AddDatasets/components/DataEntryTable.tsx
+++ b/react/src/AddDatasets/components/DataEntryTable.tsx
@@ -161,7 +161,7 @@ export default function DataEntryTable({
                     <TableBody>
                         {data.map((row, rowIndex) => (
                             <DataEntryTableRow
-                                row={row}
+                                data={data}
                                 rowIndex={rowIndex}
                                 key={rowIndex}
                                 columns={columns}

--- a/react/src/AddDatasets/components/DataEntryTableRow.tsx
+++ b/react/src/AddDatasets/components/DataEntryTableRow.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { TableRow } from "@material-ui/core";
 import { Delete, LibraryAdd } from "@material-ui/icons";
 import { DNA_ONLY_FIELDS, RNA_ONLY_FIELDS } from "..";
@@ -15,6 +15,7 @@ import { participantColumns } from "./utils";
 
 interface DataEntryTableRowProps {
     columns: DataEntryColumnConfig[];
+    data: DataEntryRow[];
     getOptions: (rowIndex: number, col: DataEntryColumnConfig, families: Family[]) => any[];
     onChange: (
         newValue: string | boolean | UnlinkedFile[],
@@ -25,7 +26,6 @@ interface DataEntryTableRowProps {
     ) => void;
     onDelete: () => void;
     onDuplicate: () => void;
-    row: DataEntryRow;
     rowIndex: number;
 }
 
@@ -34,15 +34,18 @@ interface DataEntryTableRowProps {
  */
 export default function DataEntryTableRow({
     columns,
+    data,
     getOptions: _getOptions,
     onChange,
     onDelete,
     onDuplicate,
-    row,
     rowIndex,
 }: DataEntryTableRowProps) {
     const [familySearch, setFamilySearch] = useState("");
     const familiesResult = useFamiliesQuery(familySearch);
+
+    const row = useMemo(() => data[rowIndex], [data, rowIndex]);
+
     const families = familiesResult.data || [];
 
     function handleChange(
@@ -83,6 +86,7 @@ export default function DataEntryTableRow({
                     !col.hidden && (
                         <DataEntryCell
                             col={col}
+                            data={data}
                             disabled={getColumnIsDisabled(col.field, row)}
                             getOptions={getOptions}
                             key={col.field}
@@ -90,7 +94,6 @@ export default function DataEntryTableRow({
                             onEdit={newValue => handleChange(newValue, col)}
                             onSearch={search => onSearch(col, search)}
                             required={!getColumnIsDisabled(col.field, row) && col.required}
-                            row={row}
                             rowIndex={rowIndex}
                         />
                     )

--- a/react/src/AddDatasets/index.tsx
+++ b/react/src/AddDatasets/index.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useState } from "react";
-import { Box, Button, Container, Grid, makeStyles, Tooltip, Typography } from "@material-ui/core";
+import { Button, Container, Grid, makeStyles, Tooltip, Typography } from "@material-ui/core";
 import { CloudUpload } from "@material-ui/icons";
 import { useSnackbar } from "notistack";
 import { useHistory } from "react-router";
@@ -510,11 +510,9 @@ export default function AddDatasets() {
                     >
                         Submit
                     </Button>
-                    <Box>
-                        {validationErrorMessage && (
-                            <Typography color="error">{validationErrorMessage}</Typography>
-                        )}
-                    </Box>
+                    {validationErrorMessage && (
+                        <Typography color="error">{validationErrorMessage}</Typography>
+                    )}
                 </Grid>
             </Tooltip>
 

--- a/react/src/functions.tsx
+++ b/react/src/functions.tsx
@@ -221,6 +221,23 @@ export function createFieldObj(
     };
 }
 
+type NumberOrString = number | string;
+export const groupBy = <T extends { [key: NumberOrString]: any }, K extends keyof T>(
+    data: T[],
+    key: T[K] extends NumberOrString ? K : never
+) => {
+    return data.reduce(
+        (acc, curr) => ({
+            ...acc,
+            // 'never' protects against problematic keys at the expense of these verbose type assertions
+            [curr[key as NumberOrString]]: acc[curr[key as NumberOrString]]
+                ? acc[curr[key as NumberOrString]].concat(curr)
+                : [curr],
+        }),
+        {} as { [key: NumberOrString]: T[] }
+    );
+};
+
 export const getKeys = <T extends object>(obj: T) => Object.keys(obj) as (keyof T)[];
 
 /**


### PR DESCRIPTION
- filter out non-multiplexed files from select-options in AddDatasets table if the files have already been added to a previous entry row
- add validation logic for duplicate files
- separate required-field validation flag and custom validation messages
- display validation error messages below submit button