### PR TITLE
Flask/React: update /api/unlinked to query by prefix only, debounce requests on frontend

### DIFF
--- a/flask/app/buckets.py
+++ b/flask/app/buckets.py
@@ -16,59 +16,56 @@ bucket_blueprint = Blueprint(
 @bucket_blueprint.route("/api/unlinked/<prefix>", methods=["GET"])
 @login_required
 def get_unlinked_files(prefix: str):
-
-    app.logger.debug("this is prefix backend", prefix)
-
-    minio_client = get_minio_client()
-
-    app.logger.debug("Getting all minio bucket names..")
-    all_bucket_names = [bucket.name for bucket in minio_client.list_buckets()]
-    app.logger.debug("All bucket names", all_bucket_names)
-
-    # Remove buckets the current user does not have access to assuming group_code.lower() == bucket name
-    app.logger.debug("Getting all buckets that user has access to..")
-    user = (
-        models.User.query.filter_by(user_id=current_user.user_id)
-        .options(joinedload(models.User.groups))
-        .first()
-    )
-
-    valid_bucket_names = []
-    for group in user.groups:
-        code = group.group_code.lower()
-        if code in all_bucket_names:
-            valid_bucket_names.append(code)
-
-    app.logger.debug("Getting all files in valid minio buckets..")
-    all_files = []
-    for bucket in valid_bucket_names:
-        objs = minio_client.list_objects(bucket, prefix=prefix, recursive=True)
-        for obj in objs:
-            all_files.append(bucket + "/" + obj.object_name)
-
-    app.logger.debug("Getting all linked files..")
-
     files = []
 
-    linked_files = {
-        f.path: True
-        for f in models.File.query.filter(
-            or_(models.File.multiplexed == None,
-                models.File.multiplexed == False)
-        ).all()
-    }
+    if prefix != "None":
 
-    linkable_files = {
-        f.path: True
-        for f in models.File.query.filter(models.File.multiplexed == True).all()
-    }
+        minio_client = get_minio_client()
 
-    for file_name in all_files:
-        if linkable_files.get(file_name):
-            files.append({"path": file_name, "multiplexed": True})
-        elif not linked_files.get(file_name):
-            files.append({"path": file_name, "multiplexed": False})
+        app.logger.debug("Getting all minio bucket names..")
+        all_bucket_names = [bucket.name for bucket in minio_client.list_buckets()]
 
-    app.logger.debug(f"Returning JSON array with prefix {prefix}..")
+        # Remove buckets the current user does not have access to assuming group_code.lower() == bucket name
+        app.logger.debug("Getting all buckets that user has access to..")
+        user = (
+            models.User.query.filter_by(user_id=current_user.user_id)
+            .options(joinedload(models.User.groups))
+            .first()
+        )
+
+        valid_bucket_names = []
+        for group in user.groups:
+            code = group.group_code.lower()
+            if code in all_bucket_names:
+                valid_bucket_names.append(code)
+
+        app.logger.debug("Getting all files in valid minio buckets..")
+        all_files = []
+        for bucket in valid_bucket_names:
+            objs = minio_client.list_objects(bucket, prefix=prefix, recursive=True)
+            for obj in objs:
+                all_files.append(bucket + "/" + obj.object_name)
+
+        app.logger.debug("Getting all linked files..")
+
+        linked_files = {
+            f.path: True
+            for f in models.File.query.filter(
+                or_(models.File.multiplexed == None, models.File.multiplexed == False)
+            ).all()
+        }
+
+        linkable_files = {
+            f.path: True
+            for f in models.File.query.filter(models.File.multiplexed == True).all()
+        }
+
+        for file_name in all_files:
+            if linkable_files.get(file_name):
+                files.append({"path": file_name, "multiplexed": True})
+            elif not linked_files.get(file_name):
+                files.append({"path": file_name, "multiplexed": False})
+
+        app.logger.debug(f"Returning JSON array with prefix {prefix}..")
 
     return jsonify(sorted(files, key=lambda f: f["path"]))

--- a/flask/app/buckets.py
+++ b/flask/app/buckets.py
@@ -13,9 +13,9 @@ bucket_blueprint = Blueprint(
 )
 
 
-@bucket_blueprint.route("/api/unlinked", methods=["GET"])
+@bucket_blueprint.route("/api/unlinked/<string:prefix>", methods=["GET"])
 @login_required
-def get_unlinked_files():
+def get_unlinked_files(prefix: str):
 
     minio_client = get_minio_client()
 
@@ -39,7 +39,7 @@ def get_unlinked_files():
     app.logger.debug("Getting all files in valid minio buckets..")
     all_files = []
     for bucket in valid_bucket_names:
-        objs = minio_client.list_objects(bucket, recursive=True)
+        objs = minio_client.list_objects(bucket, prefix=prefix, recursive=True)
         for obj in objs:
             all_files.append(bucket + "/" + obj.object_name)
 
@@ -50,7 +50,8 @@ def get_unlinked_files():
     linked_files = {
         f.path: True
         for f in models.File.query.filter(
-            or_(models.File.multiplexed == None, models.File.multiplexed == False)
+            or_(models.File.multiplexed == None,
+                models.File.multiplexed == False)
         ).all()
     }
 

--- a/flask/app/buckets.py
+++ b/flask/app/buckets.py
@@ -1,4 +1,4 @@
-from flask import jsonify, Blueprint, current_app as app
+from flask import abort, jsonify, Blueprint, current_app as app, request
 from flask_login import current_user, login_required
 from sqlalchemy.orm import joinedload
 from sqlalchemy import or_
@@ -13,19 +13,33 @@ bucket_blueprint = Blueprint(
 )
 
 
-@bucket_blueprint.route("/api/unlinked/<prefix>", methods=["GET"])
+@bucket_blueprint.route("/api/unlinked", methods=["GET"])
 @login_required
-def get_unlinked_files(prefix: str):
+def get_unlinked_files():
+
+    path = request.args.get("path", type=str)
+
     files = []
 
-    if prefix != "None":
+    if path != "None":
+        filepath = path.split("/", 1)
+        if len(filepath) < 2:
+            abort(
+                400,
+                description="Please make sure your file path contains both folder and file name, such as c4r/folder1/folder2/filename",
+            )
+
+        bucket = filepath[0]
+        prefix = filepath[1]
 
         minio_client = get_minio_client()
 
+        # Check if the bucket in file path exists
         app.logger.debug("Getting all minio bucket names..")
         all_bucket_names = [bucket.name for bucket in minio_client.list_buckets()]
+        if bucket not in all_bucket_names:
+            abort(400, description=f"Bucket name must be one of {all_bucket_names}")
 
-        # Remove buckets the current user does not have access to assuming group_code.lower() == bucket name
         app.logger.debug("Getting all buckets that user has access to..")
         user = (
             models.User.query.filter_by(user_id=current_user.user_id)
@@ -33,18 +47,22 @@ def get_unlinked_files(prefix: str):
             .first()
         )
 
+        # Check if the user has access to the bucket, assuming group_code.lower() == bucket name
         valid_bucket_names = []
         for group in user.groups:
             code = group.group_code.lower()
             if code in all_bucket_names:
                 valid_bucket_names.append(code)
 
-        app.logger.debug("Getting all files in valid minio buckets..")
+        if bucket not in valid_bucket_names:
+            abort(400, description=f"User does not have access to bucket {bucket}.")
+
+        # Get files with prefix in the bucket user specifies
+        app.logger.debug("Getting all files in user minio buckets..")
         all_files = []
-        for bucket in valid_bucket_names:
-            objs = minio_client.list_objects(bucket, prefix=prefix, recursive=True)
-            for obj in objs:
-                all_files.append(bucket + "/" + obj.object_name)
+        objs = minio_client.list_objects(bucket, prefix=prefix, recursive=True)
+        for obj in objs:
+            all_files.append(bucket + "/" + obj.object_name)
 
         app.logger.debug("Getting all linked files..")
 

--- a/flask/app/buckets.py
+++ b/flask/app/buckets.py
@@ -13,14 +13,17 @@ bucket_blueprint = Blueprint(
 )
 
 
-@bucket_blueprint.route("/api/unlinked/<string:prefix>", methods=["GET"])
+@bucket_blueprint.route("/api/unlinked/<prefix>", methods=["GET"])
 @login_required
 def get_unlinked_files(prefix: str):
+
+    app.logger.debug('this is prefix backend', prefix)
 
     minio_client = get_minio_client()
 
     app.logger.debug("Getting all minio bucket names..")
     all_bucket_names = [bucket.name for bucket in minio_client.list_buckets()]
+    app.logger.debug("All bucket names", all_bucket_names)
 
     # Remove buckets the current user does not have access to assuming group_code.lower() == bucket name
     app.logger.debug("Getting all buckets that user has access to..")
@@ -39,6 +42,7 @@ def get_unlinked_files(prefix: str):
     app.logger.debug("Getting all files in valid minio buckets..")
     all_files = []
     for bucket in valid_bucket_names:
+        app.logger.debug("each bucket", bucket, prefix)
         objs = minio_client.list_objects(bucket, prefix=prefix, recursive=True)
         for obj in objs:
             all_files.append(bucket + "/" + obj.object_name)
@@ -66,6 +70,65 @@ def get_unlinked_files(prefix: str):
         elif not linked_files.get(file_name):
             files.append({"path": file_name, "multiplexed": False})
 
-    app.logger.debug("Returning JSON array..")
+    app.logger.debug("Returning JSON array with prefix..")
+    app.logger.debug(files)
+
+    return jsonify(sorted(files, key=lambda f: f["path"]))
+
+
+@bucket_blueprint.route("/api/unlinked", methods=["GET"])
+@login_required
+def get_unlinked_files_no_prefix():
+
+    minio_client = get_minio_client()
+
+    app.logger.debug("Getting all minio bucket names..")
+    all_bucket_names = [bucket.name for bucket in minio_client.list_buckets()]
+
+    # Remove buckets the current user does not have access to assuming group_code.lower() == bucket name
+    app.logger.debug("Getting all buckets that user has access to..")
+    user = (
+        models.User.query.filter_by(user_id=current_user.user_id)
+        .options(joinedload(models.User.groups))
+        .first()
+    )
+
+    valid_bucket_names = []
+    for group in user.groups:
+        code = group.group_code.lower()
+        if code in all_bucket_names:
+            valid_bucket_names.append(code)
+
+    app.logger.debug("Getting all files in valid minio buckets..")
+    all_files = []
+    for bucket in valid_bucket_names:
+        objs = minio_client.list_objects(bucket, recursive=True)
+        for obj in objs:
+            all_files.append(bucket + "/" + obj.object_name)
+
+    app.logger.debug("Getting all linked files..")
+
+    files = []
+
+    linked_files = {
+        f.path: True
+        for f in models.File.query.filter(
+            or_(models.File.multiplexed == None,
+                models.File.multiplexed == False)
+        ).all()
+    }
+
+    linkable_files = {
+        f.path: True
+        for f in models.File.query.filter(models.File.multiplexed == True).all()
+    }
+
+    for file_name in all_files:
+        if linkable_files.get(file_name):
+            files.append({"path": file_name, "multiplexed": True})
+        elif not linked_files.get(file_name):
+            files.append({"path": file_name, "multiplexed": False})
+
+    app.logger.debug("Returning JSON array without prefix..")
 
     return jsonify(sorted(files, key=lambda f: f["path"]))

--- a/flask/app/buckets.py
+++ b/flask/app/buckets.py
@@ -17,7 +17,7 @@ bucket_blueprint = Blueprint(
 @login_required
 def get_unlinked_files(prefix: str):
 
-    app.logger.debug('this is prefix backend', prefix)
+    app.logger.debug("this is prefix backend", prefix)
 
     minio_client = get_minio_client()
 
@@ -45,6 +45,7 @@ def get_unlinked_files(prefix: str):
         app.logger.debug("each bucket", bucket, prefix)
         objs = minio_client.list_objects(bucket, prefix=prefix, recursive=True)
         for obj in objs:
+            app.logger.debug("hello2")
             all_files.append(bucket + "/" + obj.object_name)
 
     app.logger.debug("Getting all linked files..")
@@ -54,8 +55,7 @@ def get_unlinked_files(prefix: str):
     linked_files = {
         f.path: True
         for f in models.File.query.filter(
-            or_(models.File.multiplexed == None,
-                models.File.multiplexed == False)
+            or_(models.File.multiplexed == None, models.File.multiplexed == False)
         ).all()
     }
 
@@ -70,65 +70,7 @@ def get_unlinked_files(prefix: str):
         elif not linked_files.get(file_name):
             files.append({"path": file_name, "multiplexed": False})
 
-    app.logger.debug("Returning JSON array with prefix..")
+    app.logger.debug(f"Returning JSON array with prefix {prefix}..")
     app.logger.debug(files)
-
-    return jsonify(sorted(files, key=lambda f: f["path"]))
-
-
-@bucket_blueprint.route("/api/unlinked", methods=["GET"])
-@login_required
-def get_unlinked_files_no_prefix():
-
-    minio_client = get_minio_client()
-
-    app.logger.debug("Getting all minio bucket names..")
-    all_bucket_names = [bucket.name for bucket in minio_client.list_buckets()]
-
-    # Remove buckets the current user does not have access to assuming group_code.lower() == bucket name
-    app.logger.debug("Getting all buckets that user has access to..")
-    user = (
-        models.User.query.filter_by(user_id=current_user.user_id)
-        .options(joinedload(models.User.groups))
-        .first()
-    )
-
-    valid_bucket_names = []
-    for group in user.groups:
-        code = group.group_code.lower()
-        if code in all_bucket_names:
-            valid_bucket_names.append(code)
-
-    app.logger.debug("Getting all files in valid minio buckets..")
-    all_files = []
-    for bucket in valid_bucket_names:
-        objs = minio_client.list_objects(bucket, recursive=True)
-        for obj in objs:
-            all_files.append(bucket + "/" + obj.object_name)
-
-    app.logger.debug("Getting all linked files..")
-
-    files = []
-
-    linked_files = {
-        f.path: True
-        for f in models.File.query.filter(
-            or_(models.File.multiplexed == None,
-                models.File.multiplexed == False)
-        ).all()
-    }
-
-    linkable_files = {
-        f.path: True
-        for f in models.File.query.filter(models.File.multiplexed == True).all()
-    }
-
-    for file_name in all_files:
-        if linkable_files.get(file_name):
-            files.append({"path": file_name, "multiplexed": True})
-        elif not linked_files.get(file_name):
-            files.append({"path": file_name, "multiplexed": False})
-
-    app.logger.debug("Returning JSON array without prefix..")
 
     return jsonify(sorted(files, key=lambda f: f["path"]))

--- a/flask/app/buckets.py
+++ b/flask/app/buckets.py
@@ -36,11 +36,9 @@ def get_unlinked_files():
 
         # Check if the bucket in file path exists
         app.logger.debug("Getting all minio bucket names..")
-        all_bucket_names = [
-            bucket.name for bucket in minio_client.list_buckets()]
+        all_bucket_names = [bucket.name for bucket in minio_client.list_buckets()]
         if bucket_name not in all_bucket_names:
-            abort(
-                400, description=f"Bucket name must be one of {all_bucket_names}")
+            abort(400, description=f"Bucket name must be one of {all_bucket_names}")
 
         app.logger.debug("Getting all buckets that user has access to..")
         user = (
@@ -64,8 +62,7 @@ def get_unlinked_files():
         # Get files with prefix in the bucket user specifies
         app.logger.debug("Getting all files in user minio buckets..")
         all_files = []
-        objs = minio_client.list_objects(
-            bucket_name, prefix=file_name, recursive=True)
+        objs = minio_client.list_objects(bucket_name, prefix=file_name, recursive=True)
         for obj in objs:
             if obj.object_name == file_name:
                 all_files.append(bucket_name + "/" + obj.object_name)
@@ -75,8 +72,7 @@ def get_unlinked_files():
         linked_files = {
             f.path: True
             for f in models.File.query.filter(
-                or_(models.File.multiplexed == None,
-                    models.File.multiplexed == False)
+                or_(models.File.multiplexed == None, models.File.multiplexed == False)
             ).all()
         }
 

--- a/flask/app/buckets.py
+++ b/flask/app/buckets.py
@@ -36,11 +36,9 @@ def get_unlinked_files():
 
         # Check if the bucket in file path exists
         app.logger.debug("Getting all minio bucket names..")
-        all_bucket_names = [
-            bucket.name for bucket in minio_client.list_buckets()]
+        all_bucket_names = [bucket.name for bucket in minio_client.list_buckets()]
         if bucket_name not in all_bucket_names:
-            abort(
-                400, description=f"Bucket name must be one of {all_bucket_names}")
+            abort(400, description=f"Bucket name must be one of {all_bucket_names}")
 
         app.logger.debug("Getting all buckets that user has access to..")
         user = (
@@ -58,13 +56,13 @@ def get_unlinked_files():
 
         if bucket_name not in valid_bucket_names:
             abort(
-                400, description=f"User does not have access to bucket {bucket_name}.")
+                400, description=f"User does not have access to bucket {bucket_name}."
+            )
 
         # Get files with prefix in the bucket user specifies
         app.logger.debug("Getting all files in user minio buckets..")
         all_files = []
-        objs = minio_client.list_objects(
-            bucket_name, prefix=file_name, recursive=True)
+        objs = minio_client.list_objects(bucket_name, prefix=file_name, recursive=True)
         for obj in objs:
             if obj.object_name == file_name:
                 all_files.append(bucket_name + "/" + obj.object_name)
@@ -74,8 +72,7 @@ def get_unlinked_files():
         linked_files = {
             f.path: True
             for f in models.File.query.filter(
-                or_(models.File.multiplexed == None,
-                    models.File.multiplexed == False)
+                or_(models.File.multiplexed == None, models.File.multiplexed == False)
             ).all()
         }
 

--- a/flask/app/buckets.py
+++ b/flask/app/buckets.py
@@ -42,10 +42,8 @@ def get_unlinked_files(prefix: str):
     app.logger.debug("Getting all files in valid minio buckets..")
     all_files = []
     for bucket in valid_bucket_names:
-        app.logger.debug("each bucket", bucket, prefix)
         objs = minio_client.list_objects(bucket, prefix=prefix, recursive=True)
         for obj in objs:
-            app.logger.debug("hello2")
             all_files.append(bucket + "/" + obj.object_name)
 
     app.logger.debug("Getting all linked files..")
@@ -72,6 +70,5 @@ def get_unlinked_files(prefix: str):
             files.append({"path": file_name, "multiplexed": False})
 
     app.logger.debug(f"Returning JSON array with prefix {prefix}..")
-    app.logger.debug(files)
 
     return jsonify(sorted(files, key=lambda f: f["path"]))

--- a/flask/app/buckets.py
+++ b/flask/app/buckets.py
@@ -55,7 +55,8 @@ def get_unlinked_files(prefix: str):
     linked_files = {
         f.path: True
         for f in models.File.query.filter(
-            or_(models.File.multiplexed == None, models.File.multiplexed == False)
+            or_(models.File.multiplexed == None,
+                models.File.multiplexed == False)
         ).all()
     }
 

--- a/flask/app/buckets.py
+++ b/flask/app/buckets.py
@@ -26,7 +26,7 @@ def get_unlinked_files():
         if len(filepath) < 2:
             abort(
                 400,
-                description="Please make sure your file path contains both folder and file name, such as c4r/folder1/folder2/filename",
+                description="Please make sure your filepath contains both bucket name and prefixes, such as c4r/folder1/folder2/myfile.txt",
             )
 
         bucket_name = filepath[0].strip()
@@ -36,9 +36,11 @@ def get_unlinked_files():
 
         # Check if the bucket in file path exists
         app.logger.debug("Getting all minio bucket names..")
-        all_bucket_names = [bucket.name for bucket in minio_client.list_buckets()]
+        all_bucket_names = [
+            bucket.name for bucket in minio_client.list_buckets()]
         if bucket_name not in all_bucket_names:
-            abort(400, description=f"Bucket name must be one of {all_bucket_names}")
+            abort(
+                400, description=f"Bucket name must be one of {all_bucket_names}")
 
         app.logger.debug("Getting all buckets that user has access to..")
         user = (
@@ -62,7 +64,8 @@ def get_unlinked_files():
         # Get files with prefix in the bucket user specifies
         app.logger.debug("Getting all files in user minio buckets..")
         all_files = []
-        objs = minio_client.list_objects(bucket_name, prefix=file_name, recursive=True)
+        objs = minio_client.list_objects(
+            bucket_name, prefix=file_name, recursive=True)
         for obj in objs:
             if obj.object_name == file_name:
                 all_files.append(bucket_name + "/" + obj.object_name)
@@ -72,7 +75,8 @@ def get_unlinked_files():
         linked_files = {
             f.path: True
             for f in models.File.query.filter(
-                or_(models.File.multiplexed == None, models.File.multiplexed == False)
+                or_(models.File.multiplexed == None,
+                    models.File.multiplexed == False)
             ).all()
         }
 

--- a/react/src/AddDatasets/components/DataEntryTable.tsx
+++ b/react/src/AddDatasets/components/DataEntryTable.tsx
@@ -68,7 +68,7 @@ export default function DataEntryTable({
 
     const [files, setFiles] = useState<UnlinkedFile[]>([]);
 
-    const filesQuery = useUnlinkedFilesQuery();
+    const filesQuery = useUnlinkedFilesQuery('c4r');
     const { data: institutions } = useInstitutionsQuery();
     const { data: enums } = useEnumsQuery();
 

--- a/react/src/AddDatasets/components/DataEntryTable.tsx
+++ b/react/src/AddDatasets/components/DataEntryTable.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback } from "react";
 import {
     Button,
     makeStyles,
@@ -13,7 +13,7 @@ import {
 import { Add } from "@material-ui/icons";
 import dayjs from "dayjs";
 import { ALL_OPTIONAL_FIELDS, createEmptyRow, makeFreshColumns } from "..";
-import { useEnumsQuery, useInstitutionsQuery, useUnlinkedFilesQuery } from "../../hooks";
+import { useEnumsQuery, useInstitutionsQuery } from "../../hooks";
 import {
     DataEntryColumnConfig,
     DataEntryField,
@@ -66,9 +66,6 @@ export default function DataEntryTable({
 }: DataEntryTableProps) {
     const classes = useTableStyles();
 
-    const [files, setFiles] = useState<UnlinkedFile[]>([]);
-
-    const filesQuery = useUnlinkedFilesQuery();
     const { data: institutions } = useInstitutionsQuery();
     const { data: enums } = useEnumsQuery();
 
@@ -96,13 +93,9 @@ export default function DataEntryTable({
             )
         );
 
-    useEffect(() => {
-        if (filesQuery.isSuccess) setFiles(filesQuery.data);
-    }, [filesQuery]);
-
     // Return the options for a given cell based on row, column
     function getOptions(rowIndex: number, col: DataEntryColumnConfig, families: Family[]) {
-        return _getOptions(data, col, rowIndex, families, enums, files, institutions || []);
+        return _getOptions(data, col, rowIndex, families, enums, institutions || []);
     }
 
     function toggleHideColumn(field: DataEntryField) {

--- a/react/src/AddDatasets/components/DataEntryTable.tsx
+++ b/react/src/AddDatasets/components/DataEntryTable.tsx
@@ -68,7 +68,7 @@ export default function DataEntryTable({
 
     const [files, setFiles] = useState<UnlinkedFile[]>([]);
 
-    const filesQuery = useUnlinkedFilesQuery('c4r');
+    const filesQuery = useUnlinkedFilesQuery();
     const { data: institutions } = useInstitutionsQuery();
     const { data: enums } = useEnumsQuery();
 

--- a/react/src/AddDatasets/components/TableCells.tsx
+++ b/react/src/AddDatasets/components/TableCells.tsx
@@ -59,10 +59,7 @@ export function DataEntryCell(props: {
 }) {
     const row = useMemo(() => props.data[props.rowIndex], [props.data, props.rowIndex]);
 
-    const [filePrefix, setFilePrefix] = useState<string>('');
-
-    console.log('this is filePrefix', filePrefix)
-
+    const [filePrefix, setFilePrefix] = useState<string>("");
     const fieldName = props.col.field;
 
     if (booleanColumns.includes(fieldName)) {
@@ -89,14 +86,6 @@ export function DataEntryCell(props: {
                     inputValue={filePrefix}
                     onInputChange={setFilePrefix}
                     values={(row.fields[fieldName] || []) as LinkedFile[]}
-                    options={props
-                        .getOptions<UnlinkedFile>(props.rowIndex, props.col)
-                        .filter(
-                            uf =>
-                                !props?.data
-                                    .flatMap(d => d.fields.linked_files)
-                                    .filter(f => f && !f.multiplexed && f.path === uf.path).length
-                        )}
                     onEdit={props.onEdit}
                     disabled={props.disabled}
                 />

--- a/react/src/AddDatasets/components/TableCells.tsx
+++ b/react/src/AddDatasets/components/TableCells.tsx
@@ -59,6 +59,10 @@ export function DataEntryCell(props: {
 }) {
     const row = useMemo(() => props.data[props.rowIndex], [props.data, props.rowIndex]);
 
+    const [filePrefix, setFilePrefix] = useState<string>('');
+
+    console.log('this is filePrefix', filePrefix)
+
     const fieldName = props.col.field;
 
     if (booleanColumns.includes(fieldName)) {
@@ -82,6 +86,8 @@ export function DataEntryCell(props: {
         return (
             <TableCell padding="none" align="center">
                 <FileLinkingComponent
+                    inputValue={filePrefix}
+                    onInputChange={setFilePrefix}
                     values={(row.fields[fieldName] || []) as LinkedFile[]}
                     options={props
                         .getOptions<UnlinkedFile>(props.rowIndex, props.col)

--- a/react/src/AddDatasets/components/utils.tsx
+++ b/react/src/AddDatasets/components/utils.tsx
@@ -1,4 +1,4 @@
-import { DataEntryColumnConfig, DataEntryField, DataEntryRow, Family, Option, UnlinkedFile } from "../../typings";
+import { DataEntryColumnConfig, DataEntryField, DataEntryRow, Family, Option } from "../../typings";
 
 export const booleanColumns: DataEntryField[] = ["affected", "solved", "vcf_available"];
 export const dateColumns: DataEntryField[] = ["sequencing_date"];

--- a/react/src/AddDatasets/components/utils.tsx
+++ b/react/src/AddDatasets/components/utils.tsx
@@ -1,4 +1,4 @@
-import { DataEntryColumnConfig, DataEntryField, DataEntryRow, Family, Option } from "../../typings";
+import { DataEntryColumnConfig, DataEntryField, DataEntryRow, Family, Option, UnlinkedFile } from "../../typings";
 
 export const booleanColumns: DataEntryField[] = ["affected", "solved", "vcf_available"];
 export const dateColumns: DataEntryField[] = ["sequencing_date"];
@@ -144,6 +144,9 @@ export function getOptions(
 
         case "solved":
             return booleans.map(b => toOption(b, "Is Solved"));
+
+        // case "linked_files":
+        //     return files;
 
         case "condition":
             if (enums) {

--- a/react/src/AddDatasets/components/utils.tsx
+++ b/react/src/AddDatasets/components/utils.tsx
@@ -1,11 +1,4 @@
-import {
-    DataEntryColumnConfig,
-    DataEntryField,
-    DataEntryRow,
-    Family,
-    Option,
-    UnlinkedFile,
-} from "../../typings";
+import { DataEntryColumnConfig, DataEntryField, DataEntryRow, Family, Option } from "../../typings";
 
 export const booleanColumns: DataEntryField[] = ["affected", "solved", "vcf_available"];
 export const dateColumns: DataEntryField[] = ["sequencing_date"];
@@ -68,7 +61,6 @@ export function getOptions(
     rowIndex: number,
     families: Family[],
     enums: Record<string, string[]> | undefined,
-    files: UnlinkedFile[],
     institutions: string[]
 ) {
     const row = rows[rowIndex];
@@ -152,9 +144,6 @@ export function getOptions(
 
         case "solved":
             return booleans.map(b => toOption(b, "Is Solved"));
-
-        case "linked_files":
-            return files;
 
         case "condition":
             if (enums) {

--- a/react/src/AddDatasets/components/utils.tsx
+++ b/react/src/AddDatasets/components/utils.tsx
@@ -145,9 +145,6 @@ export function getOptions(
         case "solved":
             return booleans.map(b => toOption(b, "Is Solved"));
 
-        // case "linked_files":
-        //     return files;
-
         case "condition":
             if (enums) {
                 return (enums.DatasetCondition as string[]).map(value =>

--- a/react/src/Datasets/components/DatasetTable.tsx
+++ b/react/src/Datasets/components/DatasetTable.tsx
@@ -57,22 +57,6 @@ const customFileFilterAndSearch = (filter: string, rowData: DatasetDetailed) => 
     );
 };
 
-const EditFilesComponent = (props: EditComponentProps<DatasetDetailed>) => {
-    const filesQuery = useUnlinkedFilesQuery();;
-    const files = filesQuery.data || [];
-    const [filePrefix, setFilePrefix] = useState<string>('');
-    return (
-        <FileLinkingComponent
-            inputValue={filePrefix}
-            onInputChange={setFilePrefix}
-            values={props.rowData.linked_files}
-            options={files}
-            onEdit={newValue => props.onChange(newValue)}
-            disableTooltip
-        />
-    );
-};
-
 const linkedFileSort = (a: { linked_files: LinkedFile[] }, b: { linked_files: LinkedFile[] }) =>
     a.linked_files.length - b.linked_files.length;
 
@@ -106,7 +90,8 @@ export default function DatasetTable() {
     const tissueSampleTypes = useMemo(() => enums && toKeyValue(enums.TissueSampleType), [enums]);
     const conditions = useMemo(() => enums && toKeyValue(enums.DatasetCondition), [enums]);
 
-    const filesQuery = useUnlinkedFilesQuery();;
+    const [filePrefix, setFilePrefix] = useState("");
+    const filesQuery = useUnlinkedFilesQuery("");
     const files = filesQuery.data || [];
 
     const [showInfo, setShowInfo] = useState(false);
@@ -183,7 +168,15 @@ export default function DatasetTable() {
                 customFilterAndSearch: customFileFilterAndSearch,
                 customSort: linkedFileSort,
                 render: RenderLinkedFilesButton,
-                editComponent: EditFilesComponent,
+                editComponent: (props: EditComponentProps<DatasetDetailed>) => (
+                    <FileLinkingComponent
+                        inputValue={filePrefix}
+                        onInputChange={setFilePrefix}
+                        values={props.rowData.linked_files}
+                        onEdit={newValue => props.onChange(newValue)}
+                        disableTooltip
+                    />
+                ),
                 sorting: false,
                 filtering: true,
             },
@@ -245,6 +238,7 @@ export default function DatasetTable() {
         conditions,
         currentUser,
         datasetTypes,
+        filePrefix,
         paramID,
         tissueSampleTypes,
         setInitialSorting,

--- a/react/src/Datasets/components/DatasetTable.tsx
+++ b/react/src/Datasets/components/DatasetTable.tsx
@@ -58,7 +58,7 @@ const customFileFilterAndSearch = (filter: string, rowData: DatasetDetailed) => 
 };
 
 const EditFilesComponent = (props: EditComponentProps<DatasetDetailed>) => {
-    const filesQuery = useUnlinkedFilesQuery();
+    const filesQuery = useUnlinkedFilesQuery('c4r');;
     const files = filesQuery.data || [];
     return (
         <FileLinkingComponent
@@ -103,7 +103,7 @@ export default function DatasetTable() {
     const tissueSampleTypes = useMemo(() => enums && toKeyValue(enums.TissueSampleType), [enums]);
     const conditions = useMemo(() => enums && toKeyValue(enums.DatasetCondition), [enums]);
 
-    const filesQuery = useUnlinkedFilesQuery();
+    const filesQuery = useUnlinkedFilesQuery('c4r');;
     const files = filesQuery.data || [];
 
     const [showInfo, setShowInfo] = useState(false);

--- a/react/src/Datasets/components/DatasetTable.tsx
+++ b/react/src/Datasets/components/DatasetTable.tsx
@@ -58,10 +58,13 @@ const customFileFilterAndSearch = (filter: string, rowData: DatasetDetailed) => 
 };
 
 const EditFilesComponent = (props: EditComponentProps<DatasetDetailed>) => {
-    const filesQuery = useUnlinkedFilesQuery('c4r');;
+    const filesQuery = useUnlinkedFilesQuery();;
     const files = filesQuery.data || [];
+    const [filePrefix, setFilePrefix] = useState<string>('');
     return (
         <FileLinkingComponent
+            inputValue={filePrefix}
+            onInputChange={setFilePrefix}
             values={props.rowData.linked_files}
             options={files}
             onEdit={newValue => props.onChange(newValue)}
@@ -103,7 +106,7 @@ export default function DatasetTable() {
     const tissueSampleTypes = useMemo(() => enums && toKeyValue(enums.TissueSampleType), [enums]);
     const conditions = useMemo(() => enums && toKeyValue(enums.DatasetCondition), [enums]);
 
-    const filesQuery = useUnlinkedFilesQuery('c4r');;
+    const filesQuery = useUnlinkedFilesQuery();;
     const files = filesQuery.data || [];
 
     const [showInfo, setShowInfo] = useState(false);

--- a/react/src/components/AutocompleteMultiselect.tsx
+++ b/react/src/components/AutocompleteMultiselect.tsx
@@ -34,6 +34,8 @@ export default function AutocompleteMultiselect<T extends Record<string, any>>({
     const [inputValue, setInputValue] = useState("");
     const [removedOptions, setRemovedOptions] = useState<T[]>([]);
 
+    console.log("hello input", inputValue);
+
     return (
         <Autocomplete
             autoComplete

--- a/react/src/components/AutocompleteMultiselect.tsx
+++ b/react/src/components/AutocompleteMultiselect.tsx
@@ -18,6 +18,7 @@ interface AutocompleteMultiselectProps<T> {
     selectedValues: T[];
     classes?: StyledComponentProps<AutocompleteClassKey>["classes"];
     uniqueLabelPath: string;
+    noOptionsText?: string;
 }
 
 export default function AutocompleteMultiselect<T extends Record<string, any>>({
@@ -30,11 +31,10 @@ export default function AutocompleteMultiselect<T extends Record<string, any>>({
     renderTags,
     selectedValues,
     uniqueLabelPath,
+    noOptionsText,
 }: AutocompleteMultiselectProps<T>) {
     const [inputValue, setInputValue] = useState("");
     const [removedOptions, setRemovedOptions] = useState<T[]>([]);
-
-    console.log("hello input", inputValue);
 
     return (
         <Autocomplete
@@ -82,7 +82,7 @@ export default function AutocompleteMultiselect<T extends Record<string, any>>({
             renderInput={params => <TextField {...params} label={inputLabel} variant="outlined" />}
             multiple
             value={selectedValues}
-            noOptionsText="No options found. Please enter a search phrase."
+            noOptionsText={noOptionsText || "No options found. Please enter another search phrase."}
         />
     );
 }

--- a/react/src/components/AutocompleteMultiselect.tsx
+++ b/react/src/components/AutocompleteMultiselect.tsx
@@ -34,6 +34,9 @@ export default function AutocompleteMultiselect<T extends Record<string, any>>({
     const [inputValue, setInputValue] = useState("");
     const [removedOptions, setRemovedOptions] = useState<T[]>([]);
 
+    console.log('input value in multiselect', inputValue)
+    console.log(onInputChange)
+
     return (
         <Autocomplete
             autoComplete
@@ -43,6 +46,8 @@ export default function AutocompleteMultiselect<T extends Record<string, any>>({
                 if (reason === "input") {
                     setInputValue(value);
                 }
+
+                console.log(value, reason)
                 if (onInputChange) {
                     //if options are filtered dynamically
                     onInputChange(value);

--- a/react/src/components/AutocompleteMultiselect.tsx
+++ b/react/src/components/AutocompleteMultiselect.tsx
@@ -80,6 +80,7 @@ export default function AutocompleteMultiselect<T extends Record<string, any>>({
             renderInput={params => <TextField {...params} label={inputLabel} variant="outlined" />}
             multiple
             value={selectedValues}
+            noOptionsText="No options found. Please enter a search phrase."
         />
     );
 }

--- a/react/src/components/AutocompleteMultiselect.tsx
+++ b/react/src/components/AutocompleteMultiselect.tsx
@@ -33,6 +33,7 @@ export default function AutocompleteMultiselect<T extends Record<string, any>>({
 }: AutocompleteMultiselectProps<T>) {
     const [inputValue, setInputValue] = useState("");
     const [removedOptions, setRemovedOptions] = useState<T[]>([]);
+
     return (
         <Autocomplete
             autoComplete

--- a/react/src/components/AutocompleteMultiselect.tsx
+++ b/react/src/components/AutocompleteMultiselect.tsx
@@ -34,9 +34,6 @@ export default function AutocompleteMultiselect<T extends Record<string, any>>({
     const [inputValue, setInputValue] = useState("");
     const [removedOptions, setRemovedOptions] = useState<T[]>([]);
 
-    console.log('input value in multiselect', inputValue)
-    console.log(onInputChange)
-
     return (
         <Autocomplete
             autoComplete
@@ -45,12 +42,10 @@ export default function AutocompleteMultiselect<T extends Record<string, any>>({
             onInputChange={(_, value, reason) => {
                 if (reason === "input") {
                     setInputValue(value);
-                }
-
-                console.log(value, reason)
-                if (onInputChange) {
-                    //if options are filtered dynamically
-                    onInputChange(value);
+                    if (onInputChange) {
+                        //if options are filtered dynamically
+                        onInputChange(value);
+                    }
                 }
             }}
             disableClearable={true}

--- a/react/src/components/FieldDisplayEditable.tsx
+++ b/react/src/components/FieldDisplayEditable.tsx
@@ -1,7 +1,7 @@
-import React from "react";
+import React, { useState } from "react";
 import { Box, Fade, makeStyles, MenuItem, TextField, TextFieldProps } from "@material-ui/core";
 import { formatDisplayValue } from "../functions";
-import { useUnlinkedFilesQuery } from "../hooks";
+import { useUnlinkedFilesQuery } from '../hooks';
 import { Field, LinkedFile, PseudoBooleanReadableMap, UnlinkedFile } from "../typings";
 import FieldDisplay from "./FieldDisplay";
 import FileLinkingComponent from "./FileLinkingComponent";
@@ -51,8 +51,10 @@ function EnhancedTextField({
     enums?: Record<string, string[]>;
     onEdit: (fieldName: string, value: boolean | string | null | UnlinkedFile[]) => void;
 }) {
-    const filesQuery = useUnlinkedFilesQuery('c4r');;
+    const filesQuery = useUnlinkedFilesQuery();;
     const files = filesQuery.data || [];
+
+    const [filePrefix, setFilePrefix] = useState<string>('');
 
     const classes = useTextStyles();
     const nullOption = (
@@ -151,6 +153,8 @@ function EnhancedTextField({
         if (field.type === "linked_files") {
             return (
                 <FileLinkingComponent
+                    inputValue={filePrefix}
+                    onInputChange={setFilePrefix}
                     values={textFieldProps.value as LinkedFile[]}
                     options={files}
                     onEdit={files => {

--- a/react/src/components/FieldDisplayEditable.tsx
+++ b/react/src/components/FieldDisplayEditable.tsx
@@ -51,7 +51,7 @@ function EnhancedTextField({
     enums?: Record<string, string[]>;
     onEdit: (fieldName: string, value: boolean | string | null | UnlinkedFile[]) => void;
 }) {
-    const filesQuery = useUnlinkedFilesQuery();
+    const filesQuery = useUnlinkedFilesQuery('c4r');;
     const files = filesQuery.data || [];
 
     const classes = useTextStyles();

--- a/react/src/components/FieldDisplayEditable.tsx
+++ b/react/src/components/FieldDisplayEditable.tsx
@@ -1,7 +1,6 @@
 import React, { useState } from "react";
 import { Box, Fade, makeStyles, MenuItem, TextField, TextFieldProps } from "@material-ui/core";
 import { formatDisplayValue } from "../functions";
-import { useUnlinkedFilesQuery } from '../hooks';
 import { Field, LinkedFile, PseudoBooleanReadableMap, UnlinkedFile } from "../typings";
 import FieldDisplay from "./FieldDisplay";
 import FileLinkingComponent from "./FileLinkingComponent";
@@ -51,10 +50,7 @@ function EnhancedTextField({
     enums?: Record<string, string[]>;
     onEdit: (fieldName: string, value: boolean | string | null | UnlinkedFile[]) => void;
 }) {
-    const filesQuery = useUnlinkedFilesQuery();;
-    const files = filesQuery.data || [];
-
-    const [filePrefix, setFilePrefix] = useState<string>('');
+    const [filePrefix, setFilePrefix] = useState<string>("");
 
     const classes = useTextStyles();
     const nullOption = (
@@ -156,7 +152,6 @@ function EnhancedTextField({
                     inputValue={filePrefix}
                     onInputChange={setFilePrefix}
                     values={textFieldProps.value as LinkedFile[]}
-                    options={files}
                     onEdit={files => {
                         onEdit(field.fieldName, files);
                     }}

--- a/react/src/components/FileLinkingComponent.tsx
+++ b/react/src/components/FileLinkingComponent.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import {
     Box,
     Button,
@@ -14,6 +14,7 @@ import {
 } from "@material-ui/core";
 import { Description } from "@material-ui/icons";
 import { AutocompleteMultiselect, Note } from "../components";
+import { useDebounce, useUnlinkedFilesQueryPrefix } from "../hooks";
 import { LinkedFile, UnlinkedFile } from "../typings";
 
 const useStyles = makeStyles(theme => ({
@@ -51,7 +52,19 @@ const FileLinkingComponent: React.FC<{
     onEdit: (newValue: UnlinkedFile[]) => void;
     disabled?: boolean;
     disableTooltip?: boolean;
-}> = ({ values, options, onEdit, disabled, disableTooltip }) => {
+    inputValue?: string;
+    onInputChange?: (newInputvalue: string) => void;
+}> = ({ values, options, onEdit, disabled, disableTooltip, inputValue, onInputChange }) => {
+
+    const debouncedSearchQuery = useDebounce(inputValue || 'c4r', 600);
+    const files = useUnlinkedFilesQueryPrefix(debouncedSearchQuery);
+    const [fileOptions, setFileOptions] = useState<UnlinkedFile[]>([]);
+
+    console.log('these are file options', fileOptions)
+
+    console.log('this is debounced value', inputValue)
+    console.log(files)
+
     const autocompleteClasses = useAutocompleteStyles();
     const classes = useStyles();
     const [anchorEl, setAnchorEl] = useState<HTMLButtonElement | null>(null);
@@ -64,6 +77,10 @@ const FileLinkingComponent: React.FC<{
     const handleClose = () => {
         setAnchorEl(null);
     };
+
+    useEffect(() => {
+        if (files.isSuccess) setFileOptions(files.data)
+    }, [files])
 
     return (
         <>
@@ -144,6 +161,7 @@ const FileLinkingComponent: React.FC<{
                                 <AutocompleteMultiselect
                                     classes={autocompleteClasses}
                                     inputLabel="Search Unlinked Files"
+                                    onInputChange={onInputChange}
                                     limit={25}
                                     onSelect={onEdit}
                                     options={options}

--- a/react/src/components/FileLinkingComponent.tsx
+++ b/react/src/components/FileLinkingComponent.tsx
@@ -48,16 +48,13 @@ const useAutocompleteStyles = makeStyles(() => ({
 /* A cell for linking files to a dataset. */
 const FileLinkingComponent: React.FC<{
     values: LinkedFile[];
-    // options: UnlinkedFile[];
     onEdit: (newValue: UnlinkedFile[]) => void;
+    setFiles?: React.Dispatch<React.SetStateAction<UnlinkedFile[]>>;
     disabled?: boolean;
     disableTooltip?: boolean;
     inputValue?: string;
     onInputChange?: (newInputvalue: string) => void;
 }> = ({ values, onEdit, disabled, disableTooltip, inputValue, onInputChange }) => {
-
-    console.log('this is input value', inputValue)
-
     const debouncedSearchQuery = useDebounce(inputValue || "big", 600);
     const files = useUnlinkedFilesQuery(debouncedSearchQuery);
     const [options, setOptions] = useState<UnlinkedFile[]>([]);
@@ -76,7 +73,9 @@ const FileLinkingComponent: React.FC<{
     };
 
     useEffect(() => {
-        if (files.isSuccess) setOptions(files.data);
+        if (files.isSuccess) {
+            setOptions(files.data);
+        }
     }, [files]);
 
     return (

--- a/react/src/components/FileLinkingComponent.tsx
+++ b/react/src/components/FileLinkingComponent.tsx
@@ -13,8 +13,9 @@ import {
     Typography,
 } from "@material-ui/core";
 import { Description } from "@material-ui/icons";
+import { useSnackbar } from "notistack";
 import { AutocompleteMultiselect, Note } from "../components";
-import { useDebounce, useUnlinkedFilesQuery } from "../hooks";
+import { useDebounce, useErrorSnackbar, useUnlinkedFilesQuery } from "../hooks";
 import { LinkedFile, UnlinkedFile } from "../typings";
 
 const useStyles = makeStyles(theme => ({
@@ -52,7 +53,9 @@ const FileLinkingComponent: React.FC<{
     inputValue?: string;
     onInputChange?: (newInputvalue: string) => void;
 }> = ({ values, onEdit, disabled, disableTooltip, inputValue, onInputChange }) => {
-    const debouncedSearchQuery = useDebounce(inputValue || "None", 600);
+    const enqueueErrorSnackbar = useErrorSnackbar();
+
+    const debouncedSearchQuery = useDebounce(inputValue || "None", 500);
 
     console.log("debounced search query", debouncedSearchQuery);
 
@@ -73,10 +76,13 @@ const FileLinkingComponent: React.FC<{
     };
 
     useEffect(() => {
+        console.log(files);
         if (files.isSuccess) {
             setOptions(files.data);
+        } else if (files.isError) {
+            enqueueErrorSnackbar(files.error, "Failed to get unlinked files.");
         }
-    }, [files]);
+    }, [files, enqueueErrorSnackbar]);
 
     return (
         <>

--- a/react/src/components/FileLinkingComponent.tsx
+++ b/react/src/components/FileLinkingComponent.tsx
@@ -53,7 +53,7 @@ const FileLinkingComponent: React.FC<{
     onInputChange?: (newInputvalue: string) => void;
 }> = ({ values, onEdit, disabled, disableTooltip, inputValue, onInputChange }) => {
     const debouncedSearchQuery = useDebounce(inputValue || "None", 600);
-    
+
     const files = useUnlinkedFilesQuery(debouncedSearchQuery);
     const [options, setOptions] = useState<UnlinkedFile[]>([]);
 
@@ -146,59 +146,59 @@ const FileLinkingComponent: React.FC<{
             >
                 <Box className={classes.popoverBox}>
                     <div className={classes.popoverBoxHeader}>
-                    <Grid container direction="column">
-                                <AutocompleteMultiselect
-                                    classes={autocompleteClasses}
-                                    inputLabel="Search Unlinked Files"
-                                    onInputChange={onInputChange}
-                                    limit={25}
-                                    onSelect={onEdit}
-                                    options={options}
-                                    renderTags={(tags, getTagProps) => (
-                                        <>
-                                            {tags.map((tag, i) => {
-                                                const onChange = () => {
-                                                    onEdit(
-                                                        tags.map(t => ({
-                                                            ...t,
-                                                            multiplexed:
-                                                                t.path === tag.path
-                                                                    ? !t.multiplexed
-                                                                    : t.multiplexed,
-                                                        }))
-                                                    );
-                                                };
-                                                const Detail = (
-                                                    <Box margin={1}>
-                                                        <FormControlLabel
-                                                            label="Multiplexed?"
-                                                            control={
-                                                                <Checkbox
-                                                                    checked={tag.multiplexed}
-                                                                    onChange={onChange}
-                                                                />
-                                                            }
-                                                        />
-                                                    </Box>
+                        <Grid container direction="column">
+                            <AutocompleteMultiselect
+                                classes={autocompleteClasses}
+                                inputLabel="Search Unlinked Files"
+                                onInputChange={onInputChange}
+                                limit={25}
+                                onSelect={onEdit}
+                                options={options}
+                                renderTags={(tags, getTagProps) => (
+                                    <>
+                                        {tags.map((tag, i) => {
+                                            const onChange = () => {
+                                                onEdit(
+                                                    tags.map(t => ({
+                                                        ...t,
+                                                        multiplexed:
+                                                            t.path === tag.path
+                                                                ? !t.multiplexed
+                                                                : t.multiplexed,
+                                                    }))
                                                 );
-                                                return (
-                                                    <Chip
-                                                        key={tag.path}
-                                                        {...getTagProps({ index: i })}
-                                                        label={
-                                                            <Note detailElement={Detail}>
-                                                                {tag.path}
-                                                            </Note>
+                                            };
+                                            const Detail = (
+                                                <Box margin={1}>
+                                                    <FormControlLabel
+                                                        label="Multiplexed?"
+                                                        control={
+                                                            <Checkbox
+                                                                checked={tag.multiplexed}
+                                                                onChange={onChange}
+                                                            />
                                                         }
                                                     />
-                                                );
-                                            })}
-                                        </>
-                                    )}
-                                    selectedValues={values}
-                                    uniqueLabelPath="path"
-                                />
-                            </Grid>
+                                                </Box>
+                                            );
+                                            return (
+                                                <Chip
+                                                    key={tag.path}
+                                                    {...getTagProps({ index: i })}
+                                                    label={
+                                                        <Note detailElement={Detail}>
+                                                            {tag.path}
+                                                        </Note>
+                                                    }
+                                                />
+                                            );
+                                        })}
+                                    </>
+                                )}
+                                selectedValues={values}
+                                uniqueLabelPath="path"
+                            />
+                        </Grid>
                     </div>
                 </Box>
             </Popover>

--- a/react/src/components/FileLinkingComponent.tsx
+++ b/react/src/components/FileLinkingComponent.tsx
@@ -58,7 +58,7 @@ const FileLinkingComponent: React.FC<{
 
     console.log('this is input value', inputValue)
 
-    const debouncedSearchQuery = useDebounce(inputValue || "data", 600);
+    const debouncedSearchQuery = useDebounce(inputValue || "big", 600);
     const files = useUnlinkedFilesQuery(debouncedSearchQuery);
     const [options, setOptions] = useState<UnlinkedFile[]>([]);
 

--- a/react/src/components/FileLinkingComponent.tsx
+++ b/react/src/components/FileLinkingComponent.tsx
@@ -14,7 +14,7 @@ import {
 } from "@material-ui/core";
 import { Description } from "@material-ui/icons";
 import { AutocompleteMultiselect, Note } from "../components";
-import { useDebounce, useUnlinkedFilesQueryPrefix } from "../hooks";
+import { useDebounce, useUnlinkedFilesQuery } from "../hooks";
 import { LinkedFile, UnlinkedFile } from "../typings";
 
 const useStyles = makeStyles(theme => ({
@@ -48,22 +48,16 @@ const useAutocompleteStyles = makeStyles(() => ({
 /* A cell for linking files to a dataset. */
 const FileLinkingComponent: React.FC<{
     values: LinkedFile[];
-    options: UnlinkedFile[];
+    // options: UnlinkedFile[];
     onEdit: (newValue: UnlinkedFile[]) => void;
     disabled?: boolean;
     disableTooltip?: boolean;
     inputValue?: string;
     onInputChange?: (newInputvalue: string) => void;
-}> = ({ values, options, onEdit, disabled, disableTooltip, inputValue, onInputChange }) => {
-
-    const debouncedSearchQuery = useDebounce(inputValue || 'c4r', 600);
-    const files = useUnlinkedFilesQueryPrefix(debouncedSearchQuery);
-    const [fileOptions, setFileOptions] = useState<UnlinkedFile[]>([]);
-
-    console.log('these are file options', fileOptions)
-
-    console.log('this is debounced value', inputValue)
-    console.log(files)
+}> = ({ values, onEdit, disabled, disableTooltip, inputValue, onInputChange }) => {
+    const debouncedSearchQuery = useDebounce(inputValue || "", 600);
+    const files = useUnlinkedFilesQuery(debouncedSearchQuery);
+    const [options, setOptions] = useState<UnlinkedFile[]>([]);
 
     const autocompleteClasses = useAutocompleteStyles();
     const classes = useStyles();
@@ -79,8 +73,8 @@ const FileLinkingComponent: React.FC<{
     };
 
     useEffect(() => {
-        if (files.isSuccess) setFileOptions(files.data)
-    }, [files])
+        if (files.isSuccess) setOptions(files.data);
+    }, [files]);
 
     return (
         <>

--- a/react/src/components/FileLinkingComponent.tsx
+++ b/react/src/components/FileLinkingComponent.tsx
@@ -53,7 +53,7 @@ const FileLinkingComponent: React.FC<{
     onInputChange?: (newInputvalue: string) => void;
 }> = ({ values, onEdit, disabled, disableTooltip, inputValue, onInputChange }) => {
     const enqueueErrorSnackbar = useErrorSnackbar();
-    const debouncedSearchQuery = useDebounce(inputValue || "None", 1000);
+    const debouncedSearchQuery = useDebounce(inputValue || "");
 
     const [options, setOptions] = useState<UnlinkedFile[]>([]);
 

--- a/react/src/components/FileLinkingComponent.tsx
+++ b/react/src/components/FileLinkingComponent.tsx
@@ -54,7 +54,9 @@ const FileLinkingComponent: React.FC<{
 }> = ({ values, onEdit, disabled, disableTooltip, inputValue, onInputChange }) => {
     const debouncedSearchQuery = useDebounce(inputValue || "None", 600);
 
-    const files = useUnlinkedFilesQuery(debouncedSearchQuery);
+    console.log("debounced search query", debouncedSearchQuery);
+
+    const files = useUnlinkedFilesQuery({ path: debouncedSearchQuery });
     const [options, setOptions] = useState<UnlinkedFile[]>([]);
 
     const autocompleteClasses = useAutocompleteStyles();

--- a/react/src/components/FileLinkingComponent.tsx
+++ b/react/src/components/FileLinkingComponent.tsx
@@ -28,9 +28,6 @@ const useStyles = makeStyles(theme => ({
         alignItems: "center",
         width: "100%",
     },
-    popoverTitle: {
-        width: "150px",
-    },
     fileName: {
         wordBreak: "break-all",
         padding: 0,
@@ -55,7 +52,8 @@ const FileLinkingComponent: React.FC<{
     inputValue?: string;
     onInputChange?: (newInputvalue: string) => void;
 }> = ({ values, onEdit, disabled, disableTooltip, inputValue, onInputChange }) => {
-    const debouncedSearchQuery = useDebounce(inputValue || "big", 600);
+    const debouncedSearchQuery = useDebounce(inputValue || "None", 600);
+    
     const files = useUnlinkedFilesQuery(debouncedSearchQuery);
     const [options, setOptions] = useState<UnlinkedFile[]>([]);
 
@@ -148,12 +146,7 @@ const FileLinkingComponent: React.FC<{
             >
                 <Box className={classes.popoverBox}>
                     <div className={classes.popoverBoxHeader}>
-                        {options.length === 0 && values.length === 0 ? (
-                            <Typography variant="h6" className={classes.popoverTitle}>
-                                No files available
-                            </Typography>
-                        ) : (
-                            <Grid container direction="column">
+                    <Grid container direction="column">
                                 <AutocompleteMultiselect
                                     classes={autocompleteClasses}
                                     inputLabel="Search Unlinked Files"
@@ -206,7 +199,6 @@ const FileLinkingComponent: React.FC<{
                                     uniqueLabelPath="path"
                                 />
                             </Grid>
-                        )}
                     </div>
                 </Box>
             </Popover>

--- a/react/src/components/FileLinkingComponent.tsx
+++ b/react/src/components/FileLinkingComponent.tsx
@@ -55,7 +55,10 @@ const FileLinkingComponent: React.FC<{
     inputValue?: string;
     onInputChange?: (newInputvalue: string) => void;
 }> = ({ values, onEdit, disabled, disableTooltip, inputValue, onInputChange }) => {
-    const debouncedSearchQuery = useDebounce(inputValue || "", 600);
+
+    console.log('this is input value', inputValue)
+
+    const debouncedSearchQuery = useDebounce(inputValue || "data", 600);
     const files = useUnlinkedFilesQuery(debouncedSearchQuery);
     const [options, setOptions] = useState<UnlinkedFile[]>([]);
 

--- a/react/src/hooks/index.tsx
+++ b/react/src/hooks/index.tsx
@@ -1,7 +1,7 @@
 export { useEnumsQuery } from "./useEnumsQuery";
 export { useInstitutionsQuery } from "./useInstitutionsQuery";
 export { useMetadatasetTypesQuery } from "./useMetadatasetTypesQuery";
-export { useUnlinkedFilesQuery } from "./unlinked/useUnlinkedFilesQuery";
+export { useUnlinkedFilesQuery, useUnlinkedFilesQueryPrefix } from "./unlinked/useUnlinkedFilesQuery";
 export { usePipelinesQuery } from "./usePipelinesQuery";
 
 export { useBulkCreateMutation } from "./bulk/useBulkCreateMutation";
@@ -13,6 +13,8 @@ export { useAnalysisCreateMutation } from "./analyses/useAnalysisCreateMutation"
 export { useAnalysisUpdateMutation } from "./analyses/useAnalysisUpdateMutation";
 export type { AnalysisOptions } from "./analyses/useAnalysisUpdateMutation";
 export { useAnalysisDeleteMutation } from "./analyses/useAnalysisDeleteMutation";
+
+export { useDebounce } from "./useDebounce";
 
 export { useFamiliesQuery } from "./family/useFamiliesQuery";
 export { useFamilyUpdateMutation } from "./family/useFamilyUpdateMutation";

--- a/react/src/hooks/index.tsx
+++ b/react/src/hooks/index.tsx
@@ -1,7 +1,7 @@
 export { useEnumsQuery } from "./useEnumsQuery";
 export { useInstitutionsQuery } from "./useInstitutionsQuery";
 export { useMetadatasetTypesQuery } from "./useMetadatasetTypesQuery";
-export { useUnlinkedFilesQuery, useUnlinkedFilesQueryPrefix } from "./unlinked/useUnlinkedFilesQuery";
+export { useUnlinkedFilesQuery } from "./unlinked/useUnlinkedFilesQuery";
 export { usePipelinesQuery } from "./usePipelinesQuery";
 
 export { useBulkCreateMutation } from "./bulk/useBulkCreateMutation";

--- a/react/src/hooks/unlinked/useUnlinkedFilesQuery.tsx
+++ b/react/src/hooks/unlinked/useUnlinkedFilesQuery.tsx
@@ -2,13 +2,8 @@ import { useQuery } from "react-query";
 import { UnlinkedFile } from "../../typings";
 import { basicFetch } from "../utils";
 
-async function fetchFilesNoPrefix() {
-    return await basicFetch("/api/unlinked");
-}
-
 async function fetchFiles(prefix: string) {
-    console.log('fetchfiles', prefix)
-    return await basicFetch(`api/unlinked/${prefix}`);
+    return await basicFetch(`api/unlinked${prefix ? "/" + prefix : ""}`);
 }
 
 /**
@@ -18,16 +13,9 @@ async function fetchFiles(prefix: string) {
  * for all unlinked files in MinIO.
  */
 
-export function useUnlinkedFilesQuery() {
-    const result = useQuery<UnlinkedFile[], Response>("unlinked", fetchFilesNoPrefix
-    );
-    return result;
-}
-
-export function useUnlinkedFilesQueryPrefix (prefix: string) {
-    console.log('prefix', prefix)
+export function useUnlinkedFilesQuery(prefix: string) {
     const result = useQuery<string, Response, UnlinkedFile[]>(["unlinked", prefix], () =>
-    fetchFiles(prefix)
+        fetchFiles(prefix)
     );
     return result;
 }

--- a/react/src/hooks/unlinked/useUnlinkedFilesQuery.tsx
+++ b/react/src/hooks/unlinked/useUnlinkedFilesQuery.tsx
@@ -2,8 +2,8 @@ import { useQuery } from "react-query";
 import { UnlinkedFile } from "../../typings";
 import { basicFetch } from "../utils";
 
-async function fetchFiles() {
-    return await basicFetch("/api/unlinked");
+async function fetchFiles(prefix: string) {
+    return await basicFetch("/api/unlinked/" + prefix);
 }
 
 /**
@@ -12,7 +12,10 @@ async function fetchFiles() {
  * That is, return a sorted list of filenames
  * for all unlinked files in MinIO.
  */
-export function useUnlinkedFilesQuery() {
-    const result = useQuery<UnlinkedFile[], Response>("unlinked", fetchFiles);
+
+export function useUnlinkedFilesQuery(prefix: string) {
+    const result = useQuery<string, Response, UnlinkedFile[]>(["unlinked", prefix], () =>
+        fetchFiles(prefix)
+    );
     return result;
 }

--- a/react/src/hooks/unlinked/useUnlinkedFilesQuery.tsx
+++ b/react/src/hooks/unlinked/useUnlinkedFilesQuery.tsx
@@ -3,7 +3,7 @@ import { UnlinkedFile } from "../../typings";
 import { basicFetch } from "../utils";
 
 async function fetchFiles(prefix: string) {
-    return await basicFetch(`api/unlinked${prefix ? "/" + prefix : ""}`);
+    return await basicFetch(`api/unlinked/${prefix}`);
 }
 
 /**

--- a/react/src/hooks/unlinked/useUnlinkedFilesQuery.tsx
+++ b/react/src/hooks/unlinked/useUnlinkedFilesQuery.tsx
@@ -1,9 +1,8 @@
-import { useQuery } from "react-query";
+import { useQuery, UseQueryOptions } from "react-query";
 import { UnlinkedFile } from "../../typings";
 import { basicFetch } from "../utils";
 
 async function fetchFiles(params: Record<string, string> = {}) {
-    console.log("unlinked params", params);
     return await basicFetch("/api/unlinked", params);
 }
 /**
@@ -13,11 +12,20 @@ async function fetchFiles(params: Record<string, string> = {}) {
  * for all unlinked files in MinIO.
  */
 
-export function useUnlinkedFilesQuery(params: Record<string, string> = {}) {
-    console.log("useUnlinkedFilesQuery", params);
-    const result = useQuery<Record<string, string>, Response, UnlinkedFile[]>(
+export function useUnlinkedFilesQuery(
+    params: Record<string, string> = {},
+    userOptions: UseQueryOptions<UnlinkedFile[], Response> = {}
+) {
+    const result = useQuery<UnlinkedFile[], Response>(
         ["unlinked", params],
-        () => fetchFiles(params)
+        () => fetchFiles(params),
+        {
+            staleTime: Infinity,
+            retry: false,
+            refetchInterval: false,
+            refetchOnMount: false,
+            ...userOptions,
+        }
     );
     return result;
 }

--- a/react/src/hooks/unlinked/useUnlinkedFilesQuery.tsx
+++ b/react/src/hooks/unlinked/useUnlinkedFilesQuery.tsx
@@ -2,10 +2,10 @@ import { useQuery } from "react-query";
 import { UnlinkedFile } from "../../typings";
 import { basicFetch } from "../utils";
 
-async function fetchFiles(prefix: string) {
-    return await basicFetch(`api/unlinked/${prefix}`);
+async function fetchFiles(params: Record<string, string> = {}) {
+    console.log("unlinked params", params);
+    return await basicFetch("/api/unlinked", params);
 }
-
 /**
  * Return result of GET /api/unlinked.
  *
@@ -13,9 +13,11 @@ async function fetchFiles(prefix: string) {
  * for all unlinked files in MinIO.
  */
 
-export function useUnlinkedFilesQuery(prefix: string) {
-    const result = useQuery<string, Response, UnlinkedFile[]>(["unlinked", prefix], () =>
-        fetchFiles(prefix)
+export function useUnlinkedFilesQuery(params: Record<string, string> = {}) {
+    console.log("useUnlinkedFilesQuery", params);
+    const result = useQuery<Record<string, string>, Response, UnlinkedFile[]>(
+        ["unlinked", params],
+        () => fetchFiles(params)
     );
     return result;
 }

--- a/react/src/hooks/unlinked/useUnlinkedFilesQuery.tsx
+++ b/react/src/hooks/unlinked/useUnlinkedFilesQuery.tsx
@@ -2,8 +2,13 @@ import { useQuery } from "react-query";
 import { UnlinkedFile } from "../../typings";
 import { basicFetch } from "../utils";
 
+async function fetchFilesNoPrefix() {
+    return await basicFetch("/api/unlinked");
+}
+
 async function fetchFiles(prefix: string) {
-    return await basicFetch("/api/unlinked/" + prefix);
+    console.log('fetchfiles', prefix)
+    return await basicFetch(`api/unlinked/${prefix}`);
 }
 
 /**
@@ -13,9 +18,16 @@ async function fetchFiles(prefix: string) {
  * for all unlinked files in MinIO.
  */
 
-export function useUnlinkedFilesQuery(prefix: string) {
+export function useUnlinkedFilesQuery() {
+    const result = useQuery<UnlinkedFile[], Response>("unlinked", fetchFilesNoPrefix
+    );
+    return result;
+}
+
+export function useUnlinkedFilesQueryPrefix (prefix: string) {
+    console.log('prefix', prefix)
     const result = useQuery<string, Response, UnlinkedFile[]>(["unlinked", prefix], () =>
-        fetchFiles(prefix)
+    fetchFiles(prefix)
     );
     return result;
 }

--- a/react/src/hooks/useDebounce.ts
+++ b/react/src/hooks/useDebounce.ts
@@ -1,0 +1,18 @@
+import React from 'react';
+
+export function useDebounce(value: string, delay: number = 500) {
+  const [debouncedValue, setDebouncedValue] = React.useState(value);
+
+  React.useEffect(() => {
+    const handler: NodeJS.Timeout = setTimeout(() => {
+      setDebouncedValue(value);
+    }, delay);
+
+    // Cancel the timeout if value changes (also on delay change or unmount)
+    return () => {
+      clearTimeout(handler);
+    };
+  }, [value, delay]);
+
+  return debouncedValue;
+}

--- a/react/src/hooks/useDebounce.ts
+++ b/react/src/hooks/useDebounce.ts
@@ -1,18 +1,18 @@
-import React from 'react';
+import React from "react";
 
 export function useDebounce(value: string, delay: number = 500) {
-  const [debouncedValue, setDebouncedValue] = React.useState(value);
+    const [debouncedValue, setDebouncedValue] = React.useState(value);
 
-  React.useEffect(() => {
-    const handler: NodeJS.Timeout = setTimeout(() => {
-      setDebouncedValue(value);
-    }, delay);
+    React.useEffect(() => {
+        const handler: NodeJS.Timeout = setTimeout(() => {
+            setDebouncedValue(value);
+        }, delay);
 
-    // Cancel the timeout if value changes (also on delay change or unmount)
-    return () => {
-      clearTimeout(handler);
-    };
-  }, [value, delay]);
+        // Cancel the timeout if value changes (also on delay change or unmount)
+        return () => {
+            clearTimeout(handler);
+        };
+    }, [value, delay]);
 
-  return debouncedValue;
+    return debouncedValue;
 }

--- a/react/src/hooks/useDebounce.ts
+++ b/react/src/hooks/useDebounce.ts
@@ -1,6 +1,6 @@
 import React from "react";
 
-export function useDebounce(value: string, delay: number = 500) {
+export function useDebounce(value: string, delay: number = 1000) {
     const [debouncedValue, setDebouncedValue] = React.useState(value);
 
     React.useEffect(() => {


### PR DESCRIPTION
- We've seen that when the unlinked file payload is very large (>2MB), it takes a long time for all files to be returned, leading to a laggy user experience. 
- I modified the `get_unlinked_files` function to only return results based on prefixes. This is per Hannah Driver's feedback since she usually already knows what files she has to pass in, and uses the prefix in stager as a way to type in the right file faster and more accurately.
- The frontend was also modified to only return results based on the prefixes that user types. 