### PR TITLE
React/Flask: Add condition to dataset_type editability, fix Analyses table part I. 

### DIFF
--- a/flask/app/analyses.py
+++ b/flask/app/analyses.py
@@ -519,32 +519,6 @@ def create_reanalysis(id: int):
         abort(404, description="Some datasets were not found")
 
     # TODO: Do we need to check for compatibility if the previous analysis already exists?
-    app.logger.info(
-        f"Checking if datasets are still compatible with pipeline {analysis.pipeline_id}..."
-    )
-    compatible_datasets_pipelines_query = (
-        db.session.query(
-            models.Dataset,
-            models.MetaDatasetType_DatasetType,
-            models.PipelineDatasets,
-        )
-        .filter(models.Dataset.dataset_id.in_(datasets))
-        .join(
-            models.MetaDatasetType_DatasetType,
-            models.Dataset.dataset_type
-            == models.MetaDatasetType_DatasetType.dataset_type,
-        )
-        .join(
-            models.PipelineDatasets,
-            models.PipelineDatasets.supported_metadataset_type
-            == models.MetaDatasetType_DatasetType.metadataset_type,
-        )
-        .filter(models.PipelineDatasets.pipeline_id == analysis.pipeline_id)
-        .all()
-    )
-
-    if len(compatible_datasets_pipelines_query) != len(datasets):
-        abort(404, description="Requested pipelines are incompatible with datasets")
 
     app.logger.info("Cloning previous analysis...")
     # Clone attributes from existing analysis, overwrite some

--- a/flask/app/analyses.py
+++ b/flask/app/analyses.py
@@ -244,7 +244,7 @@ def list_analyses(page: int, limit: int) -> Response:
 
     # this is needed to for sorting to work on assignee/requester
     query = (
-        query.join(assignee_user, models.Analysis.assignee)
+        query.join(assignee_user, models.Analysis.assignee, isouter=True)
         if order_by == "assignee"
         else query
     )

--- a/flask/app/datasets.py
+++ b/flask/app/datasets.py
@@ -252,6 +252,7 @@ def list_datasets(page: int, limit: int) -> Response:
             "created_by": dataset.created_by.username,
             "updated_by": dataset.updated_by.username,
             "group_code": [group.group_code for group in dataset.groups],
+            "analyses": [{**asdict(analysis)} for analysis in dataset.analyses],
         }
         for dataset in datasets
     ]

--- a/flask/tests/conftest.py
+++ b/flask/tests/conftest.py
@@ -286,8 +286,8 @@ def test_database(client):
     analysis_2 = Analysis(
         analysis_id=2,
         analysis_state=AnalysisState.Requested,
-        requester_id=admin.user_id,
-        assignee_id=admin.user_id,
+        requester_id=user.user_id,
+        assignee_id=None,
         updated_by_id=admin.user_id,
         pipeline_id=pipeline_1.pipeline_id,
         requested="2020-07-28",

--- a/flask/tests/conftest.py
+++ b/flask/tests/conftest.py
@@ -286,7 +286,7 @@ def test_database(client):
     analysis_2 = Analysis(
         analysis_id=2,
         analysis_state=AnalysisState.Requested,
-        requester_id=user.user_id,
+        requester_id=user_a.user_id,
         assignee_id=None,
         updated_by_id=admin.user_id,
         pipeline_id=pipeline_1.pipeline_id,

--- a/flask/tests/test_analyses.py
+++ b/flask/tests/test_analyses.py
@@ -34,6 +34,34 @@ def test_list_analyses_user_from_admin(test_database, client, login_as):
     assert len(response.get_json()["data"]) == 1
 
 
+def test_analyses_order_by_analyses_column(test_database, client, login_as):
+    login_as("admin")
+
+    response = client.get("/api/analyses?order_by=assignee&order_dir=desc")
+    assert response.status_code == 200
+    body = response.get_json()
+    assert len(body["data"]) == 3
+    assert body["data"][2]["analysis_id"] == 2
+
+    response = client.get("/api/analyses?order_by=assignee&order_dir=asc")
+    assert response.status_code == 200
+    body = response.get_json()
+    assert len(body["data"]) == 3
+    assert body["data"][0]["analysis_id"] == 2
+
+    response = client.get("/api/analyses?order_by=requester&order_dir=desc")
+    assert response.status_code == 200
+    body = response.get_json()
+    assert len(body["data"]) == 3
+    assert body["data"][0]["analysis_id"] == 2
+
+    response = client.get("/api/analyses?order_by=requester&order_dir=asc")
+    assert response.status_code == 200
+    body = response.get_json()
+    assert len(body["data"]) == 3
+    assert body["data"][2]["analysis_id"] == 2
+
+
 # GET /api/analyses/:id
 
 

--- a/react/src/Analyses/index.tsx
+++ b/react/src/Analyses/index.tsx
@@ -384,7 +384,7 @@ export default function Analyses() {
                     onClose={() => {
                         setDetail(false);
                     }}
-                    refreshTable={tableRef.current.onQueryChange()}
+                    refreshTable={tableRef.current.onQueryChange}
                 />
             )}
 

--- a/react/src/Analyses/index.tsx
+++ b/react/src/Analyses/index.tsx
@@ -382,6 +382,7 @@ export default function Analyses() {
                     analysis={activeRows[0]}
                     onClose={() => {
                         setDetail(false);
+                        tableRef.current.onQueryChange();
                     }}
                 />
             )}

