### PR TITLE
Docker: switch to Traefik for multitenant deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@
 minio*/
 mysql*/
 nginx/certs/
-nginx/logs
+traefik/certs/
 .env
 .DS_Store
 *.log

--- a/docker-compose.ccm.yaml
+++ b/docker-compose.ccm.yaml
@@ -30,14 +30,15 @@ services:
       MINIO_SECRET_KEY: "${HIRAKI_MINIO_SECRET_KEY}"
     labels:
       - traefik.enable=true
-      - traefik.http.routers.app.rule=Host(`stager-hiraki.ccm.sickkids.ca`) # && PathPrefix(`/api`)
-      - traefik.http.routers.app.entrypoints=https
-      # Assume this works for now, need to confirm with domains
+      - traefik.http.routers.app-hiraki.rule=Host(`stager-hiraki.ccm.sickkids.ca`) # && PathPrefix(`/api`)
+      - traefik.http.routers.app-hiraki.entrypoints=https
+      - traefik.http.routers.app-hiraki.middlewares=app
       - traefik.http.middlewares.app.headers.accessControlAllowOriginList=https://stager.ccm.sickkids.ca
       - traefik.http.middlewares.app.headers.accessControlAllowMethods=GET,HEAD,POST,PUT,DELETE,OPTIONS,PATCH
       - traefik.http.middlewares.app.headers.accessControlAllowHeaders=Accept,Content-Type
       - traefik.http.middlewares.app.headers.accessControlAllowCredentials=true
       - traefik.http.middlewares.app.headers.frameDeny=true
+      - traefik.http.middlewares.app.headers.browserXssFilter=true
   # app-hawkins:
   #   <<: *app
   #   environment:
@@ -47,6 +48,11 @@ services:
   #     MINIO_ENDPOINT: "${HAWKINS_MINIO_ENDPOINT}"
   #     MINIO_ACCESS_KEY: "${HAWKINS_MINIO_ACCESS_KEY}"
   #     MINIO_SECRET_KEY: "${HAWKINS_MINIO_SECRET_KEY}"
+  #   labels:
+  #     - traefik.enable=true
+  #     - traefik.http.routers.app-hawkins.rule=Host(`stager-hawkins.ccm.sickkids.ca`) # && PathPrefix(`/api`)
+  #     - traefik.http.routers.app-hawkins.entrypoints=https
+  #     - traefik.http.routers.app-hawkins.middlewares=app
   proxy:
     image: traefik:2.5
     volumes:

--- a/docker-compose.ccm.yaml
+++ b/docker-compose.ccm.yaml
@@ -28,6 +28,16 @@ services:
       MINIO_ENDPOINT: "${HIRAKI_MINIO_ENDPOINT}"
       MINIO_ACCESS_KEY: "${HIRAKI_MINIO_ACCESS_KEY}"
       MINIO_SECRET_KEY: "${HIRAKI_MINIO_SECRET_KEY}"
+    labels:
+      - traefik.enable=true
+      - traefik.http.routers.app.rule=Host(`stager-hiraki.ccm.sickkids.ca`) # && PathPrefix(`/api`)
+      - traefik.http.routers.app.entrypoints=https
+      # Assume this works for now, need to confirm with domains
+      - traefik.http.middlewares.app.headers.accessControlAllowOriginList=https://stager.ccm.sickkids.ca
+      - traefik.http.middlewares.app.headers.accessControlAllowMethods=GET,HEAD,POST,PUT,DELETE,OPTIONS,PATCH
+      - traefik.http.middlewares.app.headers.accessControlAllowHeaders=Accept,Content-Type
+      - traefik.http.middlewares.app.headers.accessControlAllowCredentials=true
+      - traefik.http.middlewares.app.headers.frameDeny=true
   # app-hawkins:
   #   <<: *app
   #   environment:
@@ -37,12 +47,28 @@ services:
   #     MINIO_ENDPOINT: "${HAWKINS_MINIO_ENDPOINT}"
   #     MINIO_ACCESS_KEY: "${HAWKINS_MINIO_ACCESS_KEY}"
   #     MINIO_SECRET_KEY: "${HAWKINS_MINIO_SECRET_KEY}"
-  nginx:
-    image: nginx:alpine
+  proxy:
+    image: traefik:2.5
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - "${PROJECT_ROOT:-.}/traefik:/etc/traefik"
+    command:
+      - --api.insecure
+      - --providers.docker
+      - --providers.docker.exposedbydefault=false
+      - --providers.file.directory=/etc/traefik
+      - --providers.file.watch=false
+      - --accesslog
+      - --log
+      - --metrics.prometheus
+      - --global.checknewversion=false
+      - --global.sendanonymoususage=false
+      - --entrypoints.http.address=:80
+      - --entrypoints.http.http.redirections.entrypoint.to=https
+      - --entrypoints.https.http.tls
+      - --entrypoints.https.address=:443
     ports:
       - "80:80"
       - "443:443"
