### PR TITLE
Flask: cleanup mixin enum checks

### DIFF
--- a/flask/app/analyses.py
+++ b/flask/app/analyses.py
@@ -13,14 +13,13 @@ from .utils import (
     check_admin,
     clone_entity,
     csv_response,
-    enum_validate,
     expects_csv,
     expects_json,
     filter_datasets_by_user_groups,
     filter_in_enum_or_abort,
     filter_updated_or_abort,
     get_current_user,
-    mixin,
+    check_set_fields,
     paged,
     paginated_response,
     transaction_or_abort,
@@ -373,7 +372,7 @@ def create_analysis():
 
     app.logger.debug("Validating priority parameter..")
 
-    enum_error = enum_validate(models.Analysis, request.json, ["priority"])
+    enum_error = check_set_fields(models.Analysis, request.json, ["priority"])
 
     if enum_error:
         abort(400, description=enum_error)
@@ -658,7 +657,9 @@ def update_analysis(id: int):
             else:
                 abort(400, description="Assignee not found")
 
-    enum_error = mixin(analysis, request.json, editable_columns)
+    enum_error = check_set_fields(
+        analysis, request.json, editable_columns, check_only=False
+    )
 
     if enum_error:
         abort(400, description=enum_error)

--- a/flask/app/datasets.py
+++ b/flask/app/datasets.py
@@ -16,7 +16,6 @@ from .extensions import db
 from .utils import (
     check_admin,
     csv_response,
-    enum_validate,
     expects_csv,
     expects_json,
     filter_datasets_by_user_groups,
@@ -24,12 +23,12 @@ from .utils import (
     filter_updated_or_abort,
     find,
     get_current_user,
-    mixin,
     paged,
     paginated_response,
     transaction_or_abort,
     validate_json,
     str_to_bool,
+    check_set_fields,
 )
 
 EDITABLE_COLUMNS = [
@@ -346,11 +345,10 @@ def update_dataset(id: int):
 
     dataset = query.first_or_404()
 
-    enum_error = mixin(
-        dataset,
-        request.json,
-        EDITABLE_COLUMNS,
+    enum_error = check_set_fields(
+        dataset, request.json, EDITABLE_COLUMNS, check_only=False
     )
+
     if enum_error:
         abort(400, description=enum_error)
 
@@ -433,7 +431,9 @@ def create_dataset():
         tissue_sample_id=tissue_sample_id
     ).first_or_404()
 
-    enum_error = enum_validate(models.Dataset, request.json, EDITABLE_COLUMNS)
+    enum_error = check_set_fields(
+        models.Dataset, request.json, EDITABLE_COLUMNS, check_only=True
+    )
 
     if enum_error:
         abort(400, description=enum_error)

--- a/flask/app/participants.py
+++ b/flask/app/participants.py
@@ -10,7 +10,6 @@ from .extensions import db
 from .utils import (
     check_admin,
     csv_response,
-    enum_validate,
     expects_csv,
     expects_json,
     filter_datasets_by_user_groups,
@@ -18,12 +17,12 @@ from .utils import (
     filter_nullable_bool_or_abort,
     filter_updated_or_abort,
     get_current_user,
-    mixin,
     paged,
     paginated_response,
     transaction_or_abort,
     validate_json,
     str_to_bool,
+    check_set_fields,
 )
 
 editable_columns = [
@@ -287,7 +286,9 @@ def update_participant(id: int):
 
     participant = query.first_or_404()
 
-    enum_error = mixin(participant, request.json, editable_columns)
+    enum_error = check_set_fields(
+        participant, request.json, editable_columns, check_only=False
+    )
 
     if enum_error:
         abort(400, description="enum_error")
@@ -343,7 +344,7 @@ def create_participant():
     ).first_or_404()
 
     # validate enums
-    enum_error = enum_validate(models.Participant, request.json, editable_columns)
+    enum_error = check_set_fields(models.Participant, request.json, editable_columns)
 
     if enum_error:
         abort(400, description=enum_error)

--- a/flask/app/routes.py
+++ b/flask/app/routes.py
@@ -13,7 +13,7 @@ from sqlalchemy.orm import joinedload
 from . import models
 from .extensions import db, oauth
 from .utils import (
-    enum_validate,
+    check_set_fields,
     find,
     get_current_user,
     transaction_or_abort,
@@ -432,7 +432,8 @@ def bulk_update():
 
         # Fail if we have any invalid values
         app.logger.debug("\tValidating enums for participants..")
-        enum_error = enum_validate(
+
+        enum_error = check_set_fields(
             models.Participant, row, editable_dict["participant"]
         )
         if enum_error:
@@ -500,7 +501,7 @@ def bulk_update():
 
         # Fail if we have any invalid values
         app.logger.debug("\tValidating enums for tissue samples..")
-        enum_error = enum_validate(
+        enum_error = check_set_fields(
             models.TissueSample, row, editable_dict["tissue_sample"]
         )
         if enum_error:
@@ -524,7 +525,7 @@ def bulk_update():
         app.logger.debug("\tDone")
         # Fail if we have any invalid values
         app.logger.debug("\tValidating enums for datasets..")
-        enum_error = enum_validate(models.Dataset, row, editable_dict["dataset"])
+        enum_error = check_set_fields(models.Dataset, row, editable_dict["dataset"])
         if enum_error:
             app.logger.error("\tEnum invalid: " + enum_error)
             db.session.rollback()

--- a/flask/app/tissue_samples.py
+++ b/flask/app/tissue_samples.py
@@ -10,8 +10,7 @@ from .utils import (
     filter_datasets_by_user_groups,
     get_current_user,
     transaction_or_abort,
-    mixin,
-    enum_validate,
+    check_set_fields,
     validate_json,
 )
 
@@ -147,7 +146,7 @@ def create_tissue_sample():
     models.Participant.query.filter_by(participant_id=participant_id).first_or_404()
     app.logger.debug("Participant ID exists")
     app.logger.debug("Validating enums")
-    enum_error = enum_validate(models.TissueSample, request.json, editable_columns)
+    enum_error = check_set_fields(models.TissueSample, request.json, editable_columns)
 
     if enum_error:
         app.logger.error("Enum invalid: " + enum_error)
@@ -222,7 +221,10 @@ def update_tissue_sample(id: int):
     tissue_sample = query.first_or_404()
 
     app.logger.debug("Validating enums..")
-    enum_error = mixin(tissue_sample, request.json, editable_columns)
+
+    enum_error = check_set_fields(
+        tissue_sample, request.json, editable_columns, check_only=False
+    )
 
     if enum_error:
         app.logger.error("Enum invalid: " + enum_error)

--- a/flask/tests/unit/test_check_set_fields.py
+++ b/flask/tests/unit/test_check_set_fields.py
@@ -1,5 +1,5 @@
 """
-test mixin works on polymorphic models, eg. rnaseq_dataset 
+test check_set_fields works on polymorphic models, eg. rnaseq_dataset 
 
 For future reference - in tests that create an instance of a model where the intent is to replicate an object returned by a query, enums must also be appropriately specified.
 For example in this test, if the 'DatasetCondition' and 'DatasetReadType' columns are not specified and passed as either a string or an enum when an RNASeqDataset instance is created, then the master `mixin` function, which is expected to throw an error, will actually pass, suggesting that there is no bug! 
@@ -7,11 +7,11 @@ For example in this test, if the 'DatasetCondition' and 'DatasetReadType' column
 """
 
 from app.models import RNASeqDataset, DatasetCondition, DatasetReadType
-from app.utils import mixin
+from app.utils import check_set_fields
 from sqlalchemy.types import Enum
 
 
-def test_mixin():
+def test_check_set_fields():
     rnaseq_dataset_instance = RNASeqDataset(
         dataset_id=1,
         candidate_genes="APOE",
@@ -28,7 +28,9 @@ def test_mixin():
 
     editable_columns = ["condition", "read_type"]
 
-    enum_error = mixin(rnaseq_dataset_instance, rnaseq_changes, editable_columns)
+    enum_error = check_set_fields(
+        rnaseq_dataset_instance, rnaseq_changes, editable_columns, check_only=False
+    )
 
     assert enum_error is None
     # this should fail on master


### PR DESCRIPTION
Cleans up `mixin` and `enum_validate`:

- adds function `check_set_valid` - checks enums and modifies a query in place (like `mixin`) if the appropriate entity is detected and the `check_only` argument is False
- `enum_validate` can now validate both model classes (used POST) and instances (used in PATCH)
