### PR TITLE
CI: rewrite backend workflow to be push-based

### DIFF
--- a/.github/workflows/flask.yml
+++ b/.github/workflows/flask.yml
@@ -135,10 +135,10 @@ jobs:
         run: |
           eval "${{ steps.configure.outputs.ssh-agent-eval }}"
           docker-compose pull
-          docker-compose up -d
+          docker-compose up -d --remove-orphans
       - name: Clean up
         if: always()
         run: |
           docker context rm -f deploy-target
-          eval "$SSH_AGENT_EVAL"
+          eval "${{ steps.configure.outputs.ssh-agent-eval }}"
           ssh-agent -k

--- a/.github/workflows/flask.yml
+++ b/.github/workflows/flask.yml
@@ -104,6 +104,11 @@ jobs:
     concurrency: CHEO-RI-DEV
     steps:
       - uses: actions/checkout@v2
+      - uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Configure SSH
         id: configure
         # https://docs.docker.com/engine/context/working-with-contexts/
@@ -118,11 +123,10 @@ jobs:
           chmod -R g-rwx,o-rwx ~/.ssh
           docker context create deploy-target --docker host=ssh://${{ secrets.DEPLOY_SSH_HOST }}
           docker context use deploy-target
-          docker login ghcr.io -u ${{ github.repository_owner }} --password-stdin <<< "${{ secrets.GITHUB_TOKEN }}"
       - name: Deploy
         env:
           COMPOSE_FILE: docker-compose.cheo.yaml
-          ST_VERSION: sha-${{ github.sha }}
+          ST_VERSION: latest
           ST_SECRET_KEY: ${{ secrets.ST_SECRET_KEY }}
           MYSQL_CONNECTION_STRING: ${{ secrets.MYSQL_CONNECTION_STRING }}
           MINIO_ENDPOINT: ${{ secrets.MINIO_ENDPOINT }}
@@ -135,6 +139,6 @@ jobs:
       - name: Clean up
         if: always()
         run: |
-          docker logout ghcr.io
           docker context rm -f deploy-target
+          eval "$SSH_AGENT_EVAL"
           ssh-agent -k

--- a/.github/workflows/flask.yml
+++ b/.github/workflows/flask.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - master
-      - kevinlul/cd-push
     paths:
       - .github/workflows/flask.yml
       - flask/**/*
@@ -20,7 +19,6 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    if: false
     env:
       COMPOSE_FILE: docker-compose.test.yaml
     steps:
@@ -70,7 +68,6 @@ jobs:
           tags: ${{ steps.meta-dev.outputs.tags }}
           labels: ${{ steps.meta-dev.outputs.labels }}
           context: flask
-          pull: true
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache,mode=max
       - name: Infer metadata (production image)
@@ -79,7 +76,7 @@ jobs:
         id: meta-prod
         with:
           images: ghcr.io/${{ github.repository }}
-          #flavor: latest=${{ github.ref == 'refs/heads/master' }}
+          flavor: latest=${{ github.ref == 'refs/heads/master' }}
           tags: |
             type=ref,event=tag
             type=sha,format=long
@@ -98,10 +95,10 @@ jobs:
           cache-to: type=local,dest=/tmp/.buildx-cache,mode=max
   deploy:
     runs-on: [self-hosted, cheo-ri]
-    # needs: build
+    needs: build
     if: github.event_name == 'push'
-    environment: CHEO-RI-DEV
-    concurrency: CHEO-RI-DEV
+    environment: CHEO-RI_backend
+    concurrency: CHEO-RI_backend
     steps:
       - uses: actions/checkout@v2
       - uses: docker/login-action@v1
@@ -111,8 +108,12 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Configure SSH
         id: configure
+        # The self-hosted runner is not ephemeral, so we load the secret key into
+        # an agent instead in memory. Keep track of it for further workflow steps
+        # and so we can clean it up and not leave orphaned processes hanging around.
+        #
         # https://docs.docker.com/engine/context/working-with-contexts/
-        # This avoids passing an -H parameter to every Docker CLI cal
+        # This avoids passing an -H parameter to every Docker CLI call.
         run: |
           SSH_AGENT_EVAL=$(ssh-agent -s)
           eval "$SSH_AGENT_EVAL"
