### PR TITLE
Flask: Check for duplicate datasets

### DIFF
--- a/flask/app/routes.py
+++ b/flask/app/routes.py
@@ -546,7 +546,8 @@ def bulk_update():
             app.logger.error("\tThe dataset is a duplicate of an existing dataset.")
             db.session.rollback()
             abort(
-                400, "One of the added datasets is a duplicate of an existing dataset."
+                400,
+                "One of the added datasets is a duplicate of an existing or added dataset.",
             )
 
         # Create a new tissue sample under this participant

--- a/flask/app/routes.py
+++ b/flask/app/routes.py
@@ -469,7 +469,7 @@ def bulk_update():
                 )
                 institution_obj = models.Institution(institution=institution)
                 db.session.add(institution_obj)
-                transaction_or_abort(db.session.commit)
+                transaction_or_abort(db.session.flush)
                 institution_id = institution_obj.institution_id
         else:
             app.logger.debug("\tNo institution supplied")
@@ -525,6 +525,30 @@ def bulk_update():
                     e.description, str(i + 1)
                 ),
             )
+
+        app.logger.debug("\tChecking duplicate dataset..")
+        db_datasets_number = (
+            db.session.query(models.Dataset)
+            .join(models.Dataset.tissue_sample)
+            .join(models.TissueSample.participant)
+            .join(models.Participant.family)
+            .filter(
+                models.Dataset.dataset_type == row.get("dataset_type"),
+                models.Participant.family_id == family_id,
+                models.Participant.participant_id == participant_id,
+                models.Dataset.sequencing_date == sequencing_date,
+                models.TissueSample.tissue_sample_type == row.get("tissue_sample_type"),
+            )
+            .count()
+        )
+
+        if db_datasets_number > 0:
+            app.logger.error("\tThe dataset is a duplicate of an existing dataset.")
+            db.session.rollback()
+            abort(
+                400, "One of the added datasets is a duplicate of an existing dataset."
+            )
+
         # Create a new tissue sample under this participant
         app.logger.debug("\tCreating a new tissue sample..")
         tissue_sample = models.TissueSample(


### PR DESCRIPTION
1. Abort the transaction when either 1) one of the newly uploaded datasets is a duplicate of an existing dataset or 2) there are duplicates among the newly uploaded datasets. The combination of unique fields is: `participant_id`-`family_id`-`tissue_sample_type`-`dataset_type`-`sequencing_date`.
2. Added unit tests. Changed a few existing unit tests to avoid errors raised by duplicate datasets. 
3. Changed line 472 in `routes.py` to `db.session.flush`

Observation: `sequencing_date` of a dataset is not shown in the dataset table nor in the dataset modal. Maybe the reason is that this is a piece of information that the user should not have access to?   