### PR TITLE
Flask: Fix updated timestamp in the modals.

### DIFF
--- a/docker-compose.test.yaml
+++ b/docker-compose.test.yaml
@@ -10,7 +10,7 @@ services:
       MYSQL_PASSWORD: "${TEST_MYSQL_PASSWORD}"
       MYSQL_ROOT_PASSWORD: "${TEST_MYSQL_ROOT_PASSWORD}"
   minio:
-    image: minio/minio
+    image: minio/minio:RELEASE.2021-11-03T03-36-36Z
     environment:
       MINIO_ACCESS_KEY: "${TEST_MINIO_ACCESS_KEY}"
       MINIO_SECRET_KEY: "${TEST_MINIO_SECRET_KEY}"

--- a/flask/app/utils.py
+++ b/flask/app/utils.py
@@ -56,6 +56,15 @@ def validate_enums_and_set_fields(
     """
     for field in allowed_columns:
         if field in json_mixin:
+
+            # convert string to datetime.Date() object
+            if (
+                field == "library_prep_date" or field == "month_of_birth"
+            ) and json_mixin[field]:
+                json_mixin[field] = datetime.strptime(
+                    request.json[field], "%Y-%m-%d"
+                ).date()
+
             validate_enum(entity, field, json_mixin[field])
             setattr(entity, field, json_mixin[field])
 

--- a/react/src/functions.tsx
+++ b/react/src/functions.tsx
@@ -52,6 +52,39 @@ export function formatDateString(date: string, type?: string) {
 }
 
 /**
+ * Transforms the 'database' value to a user-readable string.
+ */
+export function formatDisplayValue(field: Field) {
+    const { fieldName, type, value } = field;
+    if (fieldName === "month_of_birth") {
+        return dayjs(value as string).isValid() ? dayjs(value as string).format("YYYY-MM") : "";
+    }
+    if (type === "linked_files") {
+        return (value as LinkedFile[]).map(v => v.path).join(", ");
+    } else if (type === "boolean") {
+        return PseudoBooleanReadableMap[("" + value) as PseudoBoolean];
+    } else if (type === "date" || type === "timestamp") {
+        return formatDateString(value as string, type);
+    }
+    return value;
+}
+
+/* Transform input value to value that the database will accept, mainly for dealing with exceptions to standard rules */
+export function formatSubmitValue(field: Field) {
+    const { type, fieldName, value } = field;
+    let val = value;
+    if (fieldName === "month_of_birth") {
+        val = dayjs(value as string).isValid()
+            ? dayjs(value as string, "YYYY-MM").format("YYYY-MM-01")
+            : null;
+    }
+    if ((type === "date" || type === "timestamp") && !dayjs(val as string).isValid()) {
+        val = null;
+    }
+    return val;
+}
+
+/**
  * Convert the provided JSON Array to a valid array of Analysis.
  */
 export function jsonToAnalyses(data: Array<any>): Analysis[] {
@@ -245,6 +278,7 @@ export function getDatasetFields(dataset: Dataset): Field[] {
  * Return the secondary titles and values (hidden in show more detail) of dataset detail as a Field object in dialogs
  */
 export function getSecDatasetFields(dataset: Dataset): Field[] {
+    console.log("dataset updated is ", dataset.updated, typeof dataset.updated);
     let fields = [
         {
             title: "Batch ID",
@@ -438,40 +472,6 @@ export function rowDiff<T>(newRow: T, oldRow: T | undefined): Partial<T> {
         }
         return { ...diffRow };
     }
-}
-
-/**
- * Transforms the 'database' value to a user-readable string.
- */
-export function formatDisplayValue(field: Field) {
-    const { fieldName, type, value } = field;
-    if (fieldName === "month_of_birth") {
-        return dayjs(value as string).isValid() ? dayjs(value as string).format("YYYY-MM") : "";
-    }
-    if (type === "linked_files") {
-        return (value as LinkedFile[]).map(v => v.path).join(", ");
-    } else if (type === "boolean") {
-        return PseudoBooleanReadableMap[("" + value) as PseudoBoolean];
-    } else if (type === "date" || type === "timestamp") {
-        return formatDateString(value as string, type);
-    }
-    return value;
-}
-
-/* Transform input value to value that the database will accept, mainly for dealing with exceptions to standard rules */
-export function formatSubmitValue(field: Field) {
-    const { type, fieldName, value } = field;
-    let val = value;
-    if (fieldName === "month_of_birth") {
-        val = dayjs(value as string).isValid()
-            ? dayjs(value as string, "YYYY-MM").format("YYYY-MM-1")
-            : null;
-    }
-    if ((type === "date" || type === "timestamp") && !dayjs(val as string).isValid()) {
-        val = null;
-    }
-
-    return val;
 }
 
 /**


### PR DESCRIPTION
When we save changes in the modals and if there are no changes in the field values, the `updated` timestamp would still change. This is caused by either a nonnull `library_prep_date` field or a nonnull `month_of_birth` field. When the backend receives the JSON request, the values for these fields are of type String. However, the values of these fields are stored in the database as `DateTime.Date()` object. Thus, when we commit the session, SQLAlchemy will think that there's a change in data values and update the timestamp. 

The solution presented here is to convert the values from `String` type to `DateTime.Date()` type in the backend. 