### PR TITLE
Flask: fix admins not having MinIO delete permissions

### DIFF
--- a/flask/app/madmin.py
+++ b/flask/app/madmin.py
@@ -154,16 +154,18 @@ def stager_buckets_policy(*buckets: str) -> Dict[str, Any]:
         "Statement": [
             {
                 "Effect": "Allow",
-                "Action": ["s3:*"],
-                "Resource": arns,
-            },
-            {
-                "Effect": "Deny",
                 "Action": [
-                    "s3:DeleteBucket",
-                    "s3:ForceDeleteBucket",
-                    "s3:DeleteObject",
-                    "s3:DeleteObjectVersion",
+                    "s3:CreateBucket",
+                    "s3:GetBucketLocation",
+                    "s3:ListAllMyBuckets",
+                    "s3:GetObject",
+                    "s3:ListBucket",
+                    "s3:PutObject",
+                    "s3:PutObjectTagging",
+                    "s3:GetObjectTagging",
+                    "s3:AbortMultipartUpload",
+                    "s3:ListMultipartUploadParts",
+                    "s3:ListBucketMultipartUploads"
                 ],
                 "Resource": arns,
             },

--- a/flask/app/madmin.py
+++ b/flask/app/madmin.py
@@ -165,7 +165,7 @@ def stager_buckets_policy(*buckets: str) -> Dict[str, Any]:
                     "s3:GetObjectTagging",
                     "s3:AbortMultipartUpload",
                     "s3:ListMultipartUploadParts",
-                    "s3:ListBucketMultipartUploads"
+                    "s3:ListBucketMultipartUploads",
                 ],
                 "Resource": arns,
             },


### PR DESCRIPTION
Deny overrides Allow, so change the per-group policy to use explicit Allows. All policies: https://docs.min.io/minio/baremetal/security/minio-identity-management/policy-based-access-control.html

I will run `migrate-minio-policies` after merging.