### PR TITLE
CI: fix caching behaviour for frontend workflow

### DIFF
--- a/.github/workflows/react.yml
+++ b/.github/workflows/react.yml
@@ -88,7 +88,6 @@ jobs:
       id: yarn-cache-path
       run: echo "::set-output name=dir::$(yarn cache dir)"
     - uses: actions/cache@v2
-      id: restore
       with:
         path: |
           ${{ steps.yarn-cache-path.outputs.dir }}

--- a/.github/workflows/react.yml
+++ b/.github/workflows/react.yml
@@ -51,7 +51,6 @@ jobs:
       id: yarn-cache-path
       run: echo "::set-output name=dir::$(yarn cache dir)"
     - uses: actions/cache@v2
-      id: restore
       with:
         path: |
           ${{ steps.yarn-cache-path.outputs.dir }}
@@ -59,7 +58,6 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-yarn-
     - run: yarn install
-      if: steps.restore.outputs.cache-hit != 'true'
     # End setup
     - run: yarn build
       env:
@@ -94,12 +92,10 @@ jobs:
       with:
         path: |
           ${{ steps.yarn-cache-path.outputs.dir }}
-          react/node_modules
         key: ${{ runner.os }}-yarn-${{ hashFiles('react/yarn.lock') }}
         restore-keys: |
           ${{ runner.os }}-yarn-
-    - run: yarn install # should never happen due to build job
-      if: steps.restore.outputs.cache-hit != 'true'
+    - run: yarn install
     # End setup
     - name: Write out endpoints JSON
       run: |


### PR DESCRIPTION
The `yarn install` step should never be skipped as directly caching `node_modules` leads to funny behaviour.