@@ -125,6 +126,8 @@ jobs:
           docker context create deploy-target --docker host=ssh://${{ secrets.DEPLOY_SSH_HOST }}
           docker context use deploy-target
       - name: Deploy
+        # Even though this is deploying to a remote Docker Engine,
+        # Compose uses the registry credentials of the client
         env:
           COMPOSE_FILE: docker-compose.cheo.yaml
           ST_VERSION: latest

--- a/.github/workflows/flask.yml
+++ b/.github/workflows/flask.yml
@@ -104,38 +104,37 @@ jobs:
     concurrency: CHEO-RI-DEV
     steps:
       - uses: actions/checkout@v2
-      - uses: docker/login-action@v1
-        with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Configure SSH
+        id: configure
         # https://docs.docker.com/engine/context/working-with-contexts/
         # This avoids passing an -H parameter to every Docker CLI cal
         run: |
+          SSH_AGENT_EVAL=$(ssh-agent -s)
+          eval "$SSH_AGENT_EVAL"
+          ssh-add - <<< "${{ secrets.DEPLOY_PRIVATE_KEY }}"
+          echo "::set-output name=ssh-agent-eval::$SSH_AGENT_EVAL"
           mkdir -p ~/.ssh
           echo "${{ secrets.DEPLOY_HOST_KEY }}" > ~/.ssh/known_hosts
           chmod -R g-rwx,o-rwx ~/.ssh
           docker context create deploy-target --docker host=ssh://${{ secrets.DEPLOY_SSH_HOST }}
           docker context use deploy-target
+          docker login ghcr.io -u ${{ github.repository_owner }} --password-stdin <<< "${{ secrets.GITHUB_TOKEN }}"
       - name: Deploy
         env:
           COMPOSE_FILE: docker-compose.cheo.yaml
           ST_VERSION: sha-${{ github.sha }}
           ST_SECRET_KEY: ${{ secrets.ST_SECRET_KEY }}
-          MYSQL_USER: ${{ secrets.MYSQL_USER }}
-          MYSQL_PASSWORD: ${{ secrets.MYSQL_PASSWORD }}
-          MYSQL_HOST: ${{ secrets.MYSQL_HOST }}
-          MYSQL_DATABASE: ${{ secrets.MYSQL_DATABASE }}
+          MYSQL_CONNECTION_STRING: ${{ secrets.MYSQL_CONNECTION_STRING }}
           MINIO_ENDPOINT: ${{ secrets.MINIO_ENDPOINT }}
           MINIO_ACCESS_KEY: ${{ secrets.MINIO_ACCESS_KEY }}
           MINIO_SECRET_KEY: ${{ secrets.MINIO_SECRET_KEY }}
         run: |
-          eval $(ssh-agent -s)
-          ssh-add - <<< "${{ secrets.DEPLOY_PRIVATE_KEY }}"
+          eval "${{ steps.configure.outputs.ssh-agent-eval }}"
           docker-compose pull
           docker-compose up -d
       - name: Clean up
         if: always()
         run: |
+          docker logout ghcr.io
           docker context rm -f deploy-target
+          ssh-agent -k

--- a/.github/workflows/flask.yml
+++ b/.github/workflows/flask.yml
@@ -1,4 +1,4 @@
-name: Build and test backend
+name: Build, test, and deploy backend
 on:
   push:
     branches:
