### PR TITLE
Flask: Added request info to logs for 5xx error codes

### DIFF
--- a/flask/app/error_handler.py
+++ b/flask/app/error_handler.py
@@ -21,6 +21,11 @@ def get_request_info() -> str:
     return info
 
 
+def dump_error_context() -> None:
+    app.logger.error(get_request_info())
+    app.logger.error(traceback.format_exc())
+
+
 @error_blueprint.app_errorhandler(Exception)
 def handle_error(error: Exception):
 
@@ -35,13 +40,14 @@ def handle_error(error: Exception):
     code = 500  # defaults to 500 for non HTTP exceptions
     msg = error
 
-    # this is useful for non-http exceptions as well
-    app.logger.error(get_request_info())
-
     if isinstance(error, HTTPException):
         code = error.code
         msg = error.description
         # 500 codes are handled as they all exist as a subclass of HTTPException
         if code in werkzeug_500_codes:
-            app.logger.error(traceback.format_exc())
+            dump_error_context()
+    else:
+        # this is useful for non-http exceptions as well
+        dump_error_context()
+
     return jsonify(error=str(msg)), code


### PR DESCRIPTION
* For GET requests, the full url+method & query parameters are printed
* For other requests, the body is also printed (including the form data)
* Query/body is pretty printed with proper indentation

Sample log:
```
<Request 'http://localhost:5000/api/_bulk?groups=c4r' [POST]>
Query Params:
{
    "groups": "c4r"
}
Body:
[
    {
        "affected": null,
        "condition": "Control",
        "dataset_type": "CES",
        "family_codename": "test",
        "participant_codename": "test",
        "participant_type": null,
        "sequencing_date": "2021-10-13",
        "sex": "Unknown",
        "solved": false,
        "tissue_sample_type": "Blood"
    }
]
```
	
Fixes #880 