### PR TITLE
Flask: fix mc mirror --watch failing with Access Denied

### DIFF
--- a/flask/app/madmin.py
+++ b/flask/app/madmin.py
@@ -170,7 +170,7 @@ def stager_buckets_policy(*buckets: str) -> Dict[str, Any]:
                     "s3:GetBucketNotification",
                     "s3:PutBucketNotification",
                     "s3:ListenNotification",
-                    "s3:ListenBucketNotification"
+                    "s3:ListenBucketNotification",
                 ],
                 "Resource": arns,
             },

--- a/flask/app/madmin.py
+++ b/flask/app/madmin.py
@@ -167,6 +167,10 @@ def stager_buckets_policy(*buckets: str) -> Dict[str, Any]:
                     "s3:AbortMultipartUpload",
                     "s3:ListMultipartUploadParts",
                     "s3:ListBucketMultipartUploads",
+                    "s3:GetBucketNotification",
+                    "s3:PutBucketNotification",
+                    "s3:ListenNotification",
+                    "s3:ListenBucketNotification"
                 ],
                 "Resource": arns,
             },


### PR DESCRIPTION
--watch seems to additionally depend on the Bucket Notifications API https://docs.min.io/minio/baremetal/security/minio-identity-management/policy-based-access-control.html

Fixes regression introduced in #1012