@@ -84,3 +84,42 @@ jobs:
           pull: true
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache,mode=max
+  deploy:
+    runs-on: [self-hosted, cheo-ri]
+    needs: build
+    if: github.event_name == 'push'
+    environment: CHEO-RI
+    concurrency: CHEO-RI
+    steps:
+      - uses: actions/checkout@v2
+      - uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Configure SSH
+        # https://docs.docker.com/engine/context/working-with-contexts/
+        # This avoids passing an -H parameter to every Docker CLI cal
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.DEPLOY_HOST_KEY }}" >> ~/.ssh/known_hosts
+          echo "${{ secrets.DEPLOY_PUBLIC_KEY }}" > ~/.ssh/id_rsa.pub
+          echo "${{ secrets.DEPLOY_PRIVATE_KEY }}" > ~/.ssh/id_rsa
+          chmod -R g-rwx,o-rwx ~/.ssh
+          docker context create deploy-target --docker host=ssh://${{ secrets.DEPLOY_USER }}@${{ secrets.DEPLOY_HOST }}
+          docker context use deploy-target
+      - name: Deploy
+        env:
+          COMPOSE_FILE: docker-compose.cheo.yaml
+          ST_VERSION: latest
+          ST_SECRET_KEY: ${{ secrets.ST_SECRET_KEY }}
+          MYSQL_USER: ${{ secrets.MYSQL_USER }}
+          MYSQL_PASSWORD: ${{ secrets.MYSQL_PASSWORD }}
+          MYSQL_HOST: ${{ secrets.MYSQL_HOST }}
+          MYSQL_DATABASE: ${{ secrets.MYSQL_DATABASE }}
+          MINIO_ENDPOINT: ${{ secrets.MINIO_ENDPOINT }}
+          MINIO_ACCESS_KEY: ${{ secrets.MINIO_ACCESS_KEY }}
+          MINIO_SECRET_KEY: ${{ secrets.MINIO_SECRET_KEY }}
+        run: |
+          docker-compose pull
+          docker-compose up

--- a/.github/workflows/flask.yml
+++ b/.github/workflows/flask.yml
@@ -19,7 +19,6 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    if: false
     env:
       COMPOSE_FILE: docker-compose.test.yaml
     steps:
@@ -87,14 +86,13 @@ jobs:
           cache-to: type=local,dest=/tmp/.buildx-cache,mode=max
   deploy:
     runs-on: [self-hosted, cheo-ri]
-    #needs: build
-    #if: github.event_name == 'push'
+    needs: build
+    if: github.event_name == 'push'
     environment: CHEO-RI
     concurrency: CHEO-RI
     steps:
       - uses: actions/checkout@v2
       - name: Configure SSH
-        if: false
         # https://docs.docker.com/engine/context/working-with-contexts/
         # This avoids passing an -H parameter to every Docker CLI cal
         run: |
@@ -124,4 +122,4 @@ jobs:
           MINIO_SECRET_KEY: ${{ secrets.MINIO_SECRET_KEY }}
         run: |
           docker-compose pull
-          docker-compose up
+          docker-compose up -d

--- a/.github/workflows/flask.yml
+++ b/.github/workflows/flask.yml
@@ -19,6 +19,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    if: false
     env:
       COMPOSE_FILE: docker-compose.test.yaml
     steps:
@@ -86,8 +87,8 @@ jobs:
           cache-to: type=local,dest=/tmp/.buildx-cache,mode=max
   deploy:
     runs-on: [self-hosted, cheo-ri]
-    needs: build
-    if: github.event_name == 'push'
+    #needs: build
+    #if: github.event_name == 'push'
     environment: CHEO-RI
     concurrency: CHEO-RI
     steps:
@@ -98,6 +99,7 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Configure SSH
+        if: false
         # https://docs.docker.com/engine/context/working-with-contexts/
         # This avoids passing an -H parameter to every Docker CLI cal
         run: |

--- a/.github/workflows/flask.yml
+++ b/.github/workflows/flask.yml
@@ -20,6 +20,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    if: false
     env:
       COMPOSE_FILE: docker-compose.test.yaml
     steps:
@@ -97,12 +98,17 @@ jobs:
           cache-to: type=local,dest=/tmp/.buildx-cache,mode=max
   deploy:
     runs-on: [self-hosted, cheo-ri]
-    needs: build
+    # needs: build
     if: github.event_name == 'push'
     environment: CHEO-RI-DEV
     concurrency: CHEO-RI-DEV
     steps:
       - uses: actions/checkout@v2
+      - uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Configure SSH
         # https://docs.docker.com/engine/context/working-with-contexts/
         # This avoids passing an -H parameter to every Docker CLI cal
@@ -114,11 +120,6 @@ jobs:
           chmod -R g-rwx,o-rwx ~/.ssh
           docker context create deploy-target --docker host=ssh://${{ secrets.DEPLOY_SSH_HOST }}
           docker context use deploy-target
