### PR TITLE
Flask: separate MinIO upload bucket from results bucket

### DIFF
--- a/.github/workflows/flask.yml
+++ b/.github/workflows/flask.yml
@@ -136,7 +136,7 @@ jobs:
           MINIO_ENDPOINT: ${{ secrets.MINIO_ENDPOINT }}
           MINIO_ACCESS_KEY: ${{ secrets.MINIO_ACCESS_KEY }}
           MINIO_SECRET_KEY: ${{ secrets.MINIO_SECRET_KEY }}
-          MSTEAMS_WEBHOOK: ${{ secrets.MSTEAMS_WEBHOOK }}
+          MSTEAMS_WEBHOOK_URL: ${{ secrets.MSTEAMS_WEBHOOK }}
         run: |
           eval "${{ steps.configure.outputs.ssh-agent-eval }}"
           docker-compose pull

--- a/flask/app/groups.py
+++ b/flask/app/groups.py
@@ -212,14 +212,17 @@ def create_group():
 
     minio_admin = get_minio_admin()
 
-    try:
-        app.logger.debug(f"Creating minio bucket {group_code}..")
-        # Create minio bucket via mc, 422 if it already exists
-        if minio_client.bucket_exists(group_code):
-            abort(422, description="Minio bucket already exists")
+    def make_bucket_or_fail(name: str) -> None:
+        app.logger.info(f"Creating MinIO bucket '{name}'..")
+        if minio_client.bucket_exists(name):
+            abort(422, description=f"MinIO bucket '{name}' already exists")
         minio_client.make_bucket(
-            bucket_name=group_code, location=app.config["MINIO_REGION_NAME"]
+            bucket_name=name, location=app.config["MINIO_REGION_NAME"]
         )
+
+    try:
+        make_bucket_or_fail(group_code)
+        make_bucket_or_fail(f"results-{group_code}")
     except:
         abort(422, description="Invalid bucket name")
 

--- a/flask/app/manage.py
+++ b/flask/app/manage.py
@@ -1,5 +1,8 @@
 from datetime import datetime, date
-import random
+
+from pprint import pprint
+import gzip, pickle, random
+from sqlalchemy import exc
 
 import click
 from click.exceptions import ClickException
@@ -7,14 +10,13 @@ from click.exceptions import ClickException
 from flask import Flask, current_app as app
 from flask.cli import with_appcontext
 from minio import Minio
+import pandas as pd
 from sqlalchemy import and_
 
-from .models import *
+from app import models  # duplicated - how to best account for this
 from .extensions import db
 from .madmin import MinioAdmin, stager_buckets_policy
-
 from .manage_keycloak import *
-from .utils import stager_is_keycloak_admin
 
 # for report mapping and insertion
 from .mapping_utils import (
@@ -24,12 +26,8 @@ from .mapping_utils import (
     check_result_paths,
     try_int,
 )
-import pandas as pd
-from app import models  # duplicated - how to best account for this
-from sqlalchemy import exc
-from pprint import pprint
-import pickle
-import gzip
+from .models import *
+from .utils import get_minio_admin, stager_is_keycloak_admin
 
 
 def register_commands(app: Flask) -> None:
@@ -40,12 +38,24 @@ def register_commands(app: Flask) -> None:
     app.cli.add_command(map_insert_c4r_reports)
     app.cli.add_command(map_hiraki_datasets_analyses)
     app.cli.add_command(add_hiraki_reports)
+    app.cli.add_command(migrate_minio_policies)
     if app.config.get("ENABLE_OIDC"):
         app.cli.add_command(update_user)
         if os.getenv("KEYCLOAK_HOST") is not None:
             app.cli.add_command(create_realm)
             app.cli.add_command(create_client)
             app.cli.add_command(add_user)
+
+
+@click.command("migrate-minio-policies")
+@with_appcontext
+def migrate_minio_policies() -> None:
+    minio_admin = get_minio_admin()
+    groups = models.Group.query.all()
+    for group in groups:
+        policy = stager_buckets_policy(group.group_code)
+        # All adds are upserts
+        minio_admin.add_policy(group.group_code, policy)
 
 
 @click.command("map-insert-c4r-reports")

--- a/flask/tests/test_groups.py
+++ b/flask/tests/test_groups.py
@@ -144,6 +144,10 @@ def test_delete_group(test_database, client, login_as, minio_admin):
 
 def test_update_group(test_database, client, login_as, minio_admin):
     login_as("admin")
+    # Test bad payloads
+    assert client.patch("/api/groups/code").status_code == 415
+    assert client.patch("/api/groups/code", json="").status_code == 400
+    assert client.patch("/api/groups/code", json="5").status_code == 400
     # Test existence
     assert (
         client.patch("/api/groups/code", json={"group_name": "yes"}).status_code == 404
@@ -180,6 +184,10 @@ def test_create_group(test_database, client, login_as, minio_admin):
     assert client.post("/api/groups").status_code == 401
 
     login_as("admin")
+    # Test bad payloads
+    assert client.post("/api/groups").status_code == 415
+    assert client.post("/api/groups", json="").status_code == 400
+    assert client.post("/api/groups", json="5").status_code == 400
     # Test no group_code given
     assert (
         client.post(
@@ -226,6 +234,7 @@ def test_create_group(test_database, client, login_as, minio_admin):
         secure=False,
     )
     # Clean up
+    minio_client.remove_bucket("results-code")
     minio_client.remove_bucket("code")
     minio_admin.remove_policy("code")
 
@@ -256,6 +265,7 @@ def test_create_group(test_database, client, login_as, minio_admin):
         secure=False,
     )
     # Clean up
+    minio_client.remove_bucket("results-code2")
     minio_client.remove_bucket("code2")
     minio_admin.remove_policy("code2")
     minio_admin.remove_user("user")


### PR DESCRIPTION
Update policy to include 'results-CODENAME'
Deny group codes starting with 'results-'
Add Click command 'migrate-minio-policies' to retroactively update existing groups
Objects will have to be moved to the correct bucket after the migration
Fix order of input validation for POST and PATCH endpoints

Closes #874

Missing
- [x] update tests
- [x] retroactively create buckets?
- [x] create the result bucket at the time of group creation?