-    volumes:
-      - "${PROJECT_ROOT:-.}/nginx/conf.d:/etc/nginx/conf.d"
-      - "${PROJECT_ROOT:-.}/nginx/certs:/etc/nginx/certs"
+      - "8080:8080" # Traefik and Prometheus endpoint
     <<: *common

--- a/docker-compose.ccm.yaml
+++ b/docker-compose.ccm.yaml
@@ -15,6 +15,7 @@ x-app: &app
 
 x-env: &env
   MINIO_REGION_NAME: hpc4health
+  MINIO_TLS: "true"
   MSTEAMS_WEBHOOK_URL:
 
 services:
@@ -27,7 +28,6 @@ services:
       MINIO_ENDPOINT: "${HIRAKI_MINIO_ENDPOINT}"
       MINIO_ACCESS_KEY: "${HIRAKI_MINIO_ACCESS_KEY}"
       MINIO_SECRET_KEY: "${HIRAKI_MINIO_SECRET_KEY}"
-      MINIO_TLS: "true"
   # app-hawkins:
   #   <<: *app
   #   environment:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -69,7 +69,7 @@ services:
       - ./flask:/usr/src/stager
     entrypoint: ["python", "-m", "debugpy", "--listen", "0.0.0.0:5678", "-m", "flask", "run", "--host=0.0.0.0"]
   # Simulated production gunicorn configuration
-  app_gunicorn:
+  app_gunicorn: # Try naming this a domain?
     build:
       context: flask
       dockerfile: ../Dockerfile
@@ -87,7 +87,40 @@ services:
       MINIO_REGION_NAME:
     ports:
       - "${FLASK_HOST_PORT:-127.0.0.1:5000}:5000"
-      - "${METRICS_HOST_PORT:-127.0.0.1:8080}:8080"
+      - "${METRICS_HOST_PORT:-127.0.0.1:8081}:8080"
+    labels:
+      - traefik.enable=true
+      - traefik.http.routers.app.rule=Host(`localhost`) && PathPrefix(`/api`)
+      - traefik.http.routers.app.entrypoints=https
+      # Assume this works for now, need to confirm with domains
+      - traefik.http.middlewares.app.headers.accessControlAllowOriginList=https://stager.ccm.sickkids.ca
+      - traefik.http.middlewares.app.headers.accessControlAllowMethods=GET,HEAD,POST,PUT,DELETE,OPTIONS,PATCH
+      - traefik.http.middlewares.app.headers.accessControlAllowHeaders=Accept,Content-Type
+      - traefik.http.middlewares.app.headers.accessControlAllowCredentials=true
+      - traefik.http.middlewares.app.headers.frameDeny=true
     depends_on:
       - mysql
       - minio
+  proxy:
+    image: traefik:2.5
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - ./traefik:/etc/traefik
+    command:
+      - --api.insecure
+      - --providers.docker
+      - --providers.docker.exposedbydefault=false
+      - --providers.file.directory=/etc/traefik # Can disable watch
+      - --accesslog
+      - --log
+      - --metrics.prometheus
+      - --global.checknewversion=false
+      - --global.sendanonymoususage=false
+      - --entrypoints.http.address=:80
+      - --entrypoints.http.http.redirections.entrypoint.to=https
+      - --entrypoints.https.http.tls
+      - --entrypoints.https.address=:443
+    ports:
+      - "80:80"
+      - "443:443"
+      - "8080:8080" # Traefik and Prometheus endpoint

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -69,7 +69,7 @@ services:
       - ./flask:/usr/src/stager
     entrypoint: ["python", "-m", "debugpy", "--listen", "0.0.0.0:5678", "-m", "flask", "run", "--host=0.0.0.0"]
   # Simulated production gunicorn configuration
-  app_gunicorn: # Try naming this a domain?
+  app_gunicorn:
     build:
       context: flask
       dockerfile: ../Dockerfile
@@ -87,40 +87,7 @@ services:
       MINIO_REGION_NAME:
     ports:
       - "${FLASK_HOST_PORT:-127.0.0.1:5000}:5000"
-      - "${METRICS_HOST_PORT:-127.0.0.1:8081}:8080"
-    labels:
-      - traefik.enable=true
-      - traefik.http.routers.app.rule=Host(`localhost`) && PathPrefix(`/api`)
-      - traefik.http.routers.app.entrypoints=https
-      # Assume this works for now, need to confirm with domains
-      - traefik.http.middlewares.app.headers.accessControlAllowOriginList=https://stager.ccm.sickkids.ca
-      - traefik.http.middlewares.app.headers.accessControlAllowMethods=GET,HEAD,POST,PUT,DELETE,OPTIONS,PATCH
-      - traefik.http.middlewares.app.headers.accessControlAllowHeaders=Accept,Content-Type
-      - traefik.http.middlewares.app.headers.accessControlAllowCredentials=true
-      - traefik.http.middlewares.app.headers.frameDeny=true
+      - "${METRICS_HOST_PORT:-127.0.0.1:8080}:8080"
     depends_on:
       - mysql
       - minio
