### PR TITLE
React: use no-referrer globally and for all external links

### DIFF
--- a/react/public/index.html
+++ b/react/public/index.html
@@ -2,6 +2,7 @@
 <html lang="en">
     <head>
         <meta charset="utf-8" />
+        <meta name="referrer" content="no-referrer" />
         <link rel="icon" type="image/png" href="%PUBLIC_URL%/favicon.png" sizes="192x192" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
         <meta name="theme-color" content="#000000" />
@@ -10,8 +11,13 @@
         <link
             rel="stylesheet"
             href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700&display=swap"
+            referrerpolicy="no-referrer"
         />
-        <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons" />
+        <link
+            rel="stylesheet"
+            href="https://fonts.googleapis.com/icon?family=Material+Icons"
+            referrerpolicy="no-referrer"
+        />
         <!--
             manifest.json provides metadata used when your web app is installed on a
             user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/

--- a/react/src/AddDatasets/components/DataEntryToolbar.tsx
+++ b/react/src/AddDatasets/components/DataEntryToolbar.tsx
@@ -107,7 +107,7 @@ export default function DataEntryToolbar(props: {
                     </IconButton>
                 </Tooltip>
                 <Tooltip title="Go to MinIO">
-                    <Link href={process.env.REACT_APP_MINIO_URL} target="_blank">
+                    <Link href={process.env.REACT_APP_MINIO_URL} target="_blank" rel="noreferrer">
                         <IconButton>
                             <OpenInNew />
                         </IconButton>

--- a/react/src/Settings/components/Instructions.tsx
+++ b/react/src/Settings/components/Instructions.tsx
@@ -25,11 +25,11 @@ export default function Instructions() {
                 Using MinIO with {process.env.REACT_APP_NAME}
             </Typography>
             <P>
-                <Link href="https://min.io/" color="textSecondary">
+                <Link href="https://min.io/" rel="noreferrer" color="textSecondary">
                     MinIO
                 </Link>{" "}
                 is an open-source{" "}
-                <Link href="https://aws.amazon.com/s3/" color="textSecondary">
+                <Link href="https://aws.amazon.com/s3/" rel="noreferrer" color="textSecondary">
                     Amazon S3
                 </Link>
                 -compatible object storage server. We're using an instance managed by{" "}
@@ -46,6 +46,7 @@ export default function Instructions() {
                 pertain to the{" "}
                 <Link
                     href="https://docs.min.io/docs/minio-client-complete-guide.html"
+                    rel="noreferrer"
                     color="textSecondary"
                 >
                     command-line MinIO Client
@@ -55,6 +56,7 @@ export default function Instructions() {
             <Typography variant="h6" gutterBottom>
                 <Link
                     href="https://docs.min.io/docs/minio-client-quickstart-guide.html"
+                    rel="noreferrer"
                     color="textSecondary"
                 >
                     <GetApp /> Download the MinIO Client for your operating system here.
@@ -123,6 +125,7 @@ export default function Instructions() {
                 Full documentation is available from MinIO's{" "}
                 <Link
                     href="https://docs.min.io/docs/minio-client-complete-guide.html"
+                    rel="noreferrer"
                     color="textSecondary"
                 >
                     documentation site

--- a/react/src/Settings/index.tsx
+++ b/react/src/Settings/index.tsx
@@ -190,6 +190,7 @@ export default function Settings() {
                         <Link
                             href={process.env.REACT_APP_MINIO_URL}
                             target="_blank"
+                            rel="noreferrer"
                             className={classes.link}
                         >
                             <Button variant="contained" color="primary">


### PR DESCRIPTION
Please check if I missed any. To observe the behaviour change, open the developer tools, disable cache, and click on outbound links. There should be no `Referer:` header. This should also be true for the two font requests on a hard reload.

Documentation:
https://developer.mozilla.org/en-US/docs/Web/HTML/Link_types/noreferrer
https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Referer
https://developer.mozilla.org/en-US/docs/Web/Security/Referer_header:_privacy_and_security_concerns
https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Referrer-Policy
https://developer.mozilla.org/en-US/docs/Web/HTML/Element/link#attr-referrerpolicy