### PR TITLE
Flask: Upgrade to python 3.8 (again)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Production image. Runs a Gunicorn WSGI server.
 FROM minio/mc:RELEASE.2021-12-10T00-14-28Z AS mc
-FROM python:3.7-slim
+FROM python:3.8-slim
 ARG GIT_SHA
 LABEL org.opencontainers.image.title Stager production
 LABEL org.opencontainers.image.authors https://ccm.sickkids.ca/

--- a/flask/Dockerfile
+++ b/flask/Dockerfile
@@ -1,6 +1,6 @@
 # Development image only. Runs a Flask development server.
 FROM minio/mc:RELEASE.2021-12-10T00-14-28Z AS mc
-FROM python:3.7-slim
+FROM python:3.8-slim
 LABEL org.opencontainers.image.title Stager development
 LABEL org.opencontainers.image.authors https://ccm.sickkids.ca/
 LABEL org.opencontainers.image.source https://github.com/ccmbioinfo/stager

--- a/flask/app/schemas.py
+++ b/flask/app/schemas.py
@@ -1,6 +1,5 @@
-from typing_extensions import Required
-from marshmallow_sqlalchemy import SQLAlchemyAutoSchema
 from marshmallow import fields, ValidationError
+from marshmallow_sqlalchemy import SQLAlchemyAutoSchema
 from marshmallow.validate import And, Length, Range, Regexp
 from .models import *
 

--- a/flask/tests/test_misc.py
+++ b/flask/tests/test_misc.py
@@ -1,10 +1,9 @@
-from unittest.mock import Mock, patch
+from unittest.mock import Mock
 from csv import DictReader
 from io import StringIO
 from pytest import raises
-
-from flask import current_app as app
 from flask.wrappers import Request
+from flask import request
 from sqlalchemy.orm import joinedload
 from werkzeug.exceptions import BadRequest
 
@@ -554,27 +553,22 @@ def test_filter_datasets_by_user_groups(test_database):
     assert len(filtered_query.all()) == 1
 
 
-@patch("app.utils.request")
-def test_must_pass_in_user_arguement_if_login_disabled(
-    mock_request, application, test_database
-):
+def test_must_pass_in_user_arguement_if_login_disabled(application, test_database):
     """do we get a 400 if log in is disabled and no user argument is passed in?"""
     application.config["LOGIN_DISABLED"] = True
 
     """ no user argument """
-    mock_request.args.get.return_value = None
-    with raises(BadRequest):
-        get_current_user()
-    """ sanity check that the mock actually got passed the `user` key """
-    assert mock_request.args.get.call_args == (("user",),)
+    with application.test_request_context("/api"):
+        with raises(BadRequest):
+            get_current_user()
 
     """ invalid user argument """
-    mock_request.args.get.return_value = 0
-    with raises(BadRequest):
-        get_current_user()
+    with application.test_request_context("/api/?user=0"):
+        with raises(BadRequest):
+            get_current_user()
 
     """ valid user argument """
-    mock_request.args.get.return_value = 1
-    assert get_current_user().user_id == 1
+    with application.test_request_context("/api/?user=1"):
+        assert get_current_user().user_id == 1
 
     application.config["LOGIN_DISABLED"] = False

--- a/flask/tests/unit/test_json_validation_decorator.py
+++ b/flask/tests/unit/test_json_validation_decorator.py
@@ -1,32 +1,32 @@
-""" test json validator """
-from unittest.mock import patch
-from unittest import TestCase
+from pytest import raises
 from werkzeug.exceptions import UnsupportedMediaType
 from app.utils import validate_json
 
 
-class ValidationTest(TestCase):
-    """test class for validation"""
+def test_validate_json_throws_415_on_non_json_header(application):
+    """test that validate_json throws when content-type is not json"""
 
-    @patch("app.utils.request")
-    def test_validate_json_throws_415_on_non_json_header(self, mock_request):
-        """test that validate_json throws when content-type is not json"""
-        mock_request.headers = {"Content-Type": "application/foo"}
+    @validate_json
+    def mock_route():
+        return True
 
-        @validate_json
-        def mock_route():
-            return True
+    with application.test_request_context(
+        "/api", headers={"Content-Type": "application/foo"}
+    ):
 
-        with self.assertRaises(UnsupportedMediaType):
+        with raises(UnsupportedMediaType):
             mock_route()
 
-    @patch("app.utils.request")
-    def test_validate_json_passes_on_json_header(self, mock_request):
-        """test that validate_json raises no exception when content-type is json"""
-        mock_request.headers = {"Content-Type": "application/json"}
 
-        @validate_json
-        def mock_route():
-            return True
+def test_validate_json_passes_on_json_header(application):
+    """test that validate_json raises no exception when content-type is json"""
+
+    @validate_json
+    def mock_route():
+        return True
+
+    with application.test_request_context(
+        "/api", headers={"Content-Type": "application/json"}
+    ):
 
         assert mock_route()


### PR DESCRIPTION
This PR is a continuation of #1028 . In production, `wsgi` import raised an error because the module import `typing_extensions` in `schemas.py` can't be found. With this PR, simulating the production environment with `docker-compose up app_gunicorn` raised no errors. 