### PR TITLE
Flask: fix security warning for 'starbank'

### DIFF
--- a/flask/requirements-dev.txt
+++ b/flask/requirements-dev.txt
@@ -110,8 +110,6 @@ python-dateutil==2.8.1
     #   pandas
 python-editor==1.0.4
     # via alembic
-python-http-client==3.3.3
-    # via sendgrid
 pytz==2021.1
     # via
     #   apscheduler
@@ -122,19 +120,19 @@ regex==2021.4.4
     # via black
 requests==2.26.0
     # via -r requirements.in
-sendgrid==6.9.0
+sendgrid==1.6.20
     # via -r requirements.in
 six==1.15.0
     # via
     #   apscheduler
     #   python-dateutil
+smtpapi==0.3.1
+    # via sendgrid
 sqlalchemy==1.3.24
     # via
     #   -r requirements.in
     #   alembic
     #   flask-sqlalchemy
-starkbank-ecdsa==1.1.1
-    # via sendgrid
 toml==0.10.2
     # via
     #   pylint

--- a/flask/requirements-dev.txt
+++ b/flask/requirements-dev.txt
@@ -4,13 +4,13 @@
 #
 #    pip-compile requirements-dev.in
 #
-alembic==1.5.8
+alembic==1.7.5
     # via flask-migrate
 apscheduler==3.8.1
     # via -r requirements.in
 astroid==2.9.0
     # via pylint
-attrs==20.3.0
+attrs==21.2.0
     # via pytest
 authlib==0.15.5
     # via -r requirements.in
@@ -18,21 +18,21 @@ backports.zoneinfo==0.2.1
     # via
     #   pytz-deprecation-shim
     #   tzlocal
-black==21.11b1
+black==21.12b0
     # via -r requirements-dev.in
-certifi==2020.12.5
+certifi==2021.10.8
     # via
     #   minio
     #   requests
-cffi==1.14.5
+cffi==1.15.0
     # via cryptography
-charset-normalizer==2.0.3
+charset-normalizer==2.0.9
     # via requests
-click==8.0.1
+click==8.0.3
     # via
     #   black
     #   flask
-cryptography==3.4.7
+cryptography==36.0.0
     # via
     #   authlib
     #   pymysql
@@ -52,21 +52,27 @@ flask-sqlalchemy==2.5.1
     # via
     #   -r requirements.in
     #   flask-migrate
+greenlet==1.1.2
+    # via sqlalchemy
 gunicorn==20.1.0
     # via -r requirements.in
-idna==2.10
+idna==3.3
     # via requests
+importlib-metadata==4.8.2
+    # via alembic
+importlib-resources==5.4.0
+    # via alembic
 iniconfig==1.1.1
     # via pytest
-isort==5.8.0
+isort==5.10.1
     # via pylint
 itsdangerous==2.0.1
     # via flask
-jinja2==3.0.1
+jinja2==3.0.3
     # via flask
 lazy-object-proxy==1.6.0
     # via astroid
-mako==1.1.4
+mako==1.1.6
     # via alembic
 markupsafe==2.0.1
     # via
@@ -74,72 +80,68 @@ markupsafe==2.0.1
     #   mako
 mccabe==0.6.1
     # via pylint
-minio==7.1.1
+minio==7.1.2
     # via -r requirements.in
 mypy-extensions==0.4.3
     # via black
-numpy==1.21.3
+numpy==1.21.4
     # via pandas
-packaging==20.9
+packaging==21.3
     # via pytest
 pandas==1.3.4
     # via -r requirements.in
 pathspec==0.9.0
     # via black
-platformdirs==2.2.0
+platformdirs==2.4.0
     # via
     #   black
     #   pylint
-pluggy==0.13.1
+pluggy==1.0.0
     # via pytest
-py==1.10.0
+py==1.11.0
     # via pytest
-pycparser==2.20
+pycparser==2.21
     # via cffi
-pylint==2.12.1
+pylint==2.12.2
     # via -r requirements-dev.in
 pymysql[rsa]==1.0.2
     # via -r requirements.in
-pyparsing==2.4.7
+pyparsing==3.0.6
     # via packaging
 pytest==6.2.5
     # via -r requirements-dev.in
-python-dateutil==2.8.1
-    # via
-    #   alembic
-    #   pandas
-python-editor==1.0.4
-    # via alembic
-pytz==2021.1
+python-dateutil==2.8.2
+    # via pandas
+python-http-client==3.3.4
+    # via sendgrid
+pytz==2021.3
     # via
     #   apscheduler
     #   pandas
 pytz-deprecation-shim==0.1.0.post0
     # via tzlocal