-      - uses: docker/login-action@v1
-        with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Deploy
         env:
           COMPOSE_FILE: docker-compose.cheo.yaml
@@ -137,4 +138,4 @@ jobs:
       - name: Clean up
         if: always()
         run: |
-          docker context rm deploy-target
+          docker context rm -f deploy-target

--- a/.github/workflows/flask.yml
+++ b/.github/workflows/flask.yml
@@ -93,11 +93,6 @@ jobs:
     concurrency: CHEO-RI
     steps:
       - uses: actions/checkout@v2
-      - uses: docker/login-action@v1
-        with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Configure SSH
         if: false
         # https://docs.docker.com/engine/context/working-with-contexts/
@@ -110,6 +105,11 @@ jobs:
           chmod -R g-rwx,o-rwx ~/.ssh
           docker context create deploy-target --docker host=ssh://${{ secrets.DEPLOY_USER }}@${{ secrets.DEPLOY_HOST }}
           docker context use deploy-target
+      - uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Deploy
         env:
           COMPOSE_FILE: docker-compose.cheo.yaml

--- a/.github/workflows/flask.yml
+++ b/.github/workflows/flask.yml
@@ -46,7 +46,6 @@ jobs:
       - name: Build development image
         uses: docker/build-push-action@v2
         with:
-          push: ${{ github.event_name == 'push' }}
           tags: ${{ steps.meta-dev.outputs.tags }}
           labels: ${{ steps.meta-dev.outputs.labels }}
           context: flask
@@ -61,6 +60,17 @@ jobs:
         run: docker-compose run --rm app black --check
       - name: Stop services
         run: docker-compose down
+      - name: Push development image
+        uses: docker/build-push-action@v2
+        if: github.event_name == 'push'
+        with:
+          push: true
+          tags: ${{ steps.meta-dev.outputs.tags }}
+          labels: ${{ steps.meta-dev.outputs.labels }}
+          context: flask
+          pull: true
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache,mode=max
       - name: Infer metadata (production image)
         uses: docker/metadata-action@v3
         if: github.event_name == 'push'

--- a/.github/workflows/flask.yml
+++ b/.github/workflows/flask.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - master
+      - kevinlul/cd-push
     paths:
       - .github/workflows/flask.yml
       - flask/**/*
@@ -77,7 +78,7 @@ jobs:
         id: meta-prod
         with:
           images: ghcr.io/${{ github.repository }}
-          flavor: latest=${{ github.ref == 'refs/heads/master' }}
+          #flavor: latest=${{ github.ref == 'refs/heads/master' }}
           tags: |
             type=ref,event=tag
             type=sha,format=long
@@ -98,20 +99,20 @@ jobs:
     runs-on: [self-hosted, cheo-ri]
     needs: build
     if: github.event_name == 'push'
-    environment: CHEO-RI
-    concurrency: CHEO-RI
+    environment: CHEO-RI-DEV
+    concurrency: CHEO-RI-DEV
     steps:
       - uses: actions/checkout@v2
       - name: Configure SSH
         # https://docs.docker.com/engine/context/working-with-contexts/
         # This avoids passing an -H parameter to every Docker CLI cal
         run: |
+          eval $(ssh-agent -s)
+          ssh-add - <<< "${{ secrets.DEPLOY_PRIVATE_KEY }}"
           mkdir -p ~/.ssh
-          echo "${{ secrets.DEPLOY_HOST_KEY }}" >> ~/.ssh/known_hosts
-          echo "${{ secrets.DEPLOY_PUBLIC_KEY }}" > ~/.ssh/id_rsa.pub
-          echo "${{ secrets.DEPLOY_PRIVATE_KEY }}" > ~/.ssh/id_rsa
+          echo "${{ secrets.DEPLOY_HOST_KEY }}" > ~/.ssh/known_hosts
           chmod -R g-rwx,o-rwx ~/.ssh
-          docker context create deploy-target --docker host=ssh://${{ secrets.DEPLOY_USER }}@${{ secrets.DEPLOY_HOST }}
+          docker context create deploy-target --docker host=ssh://${{ secrets.DEPLOY_SSH_HOST }}
           docker context use deploy-target
       - uses: docker/login-action@v1
         with:
@@ -121,7 +122,7 @@ jobs:
       - name: Deploy
         env:
           COMPOSE_FILE: docker-compose.cheo.yaml
-          ST_VERSION: latest
+          ST_VERSION: sha-${{ github.sha }}
           ST_SECRET_KEY: ${{ secrets.ST_SECRET_KEY }}
           MYSQL_USER: ${{ secrets.MYSQL_USER }}
           MYSQL_PASSWORD: ${{ secrets.MYSQL_PASSWORD }}
@@ -133,3 +134,7 @@ jobs:
         run: |
           docker-compose pull
           docker-compose up -d
+      - name: Clean up
+        if: always()
+        run: |
+          docker context rm deploy-target

--- a/.github/workflows/flask.yml
+++ b/.github/workflows/flask.yml
@@ -113,8 +113,6 @@ jobs:
         # https://docs.docker.com/engine/context/working-with-contexts/
         # This avoids passing an -H parameter to every Docker CLI cal
         run: |
-          eval $(ssh-agent -s)
-          ssh-add - <<< "${{ secrets.DEPLOY_PRIVATE_KEY }}"
           mkdir -p ~/.ssh
           echo "${{ secrets.DEPLOY_HOST_KEY }}" > ~/.ssh/known_hosts
           chmod -R g-rwx,o-rwx ~/.ssh
@@ -133,6 +131,8 @@ jobs:
           MINIO_ACCESS_KEY: ${{ secrets.MINIO_ACCESS_KEY }}
           MINIO_SECRET_KEY: ${{ secrets.MINIO_SECRET_KEY }}
         run: |
+          eval $(ssh-agent -s)
+          ssh-add - <<< "${{ secrets.DEPLOY_PRIVATE_KEY }}"
           docker-compose pull
           docker-compose up -d
       - name: Clean up

--- a/.github/workflows/flask.yml
+++ b/.github/workflows/flask.yml
@@ -30,6 +30,13 @@ jobs:
           key: ${{ runner.os }}-buildx-${{ github.sha }}
           restore-keys: |
             ${{ runner.os }}-buildx-
+      - name: Infer metadata (development image)
+        uses: docker/metadata-action@v3
+        id: meta-dev
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            dev
       - uses: docker/login-action@v1
         if: github.event_name == 'push'
         with:
@@ -39,15 +46,14 @@ jobs:
       - name: Build development image
         uses: docker/build-push-action@v2
         with:
-          tags: ghcr.io/ccmbioinfo/stager:dev
+          push: ${{ github.event_name == 'push' }}
+          tags: ${{ steps.meta-dev.outputs.tags }}
+          labels: ${{ steps.meta-dev.outputs.labels }}
           context: flask
           pull: true
           load: true
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache,mode=max
-      - name: Push development image
-        if: ${{ github.event_name == 'push' }}
-        run: docker push ghcr.io/ccmbioinfo/stager:dev
       - run: cp sample.env .env
       - name: Pytest
         run: docker-compose run --rm app
@@ -55,23 +61,26 @@ jobs:
         run: docker-compose run --rm app black --check
       - name: Stop services
         run: docker-compose down
-      - name: Infer production image tag
-        id: infer
+      - name: Infer metadata (production image)
+        uses: docker/metadata-action@v3
         if: github.event_name == 'push'
-        run: |
-          # Strip git ref prefix from version
-          VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
-          # Use Docker `latest` tag convention
-          [[ "$VERSION" == "master" ]] && VERSION=latest
-          echo "::set-output name=tag::$VERSION"
-      - name: Build and push production image
-        uses: docker/build-push-action@v2
+        id: meta-prod
         with:
-          tags: ghcr.io/ccmbioinfo/stager:${{ steps.infer.outputs.tag || 'latest' }}
+          images: ghcr.io/${{ github.repository }}
+          flavor: latest=${{ github.ref == 'refs/heads/master' }}
+          tags: |
+            type=ref,event=tag
+            type=sha,format=long
+      - name: Build production image
+        uses: docker/build-push-action@v2
+        if: github.event_name == 'push'
+        with:
+          push: true
+          tags: ${{ steps.meta-prod.outputs.tags }}
+          labels: ${{ steps.meta-prod.outputs.labels }}
           context: flask
           file: "{context}/../Dockerfile"
           build-args: GIT_SHA=${{ github.sha }}
           pull: true
