### PR TITLE
CI: fix Dependabot frequency in #916

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,7 +10,7 @@ updates:
       - cklamann
     schedule:
       interval: monthly
-      time: 07:00
+      time: "07:00"
       timezone: America/Toronto
   - package-ecosystem: npm
     directory: /react
@@ -22,7 +22,7 @@ updates:
       - cklamann
     schedule:
       interval: monthly
-      time: 07:00
+      time: "07:00"
       timezone: America/Toronto
   - package-ecosystem: docker
     directory: /
@@ -34,7 +34,7 @@ updates:
       - cklamann
     schedule:
       interval: monthly
-      time: 07:00
+      time: "07:00"
       timezone: America/Toronto
   - package-ecosystem: github-actions
     directory: /
@@ -46,5 +46,5 @@ updates:
       - cklamann
     schedule:
       interval: monthly
-      time: 07:00
+      time: "07:00"
       timezone: America/Toronto


### PR DESCRIPTION
```
The property '#/updates/0/schedule/time' of type integer did not match the following type: string
The property '#/updates/1/schedule/time' of type integer did not match the following type: string
The property '#/updates/2/schedule/time' of type integer did not match the following type: string
The property '#/updates/3/schedule/time' of type integer did not match the following type: string
```
https://github.com/ccmbioinfo/stager/runs/4038445674