-regex==2021.4.4
-    # via black
 requests==2.26.0
     # via -r requirements.in
-sendgrid==1.6.20
+sendgrid==6.9.2
     # via -r requirements.in
-six==1.15.0
+six==1.16.0
     # via
     #   apscheduler
     #   python-dateutil
-smtpapi==0.3.1
-    # via sendgrid
-sqlalchemy==1.3.24
+sqlalchemy==1.4.27
     # via
     #   -r requirements.in
     #   alembic
     #   flask-sqlalchemy
+starkbank-ecdsa==2.0.3
+    # via sendgrid
 toml==0.10.2
     # via
     #   pylint
     #   pytest
-tomli==1.1.0
+tomli==1.2.2
     # via black
-typing-extensions==3.10.0.2
+typing-extensions==4.0.1
     # via
     #   astroid
     #   black
@@ -148,14 +150,18 @@ tzdata==2021.5
     # via pytz-deprecation-shim
 tzlocal==4.1
     # via apscheduler
-urllib3==1.26.5
+urllib3==1.26.7
     # via
     #   minio
     #   requests
-werkzeug==2.0.1
+werkzeug==2.0.2
     # via flask
-wrapt==1.12.1
+wrapt==1.13.3
     # via astroid
+zipp==3.6.0
+    # via
+    #   importlib-metadata
+    #   importlib-resources
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/flask/requirements-dev.txt
+++ b/flask/requirements-dev.txt
@@ -4,13 +4,13 @@
 #
 #    pip-compile requirements-dev.in
 #
-alembic==1.7.5
+alembic==1.5.8
     # via flask-migrate
 apscheduler==3.8.1
     # via -r requirements.in
 astroid==2.9.0
     # via pylint
-attrs==21.2.0
+attrs==20.3.0
     # via pytest
 authlib==0.15.5
     # via -r requirements.in
@@ -18,21 +18,21 @@ backports.zoneinfo==0.2.1
     # via
     #   pytz-deprecation-shim
     #   tzlocal
-black==21.12b0
+black==21.11b1
     # via -r requirements-dev.in
-certifi==2021.10.8
+certifi==2020.12.5
     # via
     #   minio
     #   requests
-cffi==1.15.0
+cffi==1.14.5
     # via cryptography
-charset-normalizer==2.0.9
+charset-normalizer==2.0.3
     # via requests
-click==8.0.3
+click==8.0.1
     # via
     #   black
     #   flask
-cryptography==36.0.0
+cryptography==3.4.7
     # via
     #   authlib
     #   pymysql
@@ -52,27 +52,21 @@ flask-sqlalchemy==2.5.1
     # via
     #   -r requirements.in
     #   flask-migrate
-greenlet==1.1.2
-    # via sqlalchemy
 gunicorn==20.1.0
     # via -r requirements.in
-idna==3.3
+idna==2.10
     # via requests
-importlib-metadata==4.8.2
-    # via alembic
-importlib-resources==5.4.0
-    # via alembic
 iniconfig==1.1.1
     # via pytest
-isort==5.10.1
+isort==5.8.0
     # via pylint
 itsdangerous==2.0.1
     # via flask
-jinja2==3.0.3
+jinja2==3.0.1
     # via flask
 lazy-object-proxy==1.6.0
     # via astroid
-mako==1.1.6
+mako==1.1.4
     # via alembic
 markupsafe==2.0.1
     # via
@@ -80,55 +74,61 @@ markupsafe==2.0.1
     #   mako
 mccabe==0.6.1
     # via pylint
-minio==7.1.2
+minio==7.1.1
     # via -r requirements.in
 mypy-extensions==0.4.3
     # via black
-numpy==1.21.4
+numpy==1.21.3
     # via pandas
-packaging==21.3
+packaging==20.9
     # via pytest
 pandas==1.3.4
     # via -r requirements.in
 pathspec==0.9.0
     # via black
-platformdirs==2.4.0
+platformdirs==2.2.0
     # via
     #   black
     #   pylint
-pluggy==1.0.0
+pluggy==0.13.1
     # via pytest
-py==1.11.0
+py==1.10.0
     # via pytest
-pycparser==2.21
+pycparser==2.20
     # via cffi
-pylint==2.12.2
+pylint==2.12.1
     # via -r requirements-dev.in
 pymysql[rsa]==1.0.2
     # via -r requirements.in
-pyparsing==3.0.6
+pyparsing==2.4.7
     # via packaging
 pytest==6.2.5
     # via -r requirements-dev.in
