### PR TITLE
Flask: made unlinked file query non-recursive to reduce payload

### DIFF
--- a/flask/app/buckets.py
+++ b/flask/app/buckets.py
@@ -36,9 +36,11 @@ def get_unlinked_files():
 
         # Check if the bucket in file path exists
         app.logger.debug("Getting all minio bucket names..")
-        all_bucket_names = [bucket.name for bucket in minio_client.list_buckets()]
+        all_bucket_names = [
+            bucket.name for bucket in minio_client.list_buckets()]
         if bucket_name not in all_bucket_names:
-            abort(400, description=f"Bucket name must be one of {all_bucket_names}")
+            abort(
+                400, description=f"Bucket name must be one of {all_bucket_names}")
 
         app.logger.debug("Getting all buckets that user has access to..")
         user = (
@@ -62,7 +64,10 @@ def get_unlinked_files():
         # Get files with prefix in the bucket user specifies
         app.logger.debug("Getting all files in user minio buckets..")
         all_files = []
-        objs = minio_client.list_objects(bucket_name, prefix=file_name, recursive=True)
+        objs = minio_client.list_objects(
+            bucket_name, prefix=file_name, recursive=False)
+
+        app.logger.debug('all files', objs)
 
         for obj in objs:
             if file_name in obj.object_name:
@@ -73,7 +78,8 @@ def get_unlinked_files():
         linked_files = {
             f.path: True
             for f in models.File.query.filter(
-                or_(models.File.multiplexed == None, models.File.multiplexed == False)
+                or_(models.File.multiplexed == None,
+                    models.File.multiplexed == False)
             ).all()
         }
 

--- a/flask/app/buckets.py
+++ b/flask/app/buckets.py
@@ -36,11 +36,9 @@ def get_unlinked_files():
 
         # Check if the bucket in file path exists
         app.logger.debug("Getting all minio bucket names..")
-        all_bucket_names = [
-            bucket.name for bucket in minio_client.list_buckets()]
+        all_bucket_names = [bucket.name for bucket in minio_client.list_buckets()]
         if bucket_name not in all_bucket_names:
-            abort(
-                400, description=f"Bucket name must be one of {all_bucket_names}")
+            abort(400, description=f"Bucket name must be one of {all_bucket_names}")
 
         app.logger.debug("Getting all buckets that user has access to..")
         user = (
@@ -64,10 +62,9 @@ def get_unlinked_files():
         # Get files with prefix in the bucket user specifies
         app.logger.debug("Getting all files in user minio buckets..")
         all_files = []
-        objs = minio_client.list_objects(
-            bucket_name, prefix=file_name, recursive=False)
+        objs = minio_client.list_objects(bucket_name, prefix=file_name, recursive=False)
 
-        app.logger.debug('all files', objs)
+        app.logger.debug("all files", objs)
 
         for obj in objs:
             if file_name in obj.object_name:
@@ -78,8 +75,7 @@ def get_unlinked_files():
         linked_files = {
             f.path: True
             for f in models.File.query.filter(
-                or_(models.File.multiplexed == None,
-                    models.File.multiplexed == False)
+                or_(models.File.multiplexed == None, models.File.multiplexed == False)
             ).all()
         }
 

--- a/react/src/components/AutocompleteMultiselect.tsx
+++ b/react/src/components/AutocompleteMultiselect.tsx
@@ -34,7 +34,8 @@ export default function AutocompleteMultiselect<T extends Record<string, any>>({
     noOptionsText,
 }: AutocompleteMultiselectProps<T>) {
     const [inputValue, setInputValue] = useState("");
-    const [removedOptions, setRemovedOptions] = useState<T[]>([]);
+
+    const isUnlinkedFileFolder = (path: string) => path.endsWith('/');
 
     return (
         <Autocomplete
@@ -53,21 +54,16 @@ export default function AutocompleteMultiselect<T extends Record<string, any>>({
             disableClearable={true}
             disableCloseOnSelect
             onChange={(event, selectedOptions, reason, details) => {
-                if (reason === "remove-option") {
-                    removedOptions.push(details!.option);
-                    setRemovedOptions(removedOptions);
-                } else if (reason === "select-option") {
-                    setRemovedOptions(removedOptions.filter(v => v.path !== details!.option.path));
-                }
 
                 //prevent keypress events from propagating to parent listeners
                 event.stopPropagation();
                 if (selectedOptions && ["select-option", "remove-option"].includes(reason)) {
                     const latestOption = selectedOptions[selectedOptions.length - 1];
-                    if (latestOption && latestOption.path.endsWith("/")) {
+
+                    // If the option chosen is a folder, change the input value instead of selecting it as an option.
+                    if (latestOption && isUnlinkedFileFolder(latestOption.path)) {
                         setInputValue(latestOption.path);
                         if (onInputChange) {
-                            //if options are filtered dynamically
                             onInputChange(latestOption.path);
                         }
                     } else {
@@ -81,7 +77,7 @@ export default function AutocompleteMultiselect<T extends Record<string, any>>({
             getOptionSelected={(option, value) =>
                 option[uniqueLabelPath] === value[uniqueLabelPath]
             }
-            options={[...new Set(options.concat(removedOptions))]}
+            options={options}
             filterOptions={createFilterOptions({
                 limit,
                 stringify: o => o[uniqueLabelPath],

--- a/react/src/components/AutocompleteMultiselect.tsx
+++ b/react/src/components/AutocompleteMultiselect.tsx
@@ -35,7 +35,7 @@ export default function AutocompleteMultiselect<T extends Record<string, any>>({
 }: AutocompleteMultiselectProps<T>) {
     const [inputValue, setInputValue] = useState("");
 
-    const isUnlinkedFileFolder = (path: string) => path.endsWith('/');
+    const isUnlinkedFileFolder = (path: string) => path.endsWith("/");
 
     return (
         <Autocomplete
@@ -54,7 +54,6 @@ export default function AutocompleteMultiselect<T extends Record<string, any>>({
             disableClearable={true}
             disableCloseOnSelect
             onChange={(event, selectedOptions, reason, details) => {
-
                 //prevent keypress events from propagating to parent listeners
                 event.stopPropagation();
                 if (selectedOptions && ["select-option", "remove-option"].includes(reason)) {

--- a/react/src/components/AutocompleteMultiselect.tsx
+++ b/react/src/components/AutocompleteMultiselect.tsx
@@ -63,8 +63,17 @@ export default function AutocompleteMultiselect<T extends Record<string, any>>({
                 //prevent keypress events from propagating to parent listeners
                 event.stopPropagation();
                 if (selectedOptions && ["select-option", "remove-option"].includes(reason)) {
-                    onSelect(selectedOptions);
-                    setInputValue("");
+                    const latestOption = selectedOptions[selectedOptions.length - 1];
+                    if (latestOption && latestOption.path.endsWith("/")) {
+                        setInputValue(latestOption.path);
+                        if (onInputChange) {
+                            //if options are filtered dynamically
+                            onInputChange(latestOption.path);
+                        }
+                    } else {
+                        onSelect(selectedOptions);
+                        setInputValue("");
+                    }
                 }
             }}
             renderOption={option => <span>{option[uniqueLabelPath]}</span>}

--- a/react/src/hooks/unlinked/useUnlinkedFilesQuery.tsx
+++ b/react/src/hooks/unlinked/useUnlinkedFilesQuery.tsx
@@ -20,7 +20,7 @@ export function useUnlinkedFilesQuery(
         ["unlinked", params],
         () => fetchFiles(params),
         {
-            staleTime: Infinity,
+            staleTime: 1000,
             retry: false,
             refetchInterval: false,
             refetchOnMount: false,


### PR DESCRIPTION
The goal of this PR is to reduce the `unlinked` file's endpoint payload. 

The main changes in this PR are:
- Set `recursive` property to `false`
- Added a check to see if an option is a file or folder. If it's a folder, autocomplete the folder path and sends off a query. If not, then the file is selected as an unlinked file. 