-          push: ${{ github.event_name == 'push' }}
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache,mode=max

--- a/.github/workflows/flask.yml
+++ b/.github/workflows/flask.yml
@@ -118,6 +118,7 @@ jobs:
           eval "$SSH_AGENT_EVAL"
           ssh-add - <<< "${{ secrets.DEPLOY_PRIVATE_KEY }}"
           echo "::set-output name=ssh-agent-eval::$SSH_AGENT_EVAL"
+          echo "::set-output name=ssh-agent-pid::$SSH_AGENT_PID"
           mkdir -p ~/.ssh
           echo "${{ secrets.DEPLOY_HOST_KEY }}" > ~/.ssh/known_hosts
           chmod -R g-rwx,o-rwx ~/.ssh
@@ -141,4 +142,4 @@ jobs:
         run: |
           docker context rm -f deploy-target
           eval "${{ steps.configure.outputs.ssh-agent-eval }}"
-          ssh-agent -k
+          SSH_AGENT_PID="${{ steps.configure.outputs.ssh-agent-pid }}" ssh-agent -k

--- a/docker-compose.cheo.yaml
+++ b/docker-compose.cheo.yaml
@@ -1,7 +1,7 @@
 version: "3.9"
 
 services:
-  stager:
+  app:
     image: "ghcr.io/ccmbioinfo/stager:${ST_VERSION}"
     user: www-data
     environment:

--- a/docker-compose.cheo.yaml
+++ b/docker-compose.cheo.yaml
@@ -1,0 +1,22 @@
+version: "3.9"
+
+services:
+  stager:
+    image: "ghcr.io/ccmbioinfo/stager:${ST_VERSION}"
+    user: www-data
+    environment:
+      ST_SECRET_KEY: "${ST_SECRET_KEY}"
+      ST_DATABASE_URI: "mysql+pymysql://${MYSQL_USER}:${MYSQL_PASSWORD}@${MYSQL_HOST}/${MYSQL_DATABASE}"
+      MINIO_ENDPOINT: "${MINIO_ENDPOINT}"
+      MINIO_ACCESS_KEY: "${MINIO_ACCESS_KEY}"
+      MINIO_SECRET_KEY: "${MINIO_SECRET_KEY}"
+      MINIO_REGION_NAME: hpc4health
+    ports:
+      - "5000:5000"
+    entrypoint: ./utils/run.sh prod --bind 0.0.0.0:5000 --access-logfile - --log-file -
+    command: --preload --workers 2 --threads 2
+    healthcheck:
+      test: ["CMD", "curl", "-f", "localhost:5000/api"]
+    restart: unless-stopped
+    logging:
+      driver: journald

--- a/docker-compose.cheo.yaml
+++ b/docker-compose.cheo.yaml
@@ -6,7 +6,7 @@ services:
     user: www-data
     environment:
       ST_SECRET_KEY: "${ST_SECRET_KEY}"
-      ST_DATABASE_URI: "mysql+pymysql://${MYSQL_USER}:${MYSQL_PASSWORD}@${MYSQL_HOST}/${MYSQL_DATABASE}"
+      ST_DATABASE_URI: "mysql+pymysql://${MYSQL_CONNECTION_STRING}"
       MINIO_ENDPOINT: "${MINIO_ENDPOINT}"
       MINIO_ACCESS_KEY: "${MINIO_ACCESS_KEY}"
       MINIO_SECRET_KEY: "${MINIO_SECRET_KEY}"


### PR DESCRIPTION
Third time's the charm? #862 #877

- Use docker/metadata-action to infer image tags and labels
- Use docker/build-push-action twice to build the dev image, then test, then push. The second use will simply push from the cache
- Create a new deploy job that depends on a separate environment holding backend secrets
- Create a new Compose file for this deployment to CHEO-RI that just has a backend container on a single host, which supersedes the one in cheo-ri-infrastructure/stager. I've collapsed the database credentials into one secret to make it easier to manage

The successful run: https://github.com/ccmbioinfo/stager/runs/3910343642