--- a/react/src/Analyses/index.tsx
+++ b/react/src/Analyses/index.tsx
@@ -383,8 +383,8 @@ export default function Analyses() {
                     analysis={activeRows[0]}
                     onClose={() => {
                         setDetail(false);
-                        tableRef.current.onQueryChange();
                     }}
+                    refreshTable={tableRef.current.onQueryChange()}
                 />
             )}
 

--- a/react/src/Analyses/index.tsx
+++ b/react/src/Analyses/index.tsx
@@ -345,7 +345,6 @@ export default function Analyses() {
                     onAccept={() => {
                         changeAnalysisState(PipelineStatus.CANCELLED).then(
                             ({ changed, skipped, failed }) => {
-                                setCancel(false);
                                 if (changed > 0)
                                     enqueueSnackbar(
                                         `${changed} ${
@@ -368,6 +367,8 @@ export default function Analyses() {
                                         }`,
                                         { variant: "error" }
                                     );
+                                setCancel(false);
+                                tableRef.current.onQueryChange();
                             }
                         );
                     }}

--- a/react/src/Datasets/components/DatasetTable.tsx
+++ b/react/src/Datasets/components/DatasetTable.tsx
@@ -160,7 +160,7 @@ export default function DatasetTable() {
                 title: "Type",
                 field: "dataset_type",
                 lookup: datasetTypes,
-                editable: (columnDef, row) => row.analyses.length>0 ? false : true,
+                editable: (columnDef, row) => (row.analyses.length > 0 ? false : true),
             },
             {
                 title: "Condition",

--- a/react/src/Datasets/components/DatasetTable.tsx
+++ b/react/src/Datasets/components/DatasetTable.tsx
@@ -33,7 +33,7 @@ import {
     useUnlinkedFilesQuery,
 } from "../../hooks";
 import { transformMTQueryToCsvDownloadParams } from "../../hooks/utils";
-import { Dataset, isRNASeqDataset, LinkedFile } from "../../typings";
+import { Dataset, DatasetDetailed, isRNASeqDataset, LinkedFile } from "../../typings";
 import AnalysisRunnerDialog from "./AnalysisRunnerDialog";
 import DatasetInfoDialog from "./DatasetInfoDialog";
 import LinkedFilesButton from "./LinkedFilesButton";
@@ -50,14 +50,14 @@ const useStyles = makeStyles(theme => ({
     },
 }));
 
-const customFileFilterAndSearch = (filter: string, rowData: Dataset) => {
+const customFileFilterAndSearch = (filter: string, rowData: DatasetDetailed) => {
     return (
         filter === "" + rowData.linked_files.length ||
         rowData.linked_files.some(f => f.path.includes(filter))
     );
 };
 
-const EditFilesComponent = (props: EditComponentProps<Dataset>) => {
+const EditFilesComponent = (props: EditComponentProps<DatasetDetailed>) => {
     const filesQuery = useUnlinkedFilesQuery();
     const files = filesQuery.data || [];
     return (
@@ -128,16 +128,16 @@ export default function DatasetTable() {
 
     const handleColumnDrag = useColumnOrderCache(MTRef, "datasetTableColumnOrder", cacheDeps);
 
-    const { handleChangeColumnHidden, setHiddenColumns } = useHiddenColumnCache<Dataset>(
+    const { handleChangeColumnHidden, setHiddenColumns } = useHiddenColumnCache<DatasetDetailed>(
         "datasetTableDefaultHidden"
     );
-    const { handleOrderChange, setInitialSorting } = useSortOrderCache<Dataset>(
+    const { handleOrderChange, setInitialSorting } = useSortOrderCache<DatasetDetailed>(
         MTRef,
         "datasetTableSortOrder"
     );
 
     const columns = useMemo(() => {
-        const columns: Column<Dataset>[] = [
+        const columns: Column<DatasetDetailed>[] = [
             {
                 title: "Family",
                 field: "family_codename",
@@ -160,6 +160,7 @@ export default function DatasetTable() {
                 title: "Type",
                 field: "dataset_type",
                 lookup: datasetTypes,
+                editable: (columnDef, row) => row.analyses.length>0 ? false : true,
             },
             {
                 title: "Condition",

--- a/react/src/components/AnalysisInfoDialog.tsx
+++ b/react/src/components/AnalysisInfoDialog.tsx
@@ -74,6 +74,7 @@ interface AlertInfoDialogProp {
     open: boolean;
     analysis: Analysis;
     onClose: () => void;
+    refreshTable?: () => void;
 }
 
 export default function AnalysisInfoDialog(props: AlertInfoDialogProp) {
@@ -117,6 +118,9 @@ export default function AnalysisInfoDialog(props: AlertInfoDialogProp) {
                                     enqueueSnackbar(
                                         `Re-analysis of analysis ${props.analysis.analysis_id} requested.`
                                     );
+                                    if (props.refreshTable) {
+                                        props.refreshTable();
+                                    }
                                 },
                                 onError: async response => {
                                     enqueueErrorSnackbar(

--- a/react/src/components/ExactMatchFilterToggle.tsx
+++ b/react/src/components/ExactMatchFilterToggle.tsx
@@ -2,11 +2,11 @@ import React, { useEffect, useState } from "react";
 import { Column } from "@material-table/core";
 import { Checkbox, makeStyles, TextField, Tooltip } from "@material-ui/core";
 import { updateSearchTypeAndRequery } from "../functions";
-import { Dataset, Participant } from "../typings";
+import { DatasetDetailed, Participant } from "../typings";
 
 interface ExactMatchFilterToggleProps {
     MTRef: React.MutableRefObject<any>;
-    columnDef: Column<Participant> | Column<Dataset>;
+    columnDef: Column<Participant> | Column<DatasetDetailed>;
     onFilterChanged: (rowId: string, value: any) => void;
 }
 

--- a/react/src/functions.tsx
+++ b/react/src/functions.tsx
@@ -6,6 +6,7 @@ import {
     Analysis,
     Counts,
     Dataset,
+    DatasetDetailed,
     Field,
     Info,
     isRNASeqDataset,
@@ -193,13 +194,14 @@ export function getAnalysisInfoList(analyses: Analysis[]): Info[] {
 /**
  * Return the titles and values of dataset detail as a Field object in dialogs
  */
-export function getDatasetFields(dataset: Dataset): Field[] {
+export function getDatasetFields(dataset: DatasetDetailed ): Field[] {
+
     return [
         {
             title: "Dataset Type",
             value: dataset.dataset_type,
             fieldName: "dataset_type",
-            editable: true,
+            editable: dataset.analyses.length>0 ? false : true,
         },
 
         {
@@ -357,7 +359,7 @@ export function getSecDatasetFields(dataset: Dataset): Field[] {
 /**
  * Return an Info object for dataset detail list in dialogs
  */
-export function getDatasetInfoList(datasets: Dataset[]): Info[] {
+export function getDatasetInfoList(datasets: DatasetDetailed[] ): Info[] {
     return datasets.map(dataset => {
         return {
             primaryListTitle: `Dataset ID ${dataset.dataset_id}`,

--- a/react/src/functions.tsx
+++ b/react/src/functions.tsx
@@ -201,7 +201,7 @@ export function getDatasetFields(dataset: DatasetDetailed ): Field[] {
             title: "Dataset Type",
             value: dataset.dataset_type,
             fieldName: "dataset_type",
-            editable: dataset.analyses.length>0 ? false : true,
+            editable: dataset.analyses?.length>0 ? false : true,
         },
 
         {

--- a/react/src/functions.tsx
+++ b/react/src/functions.tsx
@@ -194,14 +194,13 @@ export function getAnalysisInfoList(analyses: Analysis[]): Info[] {
 /**
  * Return the titles and values of dataset detail as a Field object in dialogs
  */
-export function getDatasetFields(dataset: DatasetDetailed ): Field[] {
-
+export function getDatasetFields(dataset: DatasetDetailed): Field[] {
     return [
         {
             title: "Dataset Type",
             value: dataset.dataset_type,
             fieldName: "dataset_type",
-            editable: dataset.analyses?.length>0 ? false : true,
+            editable: dataset.analyses?.length > 0 ? false : true,
         },
 
         {
@@ -359,7 +358,7 @@ export function getSecDatasetFields(dataset: Dataset): Field[] {
 /**
  * Return an Info object for dataset detail list in dialogs
  */
-export function getDatasetInfoList(datasets: DatasetDetailed[] ): Info[] {
+export function getDatasetInfoList(datasets: DatasetDetailed[]): Info[] {
     return datasets.map(dataset => {
         return {
             primaryListTitle: `Dataset ID ${dataset.dataset_id}`,

--- a/react/src/hooks/analyses/useAnalysisCreateMutation.tsx
+++ b/react/src/hooks/analyses/useAnalysisCreateMutation.tsx
@@ -1,6 +1,6 @@
 import { useMutation, useQueryClient } from "react-query";
 import { Analysis, AnalysisPriority, Dataset, Pipeline } from "../../typings";
-import { changeFetch } from "../utils";
+import { changeFetch, invalidateAnalysisPredicate } from "../utils";
 
 interface NewAnalysisParams {
     type: "new";
@@ -37,8 +37,10 @@ async function createAnalysis(params: CreateAnalysisParams) {
 export function useAnalysisCreateMutation() {
     const queryClient = useQueryClient();
     const mutation = useMutation<Analysis, Response, CreateAnalysisParams>(createAnalysis, {
-        onSuccess: newAnalysis => {
-            queryClient.invalidateQueries("analyses");
+        onSuccess: () => {
+            queryClient.invalidateQueries({
+                predicate: invalidateAnalysisPredicate,
+            });
         },
     });
     return mutation;

--- a/react/src/hooks/analyses/useAnalysisCreateMutation.tsx
+++ b/react/src/hooks/analyses/useAnalysisCreateMutation.tsx
@@ -1,6 +1,6 @@
 import { useMutation, useQueryClient } from "react-query";
 import { Analysis, AnalysisPriority, Dataset, Pipeline } from "../../typings";
-import { changeFetch, invalidateAnalysisPredicate } from "../utils";
+import { changeFetch } from "../utils";
 
 interface NewAnalysisParams {
     type: "new";
@@ -20,9 +20,9 @@ type CreateAnalysisParams = NewAnalysisParams | ReAnalysisParams;
 async function createAnalysis(params: CreateAnalysisParams) {
     if (params.type === "new" && params.notes?.trim() === "") params.notes = undefined;
     if (params.type === "reanalysis")
-        return await changeFetch(`/api/analyses/${params.analysis_id}`, "POST");
+        return changeFetch(`/api/analyses/${params.analysis_id}`, "POST");
 
-    return await changeFetch("/api/analyses", "POST", params);
+    return changeFetch("/api/analyses", "POST", params);
 }
 
 /**
@@ -38,10 +38,7 @@ export function useAnalysisCreateMutation() {
     const queryClient = useQueryClient();
     const mutation = useMutation<Analysis, Response, CreateAnalysisParams>(createAnalysis, {
         onSuccess: newAnalysis => {
-            queryClient.setQueryData(["analyses", newAnalysis.analysis_id], newAnalysis);
-            queryClient.invalidateQueries({
-                predicate: invalidateAnalysisPredicate,
-            });
+            queryClient.invalidateQueries("analyses");
         },
     });
     return mutation;

--- a/react/src/hooks/analyses/useAnalysisUpdateMutation.tsx
+++ b/react/src/hooks/analyses/useAnalysisUpdateMutation.tsx
@@ -1,5 +1,5 @@
 import { useMutation, useQueryClient } from "react-query";
-import { Analysis, AnalysisChange, AnalysisDetailed } from "../../typings";
+import { Analysis, AnalysisChange } from "../../typings";
 import { changeFetch, invalidateAnalysisPredicate } from "../utils";
 
 interface UpdateSource {
@@ -36,24 +36,7 @@ async function patchAnalysis(newAnalysis: AnalysisOptions) {
 export function useAnalysisUpdateMutation() {
     const queryClient = useQueryClient();
     const mutation = useMutation<Analysis, Response, AnalysisOptions>(patchAnalysis, {
-        onSuccess: (newAnalysis, changes) => {
-            let oldAnalysis: AnalysisOptions | Partial<AnalysisDetailed> | undefined;
-            oldAnalysis = queryClient.getQueryData<AnalysisDetailed>([
-                "analyses",
-                newAnalysis.analysis_id,
-            ]);
-            if (!oldAnalysis) {
-                // we may not have fetched for analysis details yet, so we account for that here
-                const oldAnalyses = queryClient.getQueryData<Analysis[]>("analyses");
-                if (oldAnalyses)
-                    oldAnalysis = oldAnalyses.find(a => a.analysis_id === newAnalysis.analysis_id);
-                else {
-                    const { source, ...rest } = changes;
-                    oldAnalysis = rest;
-                }
-            }
-            const updatedAnalysis = { ...oldAnalysis, ...newAnalysis };
-            queryClient.setQueryData(["analyses", newAnalysis.analysis_id], updatedAnalysis);
+        onSuccess: () => {
             queryClient.invalidateQueries({
                 predicate: invalidateAnalysisPredicate,
             });

--- a/react/src/hooks/datasets/useDatasetsPage.tsx
+++ b/react/src/hooks/datasets/useDatasetsPage.tsx
@@ -19,8 +19,9 @@ async function fetchDatasets(query: QueryWithSearchOptions<DatasetDetailed>) {
 export function useDatasetsPage() {
     const queryClient = useQueryClient();
     return async (query: QueryWithSearchOptions<DatasetDetailed>) => {
-        return await queryClient.fetchQuery<QueryResult<DatasetDetailed>, Error>(["datasets", query], () =>
-            fetchDatasets(query)
+        return await queryClient.fetchQuery<QueryResult<DatasetDetailed>, Error>(
+            ["datasets", query],
+            () => fetchDatasets(query)
         );
     };
 }

--- a/react/src/hooks/datasets/useDatasetsPage.tsx
+++ b/react/src/hooks/datasets/useDatasetsPage.tsx
@@ -1,26 +1,25 @@
 import { QueryResult } from "@material-table/core";
 import { useQueryClient } from "react-query";
-import { Dataset, QueryWithSearchOptions } from "../../typings";
+import { DatasetDetailed, QueryWithSearchOptions } from "../../typings";
 
 import { queryTableData } from "../utils";
 
 export const GET_DATASETS_URL = "/api/datasets";
 
-async function fetchDatasets(query: QueryWithSearchOptions<Dataset>) {
+async function fetchDatasets(query: QueryWithSearchOptions<DatasetDetailed>) {
     const queryResult = await queryTableData(query, GET_DATASETS_URL);
-    console.log("fetchDatasets:", queryResult);
     return queryResult;
 }
 
 /**
- * Return a function for GET /api/analyses with query parameters.
+ * Return a function for GET /api/datasets with query parameters.
  *
  * Used with material-table's remote data feature.
  */
 export function useDatasetsPage() {
     const queryClient = useQueryClient();
-    return async (query: QueryWithSearchOptions<Dataset>) => {
-        return await queryClient.fetchQuery<QueryResult<Dataset>, Error>(["datasets", query], () =>
+    return async (query: QueryWithSearchOptions<DatasetDetailed>) => {
+        return await queryClient.fetchQuery<QueryResult<DatasetDetailed>, Error>(["datasets", query], () =>
             fetchDatasets(query)
         );
     };

--- a/react/src/hooks/datasets/useDatasetsPage.tsx
+++ b/react/src/hooks/datasets/useDatasetsPage.tsx
@@ -1,13 +1,14 @@
 import { QueryResult } from "@material-table/core";
 import { useQueryClient } from "react-query";
-import { Dataset, QueryWithSearchOptions } from "../../typings";
+import { Dataset, DatasetDetailed, QueryWithSearchOptions } from "../../typings";
 
 import { queryTableData } from "../utils";
 
 export const GET_DATASETS_URL = "/api/datasets";
 
-async function fetchDatasets(query: QueryWithSearchOptions<Dataset>) {
+async function fetchDatasets(query: QueryWithSearchOptions<DatasetDetailed>) {
     const queryResult = await queryTableData(query, GET_DATASETS_URL);
+    console.log("fetchDatasets:", queryResult);
     return queryResult;
 }
 
@@ -18,8 +19,8 @@ async function fetchDatasets(query: QueryWithSearchOptions<Dataset>) {
  */
 export function useDatasetsPage() {
     const queryClient = useQueryClient();
-    return async (query: QueryWithSearchOptions<Dataset>) => {
-        return await queryClient.fetchQuery<QueryResult<Dataset>, Error>(["datasets", query], () =>
+    return async (query: QueryWithSearchOptions<DatasetDetailed>) => {
+        return await queryClient.fetchQuery<QueryResult<DatasetDetailed>, Error>(["datasets", query], () =>
             fetchDatasets(query)
         );
     };

--- a/react/src/hooks/datasets/useDatasetsPage.tsx
+++ b/react/src/hooks/datasets/useDatasetsPage.tsx
@@ -1,12 +1,12 @@
 import { QueryResult } from "@material-table/core";
 import { useQueryClient } from "react-query";
-import { Dataset, DatasetDetailed, QueryWithSearchOptions } from "../../typings";
+import { Dataset, QueryWithSearchOptions } from "../../typings";
 
 import { queryTableData } from "../utils";
 
 export const GET_DATASETS_URL = "/api/datasets";
 
-async function fetchDatasets(query: QueryWithSearchOptions<DatasetDetailed>) {
+async function fetchDatasets(query: QueryWithSearchOptions<Dataset>) {
     const queryResult = await queryTableData(query, GET_DATASETS_URL);
     console.log("fetchDatasets:", queryResult);
     return queryResult;
@@ -19,8 +19,8 @@ async function fetchDatasets(query: QueryWithSearchOptions<DatasetDetailed>) {
  */
 export function useDatasetsPage() {
     const queryClient = useQueryClient();
-    return async (query: QueryWithSearchOptions<DatasetDetailed>) => {
-        return await queryClient.fetchQuery<QueryResult<DatasetDetailed>, Error>(["datasets", query], () =>
+    return async (query: QueryWithSearchOptions<Dataset>) => {
+        return await queryClient.fetchQuery<QueryResult<Dataset>, Error>(["datasets", query], () =>
             fetchDatasets(query)
         );
     };

--- a/react/src/typings.tsx
+++ b/react/src/typings.tsx
@@ -124,13 +124,19 @@ export const isRNASeqDataset = (dataset: RNASeqDataset | Dataset): dataset is RN
     dataset.discriminator === "rnaseq_dataset";
 
 // Result from /api/datasets/:id
-export interface DatasetDetails {
+// export interface DatasetDetails {
+//     tissue_sample?: Sample;
+//     institution?: string;
+//     analyses?: Analysis[];
+// }
+
+export type DatasetDetailed = Dataset & {
     tissue_sample: Sample;
     institution: string;
     analyses: Analysis[];
-}
+};
 
-export type DatasetDetailed = Dataset & DatasetDetails;
+
 
 export interface Analysis {
     analysis_id: string;
@@ -154,7 +160,7 @@ export interface Analysis {
 }
 
 export interface AnalysisDetails {
-    datasets: (Dataset & { participant_notes: string })[];
+    datasets: (DatasetDetailed & { participant_notes: string })[];
 }
 
 export type AnalysisDetailed = Analysis & AnalysisDetails;

--- a/react/src/typings.tsx
+++ b/react/src/typings.tsx
@@ -129,7 +129,6 @@ export type DatasetDetailed = Dataset & {
 export const isRNASeqDataset = (dataset: Dataset): dataset is RNASeqDataset =>
     dataset.discriminator === "rnaseq_dataset";
 
-
 export interface Analysis {
     analysis_id: string;
     analysis_state: PipelineStatus;

--- a/react/src/typings.tsx
+++ b/react/src/typings.tsx
@@ -119,23 +119,15 @@ interface RNASeqDataset extends DNADataset {
 
 export type Dataset = RNASeqDataset | DNADataset;
 
-// dataset typeguard
-export const isRNASeqDataset = (dataset: RNASeqDataset | Dataset): dataset is RNASeqDataset =>
-    dataset.discriminator === "rnaseq_dataset";
-
-// Result from /api/datasets/:id
-// export interface DatasetDetails {
-//     tissue_sample?: Sample;
-//     institution?: string;
-//     analyses?: Analysis[];
-// }
-
 export type DatasetDetailed = Dataset & {
     tissue_sample: Sample;
     institution: string;
     analyses: Analysis[];
 };
 
+// dataset typeguard
+export const isRNASeqDataset = (dataset: Dataset): dataset is RNASeqDataset =>
+    dataset.discriminator === "rnaseq_dataset";
 
 
 export interface Analysis {


### PR DESCRIPTION
1. In `Dataset` modal and table, disable a dataset's ` dataset_type` editing if there's an analysis associated with it. Now the user can't change a `dataset_type` once there's an analysis associated with it.

2. Display all analyses, including the ones that don't have an assignee.

3. Fix the table nonrefreshing issue when a re-analysis is requested through the dialogue.

4. Fix the table nonrefreshing issue when an analysis is cancelled.

Other issues to be addressed in another ticket: 

- When the user selects an analysis and performs any of the following actions: run, complete, error, set assignee, the status is not reflected immediately.  For some of these actions, the snackbar would not even show up. My preliminary investigation for the action `Run Analysis` reveals that this is due to the asynchronous nature of `setActiveRows()` such that `changeAnalysisState` is not supplied with the new `activeRows`. 