### PR TITLE
React: fix analysis requests broken by backend schema verification

### DIFF
--- a/react/src/hooks/analyses/useAnalysisCreateMutation.tsx
+++ b/react/src/hooks/analyses/useAnalysisCreateMutation.tsx
@@ -22,7 +22,7 @@ async function createAnalysis(params: CreateAnalysisParams) {
     if (params.type === "reanalysis")
         return changeFetch(`/api/analyses/${params.analysis_id}`, "POST");
 
-    return changeFetch("/api/analyses", "POST", params);
+    return changeFetch("/api/analyses", "POST", { ...params, type: undefined });
 }
 
 /**


### PR DESCRIPTION
Cause is an extraneous 'type' parameter that is only used in the frontend