### PR TITLE
React: fix dataset types going out of sync between the Dataset and Participant modals

### DIFF
--- a/flask/app/participants.py
+++ b/flask/app/participants.py
@@ -206,6 +206,11 @@ def list_participants(page: int, limit: int) -> Response:
     results = [
         {
             **asdict(participant),
+            "dataset_types": [
+                dataset.dataset_type
+                for tissue_sample in participant.tissue_samples
+                for dataset in tissue_sample.datasets
+            ],
             "family_codename": participant.family.family_codename,
             "family_aliases": participant.family.family_aliases,
             "family_id": participant.family.family_id,

--- a/flask/app/participants.py
+++ b/flask/app/participants.py
@@ -206,11 +206,6 @@ def list_participants(page: int, limit: int) -> Response:
     results = [
         {
             **asdict(participant),
-            "dataset_types": [
-                dataset.dataset_type
-                for tissue_sample in participant.tissue_samples
-                for dataset in tissue_sample.datasets
-            ],
             "family_codename": participant.family.family_codename,
             "family_aliases": participant.family.family_aliases,
             "family_id": participant.family.family_id,
@@ -285,12 +280,6 @@ def get_participant(id: int):
     if not participant:
         abort(404)
 
-    dataset_types = []
-    for tissue_sample in participant.tissue_samples:
-        for dataset in tissue_sample.datasets:
-            if dataset.dataset_type not in dataset_types:
-                dataset_types.append(dataset.dataset_type)
-
     return jsonify(
         {
             **asdict(participant),
@@ -301,7 +290,6 @@ def get_participant(id: int):
             else None,
             "updated_by": participant.updated_by.username,
             "created_by": participant.created_by.username,
-            "dataset_types": dataset_types,
             "tissue_samples": [
                 {
                     **asdict(tissue_sample),

--- a/react/src/hooks/datasets/useDatasetUpdateMutation.tsx
+++ b/react/src/hooks/datasets/useDatasetUpdateMutation.tsx
@@ -14,7 +14,10 @@ async function patchDataset(newDataset: Partial<Dataset>) {
 export function useDatasetUpdateMutation() {
     const queryClient = useQueryClient();
     const mutation = useMutation<Dataset, Response, Partial<Dataset>>(patchDataset, {
-        onSuccess: () => queryClient.invalidateQueries("datasets"),
+        onSuccess: () => {
+            queryClient.invalidateQueries("datasets");
+            queryClient.invalidateQueries("participants");
+        },
     });
     return mutation;
 }

--- a/react/src/hooks/participants/useParticipantQuery.tsx
+++ b/react/src/hooks/participants/useParticipantQuery.tsx
@@ -3,7 +3,11 @@ import { Participant } from "../../typings";
 import { basicFetch } from "../utils";
 
 async function fetchDataset(id: string) {
-    return await basicFetch("/api/participants/" + id);
+    const result: Participant = await basicFetch("/api/participants/" + id);
+    result.dataset_types = result.tissue_samples.flatMap(({ datasets }) =>
+        datasets.map(dataset => dataset.dataset_type)
+    );
+    return result;
 }
 
 /**

--- a/react/src/hooks/participants/useParticipantsPage.tsx
+++ b/react/src/hooks/participants/useParticipantsPage.tsx
@@ -10,9 +10,6 @@ async function fetchParticipants(query: Query<Participant>) {
     const queryResult = await queryTableData<Participant>(query, GET_PARTICIPANTS_URL);
     // format results
     queryResult.data.forEach((participant: Participant) => {
-        participant.dataset_types = participant.tissue_samples.flatMap(({ datasets }) =>
-            datasets.map(dataset => dataset.dataset_type)
-        );
         participant.affected += "";
         participant.solved += "";
     });

--- a/react/src/hooks/participants/useParticipantsPage.tsx
+++ b/react/src/hooks/participants/useParticipantsPage.tsx
@@ -10,6 +10,9 @@ async function fetchParticipants(query: Query<Participant>) {
     const queryResult = await queryTableData<Participant>(query, GET_PARTICIPANTS_URL);
     // format results
     queryResult.data.forEach((participant: Participant) => {
+        participant.dataset_types = participant.tissue_samples.flatMap(({ datasets }) =>
+            datasets.map(dataset => dataset.dataset_type)
+        );
         participant.affected += "";
         participant.solved += "";
     });


### PR DESCRIPTION
Fixed bug: if a dataset's type is updated in the Dataset table or Dataset modal, the corresponding change is not reflected in the Participant table or Participant modal if we don't refresh the Participant page.