### PR TITLE
React: disable fetch to labs.json

### DIFF
--- a/react/src/App.tsx
+++ b/react/src/App.tsx
@@ -86,10 +86,10 @@ function BaseApp(props: { darkMode: boolean; toggleDarkMode: () => void }) {
             setAuthenticated(loginResult.ok);
 
             let endpoints: LabSelection[] = [];
-            const availibleEndpoints = await fetch("/labs.json");
+            /* const availibleEndpoints = await fetch("/labs.json");
             if (availibleEndpoints.ok) {
                 endpoints = await availibleEndpoints.json();
-            }
+            } */
 
             if (endpoints.length > 0) {
                 setAvailableEndpoints(endpoints);


### PR DESCRIPTION
If `labs.json` does not exist, the index page will be returned instead, which the processing code can't handle. 