-python-dateutil==2.8.2
-    # via pandas
-python-http-client==3.3.4
+python-dateutil==2.8.1
+    # via
+    #   alembic
+    #   pandas
+python-editor==1.0.4
+    # via alembic
+python-http-client==3.3.3
     # via sendgrid
-pytz==2021.3
+pytz==2021.1
     # via
     #   apscheduler
     #   pandas
 pytz-deprecation-shim==0.1.0.post0
     # via tzlocal
+regex==2021.4.4
+    # via black
 requests==2.26.0
     # via -r requirements.in
 sendgrid==6.9.2
     # via -r requirements.in
-six==1.16.0
+six==1.15.0
     # via
     #   apscheduler
     #   python-dateutil
-sqlalchemy==1.4.27
+sqlalchemy==1.3.24
     # via
     #   -r requirements.in
     #   alembic
@@ -139,9 +139,9 @@ toml==0.10.2
     # via
     #   pylint
     #   pytest
-tomli==1.2.2
+tomli==1.1.0
     # via black
-typing-extensions==4.0.1
+typing-extensions==3.10.0.2
     # via
     #   astroid
     #   black
@@ -150,18 +150,14 @@ tzdata==2021.5
     # via pytz-deprecation-shim
 tzlocal==4.1
     # via apscheduler
-urllib3==1.26.7
+urllib3==1.26.5
     # via
     #   minio
     #   requests
-werkzeug==2.0.2
+werkzeug==2.0.1
     # via flask
-wrapt==1.13.3
+wrapt==1.12.1
     # via astroid
-zipp==3.6.0
-    # via
-    #   importlib-metadata
-    #   importlib-resources
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/flask/requirements.txt
+++ b/flask/requirements.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile requirements.in
 #
-alembic==1.7.5
+alembic==1.5.8
     # via flask-migrate
 apscheduler==3.8.1
     # via -r requirements.in
@@ -14,17 +14,17 @@ backports.zoneinfo==0.2.1
     # via
     #   pytz-deprecation-shim
     #   tzlocal
-certifi==2021.10.8
+certifi==2020.12.5
     # via
     #   minio
     #   requests
-cffi==1.15.0
+cffi==1.14.5
     # via cryptography
-charset-normalizer==2.0.9
+charset-normalizer==2.0.3
     # via requests
-click==8.0.3
+click==8.0.1
     # via flask
-cryptography==36.0.0
+cryptography==3.4.7
     # via
     #   authlib
     #   pymysql
@@ -42,41 +42,39 @@ flask-sqlalchemy==2.5.1
     # via
     #   -r requirements.in
     #   flask-migrate
-greenlet==1.1.2
-    # via sqlalchemy
 gunicorn==20.1.0
     # via -r requirements.in
-idna==3.3
+idna==2.10
     # via requests
-importlib-metadata==4.8.2
-    # via alembic
-importlib-resources==5.4.0
-    # via alembic
 itsdangerous==2.0.1
     # via flask
-jinja2==3.0.3
+jinja2==3.0.1
     # via flask
-mako==1.1.6
+mako==1.1.4
     # via alembic
 markupsafe==2.0.1
     # via
     #   jinja2
     #   mako
-minio==7.1.2
+minio==7.1.1
     # via -r requirements.in
-numpy==1.21.4
+numpy==1.20.2
     # via pandas
 pandas==1.3.4
     # via -r requirements.in
-pycparser==2.21
+pycparser==2.20
     # via cffi
 pymysql[rsa]==1.0.2
     # via -r requirements.in
-python-dateutil==2.8.2
-    # via pandas
-python-http-client==3.3.4
+python-dateutil==2.8.1
+    # via
+    #   alembic
+    #   pandas
+python-editor==1.0.4
+    # via alembic
+python-http-client==3.3.3
     # via sendgrid
-pytz==2021.3
+pytz==2021.1
     # via
     #   apscheduler
     #   pandas
@@ -86,31 +84,27 @@ requests==2.26.0
     # via -r requirements.in
 sendgrid==6.9.2
     # via -r requirements.in
-six==1.16.0
+six==1.15.0
     # via
     #   apscheduler
     #   python-dateutil
-sqlalchemy==1.4.27
+sqlalchemy==1.3.24
     # via
     #   -r requirements.in
     #   alembic
     #   flask-sqlalchemy
-starkbank-ecdsa==2.0.3
+starkbank-ecdsa==2.0.2
     # via sendgrid
 tzdata==2021.5
     # via pytz-deprecation-shim
 tzlocal==4.1
     # via apscheduler
-urllib3==1.26.7
+urllib3==1.26.5
     # via
     #   minio
     #   requests