-  proxy:
-    image: traefik:2.5
-    volumes:
-      - /var/run/docker.sock:/var/run/docker.sock
-      - ./traefik:/etc/traefik
-    command:
-      - --api.insecure
-      - --providers.docker
-      - --providers.docker.exposedbydefault=false
-      - --providers.file.directory=/etc/traefik # Can disable watch
-      - --accesslog
-      - --log
-      - --metrics.prometheus
-      - --global.checknewversion=false
-      - --global.sendanonymoususage=false
-      - --entrypoints.http.address=:80
-      - --entrypoints.http.http.redirections.entrypoint.to=https
-      - --entrypoints.https.http.tls
-      - --entrypoints.https.address=:443
-    ports:
-      - "80:80"
-      - "443:443"
-      - "8080:8080" # Traefik and Prometheus endpoint

--- a/nginx/conf.d/default.conf
+++ b/nginx/conf.d/default.conf
@@ -64,5 +64,6 @@ server {
     add_header Access-Control-Allow-Origin https://stager.ccm.sickkids.ca always;
     add_header Access-Control-Allow-Headers "Accept, Content-Type" always;
     add_header Access-Control-Allow-Credentials true always;
+    add_header Access-Control-Allow-Methods "GET, HEAD, POST, PUT, DELETE, OPTIONS, PATCH";
   }
 }

--- a/traefik/frontend.yml
+++ b/traefik/frontend.yml
@@ -4,6 +4,7 @@ http:
       entryPoints:
         - https
       middlewares:
+        - security
         - singlePageApplication
         - routeToBucket
       service: minio
@@ -23,3 +24,7 @@ http:
       replacePathRegex:
         regex: ^(/|[^.]*)$ # Either match / or a path without an extension (determined by .)
         replacement: /index.html
+    security:
+      headers:
+        frameDeny: true
+        browserXssFilter: true

--- a/traefik/frontend.yml
+++ b/traefik/frontend.yml
@@ -6,22 +6,16 @@ http:
       middlewares:
         - singlePageApplication
         - routeToBucket
-        #- headers
       service: minio
-      rule: Host(`localhost`)
+      rule: Host(`stager.ccm.sickkids.ca`)
       # This must be lower priority than the backend /api if on the same domain
       tls: {}
   services:
     minio:
       loadBalancer:
         servers:
-          #- url: https://minio.genomics4rd.ca
           - url: https://minio.ccm.sickkids.ca
   middlewares:
-    # headers:
-    #   headers:
-    #     customRequestHeaders:
-    #       Host: minio.genomics4rd.ca
     routeToBucket:
       addPrefix:
         prefix: /www-stager

--- a/traefik/frontend.yml
+++ b/traefik/frontend.yml
@@ -1,0 +1,31 @@
+http:
+  routers:
+    frontend:
+      entryPoints:
+        - https
+      middlewares:
+        - singlePageApplication
+        - routeToBucket
+        #- headers
+      service: minio
+      rule: Host(`localhost`)
+      # This must be lower priority than the backend /api if on the same domain
+      tls: {}
+  services:
+    minio:
+      loadBalancer:
+        servers:
+          #- url: https://minio.genomics4rd.ca
+          - url: https://minio.ccm.sickkids.ca
+  middlewares:
+    # headers:
+    #   headers:
+    #     customRequestHeaders:
+    #       Host: minio.genomics4rd.ca
+    routeToBucket:
+      addPrefix:
+        prefix: /www-stager
+    singlePageApplication:
+      replacePathRegex:
+        regex: ^(/|[^.]*)$ # Either match / or a path without an extension (determined by .)
+        replacement: /index.html

--- a/traefik/https.yml
+++ b/traefik/https.yml
@@ -1,7 +1,4 @@
 tls:
-  # certificates:
-  #   - certFile: /etc/traefik/certs/bundle.crt
-  #     keyFile: /etc/traefik/certs/star_ccm_sickkids_ca.key
   stores:
     default:
       defaultCertificate:
@@ -17,7 +14,6 @@ http:
       rule: HostRegexp(`{host:.+}`)
       service: noop@internal
       tls: false
-      # priority: 100
   middlewares:
     redirect:
       redirectScheme:

--- a/traefik/https.yml
+++ b/traefik/https.yml
@@ -1,0 +1,25 @@
+tls:
+  # certificates:
+  #   - certFile: /etc/traefik/certs/bundle.crt
+  #     keyFile: /etc/traefik/certs/star_ccm_sickkids_ca.key
+  stores:
+    default:
+      defaultCertificate:
+        certFile: /etc/traefik/certs/bundle.crt
+        keyFile: /etc/traefik/certs/star_ccm_sickkids_ca.key
+http:
+  routers:
+    redirect:
+      entryPoints:
+        - https
+      middlewares:
+        - redirect
+      rule: HostRegexp(`{host:.+}`)
+      service: noop@internal
+      tls: false
+      # priority: 100
+  middlewares:
+    redirect:
+      redirectScheme:
+        scheme: https
+        permanent: true


### PR DESCRIPTION
This is already working on the real site. Please check if the configuration makes sense and if additional documentation is needed beyond [Traefik's own](https://doc.traefik.io/traefik/).

Closes #976