### PR TITLE
gitattributes: don't treat all files as text

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,1 @@
-* text eol=lf
+* text=auto eol=lf


### PR DESCRIPTION
oops, this made Git try to "normalize line endings" in images