-werkzeug==2.0.2
+werkzeug==2.0.1
     # via flask
-zipp==3.6.0
-    # via
-    #   importlib-metadata
-    #   importlib-resources
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/flask/requirements.txt
+++ b/flask/requirements.txt
@@ -72,8 +72,6 @@ python-dateutil==2.8.1
     #   pandas
 python-editor==1.0.4
     # via alembic
-python-http-client==3.3.3
-    # via sendgrid
 pytz==2021.1
     # via
     #   apscheduler
@@ -82,19 +80,19 @@ pytz-deprecation-shim==0.1.0.post0
     # via tzlocal
 requests==2.26.0
     # via -r requirements.in
-sendgrid==6.9.1
+sendgrid==1.6.20
     # via -r requirements.in
 six==1.15.0
     # via
     #   apscheduler
     #   python-dateutil
+smtpapi==0.3.1
+    # via sendgrid
 sqlalchemy==1.3.24
     # via
     #   -r requirements.in
     #   alembic
     #   flask-sqlalchemy
-starkbank-ecdsa==2.0.2
-    # via sendgrid
 tzdata==2021.5
     # via pytz-deprecation-shim
 tzlocal==4.1

--- a/flask/requirements.txt
+++ b/flask/requirements.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile requirements.in
 #
-alembic==1.5.8
+alembic==1.7.5
     # via flask-migrate
 apscheduler==3.8.1
     # via -r requirements.in
@@ -14,17 +14,17 @@ backports.zoneinfo==0.2.1
     # via
     #   pytz-deprecation-shim
     #   tzlocal
-certifi==2020.12.5
+certifi==2021.10.8
     # via
     #   minio
     #   requests
-cffi==1.14.5
+cffi==1.15.0
     # via cryptography
-charset-normalizer==2.0.3
+charset-normalizer==2.0.9
     # via requests
-click==8.0.1
+click==8.0.3
     # via flask
-cryptography==3.4.7
+cryptography==36.0.0
     # via
     #   authlib
     #   pymysql
@@ -42,37 +42,41 @@ flask-sqlalchemy==2.5.1
     # via
     #   -r requirements.in
     #   flask-migrate
+greenlet==1.1.2
+    # via sqlalchemy
 gunicorn==20.1.0
     # via -r requirements.in
-idna==2.10
+idna==3.3
     # via requests
+importlib-metadata==4.8.2
+    # via alembic
+importlib-resources==5.4.0
+    # via alembic
 itsdangerous==2.0.1
     # via flask
-jinja2==3.0.1
+jinja2==3.0.3
     # via flask
-mako==1.1.4
+mako==1.1.6
     # via alembic
 markupsafe==2.0.1
     # via
     #   jinja2
     #   mako
-minio==7.1.1
+minio==7.1.2
     # via -r requirements.in
-numpy==1.20.2
+numpy==1.21.4
     # via pandas
 pandas==1.3.4
     # via -r requirements.in
-pycparser==2.20
+pycparser==2.21
     # via cffi
 pymysql[rsa]==1.0.2
     # via -r requirements.in
-python-dateutil==2.8.1
-    # via
-    #   alembic
-    #   pandas
-python-editor==1.0.4
-    # via alembic
-pytz==2021.1
+python-dateutil==2.8.2
+    # via pandas
+python-http-client==3.3.4
+    # via sendgrid
+pytz==2021.3
     # via
     #   apscheduler
     #   pandas
@@ -80,29 +84,33 @@ pytz-deprecation-shim==0.1.0.post0
     # via tzlocal
 requests==2.26.0
     # via -r requirements.in
-sendgrid==1.6.20
+sendgrid==6.9.2
     # via -r requirements.in
-six==1.15.0
+six==1.16.0
     # via
     #   apscheduler
     #   python-dateutil
-smtpapi==0.3.1
-    # via sendgrid
-sqlalchemy==1.3.24
+sqlalchemy==1.4.27
     # via
     #   -r requirements.in
     #   alembic
     #   flask-sqlalchemy
+starkbank-ecdsa==2.0.3
+    # via sendgrid
 tzdata==2021.5
     # via pytz-deprecation-shim
 tzlocal==4.1
     # via apscheduler
-urllib3==1.26.5
+urllib3==1.26.7
     # via
     #   minio
     #   requests
-werkzeug==2.0.1
+werkzeug==2.0.2
     # via flask
+zipp==3.6.0
+    # via
+    #   importlib-metadata
+    #   importlib-resources
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools


### PR DESCRIPTION
Dependabot identified an issue with incompatible with `starbank` dependency. Upgrading sendgrid to the latest version resolved this. 