### PR TITLE
Flask: Remove related objects when a dataset is deleted. 

### DIFF
--- a/flask/app/datasets.py
+++ b/flask/app/datasets.py
@@ -389,9 +389,6 @@ def delete_dataset(id: int):
     participant = tissue_sample.participant
     family = participant.family
 
-    # Remove permission groups with the corresponding dataset ID in groups_datasets table
-    dataset.groups = []
-
     if not dataset.analyses:
         try:
             db.session.delete(dataset)
@@ -400,15 +397,11 @@ def delete_dataset(id: int):
             if len(tissue_sample.datasets) == 0:
                 db.session.delete(tissue_sample)
 
-            # Only delete participant if it has no other datasets.
-            participant_datasets = []
-            for tissue_sample in participant.tissue_samples:
-                for d in tissue_sample.datasets:
-                    participant_datasets.append(d)
-            if len(participant_datasets) == 0:
+            # Only delete participant if it has no other tissue samples.
+            if len(participant.tissue_samples) == 0:
                 db.session.delete(participant)
 
-                # only delete family if it has no other participants
+                # only delete family if it has no other participants.
                 if len(family.participants) == 0:
                     db.session.delete(family)
             db.session.commit()

--- a/flask/app/datasets.py
+++ b/flask/app/datasets.py
@@ -387,8 +387,8 @@ def delete_dataset(id: int):
     family = participant.family
 
     if not dataset.analyses:
-        dataset = update_dataset_linked_files(dataset, [])
         try:
+            dataset = update_dataset_linked_files(dataset, [])
             db.session.delete(dataset)
 
             # Only delete tissue sample if it doesn't have any associated datasets left.

--- a/flask/app/datasets.py
+++ b/flask/app/datasets.py
@@ -378,10 +378,7 @@ def update_dataset(id: int):
 def delete_dataset(id: int):
     dataset = (
         models.Dataset.query.filter(models.Dataset.dataset_id == id)
-        .options(
-            joinedload(models.Dataset.analyses),
-            joinedload(models.Dataset.groups),
-        )
+        .options(joinedload(models.Dataset.analyses))
         .first_or_404()
     )
 
@@ -390,6 +387,7 @@ def delete_dataset(id: int):
     family = participant.family
 
     if not dataset.analyses:
+        dataset = update_dataset_linked_files(dataset, [])
         try:
             db.session.delete(dataset)
 
@@ -401,7 +399,7 @@ def delete_dataset(id: int):
             if len(participant.tissue_samples) == 0:
                 db.session.delete(participant)
 
-                # only delete family if it has no other participants.
+                # Only delete family if it has no other participants.
                 if len(family.participants) == 0:
                     db.session.delete(family)
             db.session.commit()


### PR DESCRIPTION
Addresses issue #941. 

As a side note, this is how we handle `tissue_sample` when a dataset is deleted, in the master branch:[ link ](https://github.com/ccmbioinfo/stager/blob/e0bbcdf717e25fba568e0b8674f02031e5a2db6e/flask/app/datasets.py#L378)

This is how I handle it in this PR:[ link ](https://github.com/ccmbioinfo/stager/blob/9012059f07a199c8684fb07bb0eb3550ac089f11/flask/app/datasets.py#L378)

You can see that my approach is different in the sense that I don’t check `dataset_id` when looping through tissue_sample’s datasets. This is because I get rid of joinedLoad.

I prefer my approach because it's clearer as to what to expect, in the sense of SQLAlchemy queries. Feel free to let me know if the old approach is what we want. 

Closes #941