### PR TITLE
Docker: disable MinIO update check at startup, forward Console port, freeze version

### DIFF
--- a/docker-compose.oidc.yaml
+++ b/docker-compose.oidc.yaml
@@ -19,18 +19,20 @@ services:
       - ${MYSQL_VOLUME}:/var/lib/mysql
       - ./init:/docker-entrypoint-initdb.d
   minio:
-    image: minio/minio
+    image: minio/minio:RELEASE.2021-11-03T03-36-36Z
     user: "${MINIO_UIDGID:-}"
     restart: on-failure
     environment:
       MINIO_ACCESS_KEY: "${MINIO_ACCESS_KEY}"
       MINIO_SECRET_KEY: "${MINIO_SECRET_KEY}"
       MINIO_REGION_NAME: "${MINIO_REGION_NAME}"
+      MINIO_UPDATE: "off"
     ports:
       - "${MINIO_HOST_PORT}:9000"
+      - "${CONSOLE_HOST_PORT:-127.0.0.1:9090}:9090"
     volumes:
       - ${MINIO_VOLUME}:/data
-    command: server /data
+    command: server /data --quiet --console-address ":9090"
   app:
     build: flask
     image: ghcr.io/ccmbioinfo/stager:dev

--- a/docker-compose.prod.yaml
+++ b/docker-compose.prod.yaml
@@ -22,15 +22,17 @@ services:
       test: ["CMD", "mysqladmin", "ping", "-uroot", "-p${MYSQL_ROOT_PASSWORD}"]
     <<: *common
   minio:
-    image: minio/minio
+    image: minio/minio:RELEASE.2021-11-03T03-36-36Z
     user: "${MINIO_UIDGID}"
     environment:
       MINIO_ACCESS_KEY: "${MINIO_ACCESS_KEY}"
       MINIO_SECRET_KEY: "${MINIO_SECRET_KEY}"
       MINIO_REGION_NAME: "${MINIO_REGION_NAME}"
+      MINIO_UPDATE: "off"
     volumes:
       - ${MINIO_VOLUME}:/data
-    command: server /data
+      - "${CONSOLE_HOST_PORT:-127.0.0.1:9090}:9090"
+    command: server /data --quiet --console-address ":9090"
     <<: *common
   app:
     build:

--- a/docker-compose.test.yaml
+++ b/docker-compose.test.yaml
@@ -15,7 +15,9 @@ services:
       MINIO_ACCESS_KEY: "${TEST_MINIO_ACCESS_KEY}"
       MINIO_SECRET_KEY: "${TEST_MINIO_SECRET_KEY}"
       MINIO_REGION_NAME: "${MINIO_REGION_NAME}"
-    command: server /data
+      MINIO_UPDATE: "off"
+    command: server /data --quiet --console-address ":9090"
+    # console address not needed but kept for consistency
   app:
     build: flask
     image: ghcr.io/ccmbioinfo/stager:dev

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -18,18 +18,20 @@ services:
     volumes:
       - ${MYSQL_VOLUME}:/var/lib/mysql
   minio:
-    image: minio/minio
+    image: minio/minio:RELEASE.2021-11-03T03-36-36Z
     user: "${MINIO_UIDGID:-}"
     restart: on-failure
     environment:
       MINIO_ACCESS_KEY: "${MINIO_ACCESS_KEY}"
       MINIO_SECRET_KEY: "${MINIO_SECRET_KEY}"
       MINIO_REGION_NAME: "${MINIO_REGION_NAME}"
+      MINIO_UPDATE: "off"
     ports:
       - "${MINIO_HOST_PORT}:9000"
+      - "${CONSOLE_HOST_PORT:-127.0.0.1:9090}:9090"
     volumes:
       - ${MINIO_VOLUME}:/data
-    command: server /data
+    command: server /data --quiet --console-address ":9090"
   app:
     build: flask
     image: ghcr.io/ccmbioinfo/stager:dev


### PR DESCRIPTION
The combination of MINIO_UPDATE=off AND --quiet is required to prevent calling home in this instance
This means we lose all startup messages and logs

Forward the Console port for MinIO releases since 20210617
Freeze version due to regression in 20211105 (no release notes) discovered by Jenny