### PR TITLE
CI: reduce Dependabot frequently to monthly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,9 @@ updates:
     assignees:
       - cklamann
     schedule:
-      interval: weekly
+      interval: monthly
+      time: 07:00
+      timezone: America/Toronto
   - package-ecosystem: npm
     directory: /react
     commit-message:
@@ -19,7 +21,9 @@ updates:
     assignees:
       - cklamann
     schedule:
-      interval: weekly
+      interval: monthly
+      time: 07:00
+      timezone: America/Toronto
   - package-ecosystem: docker
     directory: /
     commit-message:
@@ -29,7 +33,9 @@ updates:
     assignees:
       - cklamann
     schedule:
-      interval: weekly
+      interval: monthly
+      time: 07:00
+      timezone: America/Toronto
   - package-ecosystem: github-actions
     directory: /
     commit-message:
@@ -39,4 +45,6 @@ updates:
     assignees:
       - cklamann
     schedule:
-      interval: weekly
+      interval: monthly
+      time: 07:00
+      timezone: America/Toronto


### PR DESCRIPTION
There is no biweekly option https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/configuration-options-for-dependency-updates#scheduleinterval