### PR TITLE
Traefik: improve TLS

### DIFF
--- a/traefik/https.yml
+++ b/traefik/https.yml
@@ -1,4 +1,13 @@
 tls:
+  options:
+    default:
+      minVersion: VersionTLS12
+      cipherSuites:
+      # Drop all weak cipher suites as reported by SSL Labs and NMap
+      # This means that old browsers (IE11 pre-Windows 10, Safari 8 and older) will fail the handshake
+        - TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
+        - TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+        - TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
   stores:
     default:
       defaultCertificate:


### PR DESCRIPTION
Require TLS 1.2+ and only secure ciphers

From a security warnning issued by RIT/HPF. Check at https://www.ssllabs.com/ssltest/analyze.html?d=stager.ccm.sickkids.ca&hideResults=on or with `nmap --script ssl-enum-ciphers -p 443 stager.ccm.sickkids.ca`

Note: I already made this change effective in production