### PR TITLE
Flask: Upgrade from Python 3.8 to Python 3.9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Production image. Runs a Gunicorn WSGI server.
 FROM minio/mc:RELEASE.2021-12-10T00-14-28Z AS mc
-FROM python:3.8-slim
+FROM python:3.9-slim
 ARG GIT_SHA
 LABEL org.opencontainers.image.title Stager production
 LABEL org.opencontainers.image.authors https://ccm.sickkids.ca/

--- a/README.md
+++ b/README.md
@@ -11,17 +11,17 @@ The [Centre for Computational Medicine](https://ccm.sickkids.ca/) at SickKids su
 
 Access to Stager is restricted to team members who provide data and metadata or perform data analysis. Key features of Stager are:
 
-- Viewing and editing metadata for participants and datasets
-- Uploading new metadata for participants and datasets
-- Uploading dataset files and linking them to the metadata
-- Requesting analyses for datasets
-- Viewing aggregated analysis reports in the variant viewer
+-   Viewing and editing metadata for participants and datasets
+-   Uploading new metadata for participants and datasets
+-   Uploading dataset files and linking them to the metadata
+-   Requesting analyses for datasets
+-   Viewing aggregated analysis reports in the variant viewer
 
 ## Tech stack
 
 The browser single-page application frontend is written in [TypeScript](https://www.typescriptlang.org/docs) with the [React](https://reactjs.org/docs/getting-started.html) library, bootstrapped via [Create React App](https://create-react-app.dev/docs/getting-started/), and uses [Material-UI](https://v4.mui.com/) for theming.
 
-The backend is containerized with Docker and written in Python 3.7 with the [Flask]((https://flask.palletsprojects.com/)) microframework and [SQLAlchemy](https://docs.sqlalchemy.org/) object-relational mapper, presenting a RESTful API to the frontend.
+The backend is containerized with Docker and written in Python 3.9 with the [Flask](<(https://flask.palletsprojects.com/)>) microframework and [SQLAlchemy](https://docs.sqlalchemy.org/) object-relational mapper, presenting a RESTful API to the frontend.
 
 A [MySQL 8.0](https://dev.mysql.com/doc/refman/8.0/en/) database stores the aforementioned dataset and analysis metadata
 
@@ -33,6 +33,6 @@ For more developer documentation, see [`docs/`](https://github.com/ccmbioinfo/st
 
 ### Required tools and editors
 
-- [Git](https://git-scm.com/doc)
-- [Docker](https://docs.docker.com/engine/install/) and [Compose](https://docs.docker.com/compose/install/)
-- [Visual Studio Code](https://code.visualstudio.com/) or [PyCharm](https://www.jetbrains.com/pycharm/)
+-   [Git](https://git-scm.com/doc)
+-   [Docker](https://docs.docker.com/engine/install/) and [Compose](https://docs.docker.com/compose/install/)
+-   [Visual Studio Code](https://code.visualstudio.com/) or [PyCharm](https://www.jetbrains.com/pycharm/)

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -6,7 +6,7 @@ Docker containers for easy setup and [cleanup](#resetting-bind-mounts). Follow t
 install Docker and Compose, and read their documentation to learn more about these tools.
 
 Copy `sample.env` to `.env` and edit it to add your choice of credentials for the local servers.
-Set ```ENABLE_OIDC=``` to blank (empty). These can be overridden by your environment variables and
+Set `ENABLE_OIDC=` to blank (empty). These can be overridden by your environment variables and
 are used by Compose when starting a stack of containers from any of the `docker-compose*.yaml` in the project root.
 
 To start the backend stack for development, run:
@@ -49,7 +49,7 @@ If you need to do this, you should instead use:
 docker-compose up --build
 ```
 
-If the base `python:3.7-slim` or `minio/mc` images are updated, this will not check for updates and
+If the base `python:3.9-slim` or `minio/mc` images are updated, this will not check for updates and
 will continue to use your local tags. To use the latest base image from Docker Hub, instead run:
 
 ```bash

--- a/docs/flask.md
+++ b/docs/flask.md
@@ -1,8 +1,7 @@
 # [Flask](https://flask.palletsprojects.com/) application backend server
 
-Flask is a microframework for writing web applications in Python. At the time of
-project initialization, it did not support Python 3.8 yet, so we are using
-Python 3.7.
+Flask is a microframework for writing web applications in Python. We are using
+Python 3.9.
 
 Using [Docker](https://github.com/ccmbioinfo/stager/blob/master/docs/docker.md)
 will automatically set everything up for you and works well in general. For some
@@ -10,7 +9,7 @@ specific debugging and database purposes, you may need to set up a virtualenv.
 
 ## Setting up in a virtualenv
 
-First, you will need Python 3.7, pip, and virtualenv. To create a virtualenv,
+First, you will need Python 3.9, pip, and virtualenv. To create a virtualenv,
 switch to the `flask` directory and run one of the following commands,
 depending on how your Python installation is set up.
 
@@ -52,8 +51,8 @@ need the startup helper script. The module it should use is `wsgi`.
 
 The run script supports setting environment variables PYTHON and COMMAND to
 choose your Python interpreter. By default, it runs `python3 -m flask`, but you
-can set `COMMAND=flask` to have it call `flask` directly, or `PYTHON=python3.7`
-to have it run `python3.7 -m flask`, for example.
+can set `COMMAND=flask` to have it call `flask` directly, or `PYTHON=python3.9`
+to have it run `python3.9 -m flask`, for example.
 
 ## Adding or updating dependencies
 

--- a/docs/locust.md
+++ b/docs/locust.md
@@ -1,11 +1,10 @@
 # [Locust](https://locust.io/) for application load testing
 
-Locust is a framework for load testing in Python. Locust also supports distributed load testing, where multiple workers can be created on multiple cores on a single machine or multiple machines, therefore allowing for several users and requests to be simulated simultaneously. 
-
+Locust is a framework for load testing in Python. Locust also supports distributed load testing, where multiple workers can be created on multiple cores on a single machine or multiple machines, therefore allowing for several users and requests to be simulated simultaneously.
 
 ## Setting up in a virtualenv
 
-First, you will need Python 3.7, pip, and virtualenv. To create a virtualenv,
+First, you will need Python 3.9, pip, and virtualenv. To create a virtualenv,
 switch to the `locust` directory and run one of the following commands,
 depending on how your Python installation is set up.
 
@@ -29,23 +28,27 @@ pip3 install -r requirements.txt
 ## Launching Locust
 
 To launch Locust, run the following command in the `locust` folder.
+
 ```bash
 USERNAME=<username> PASSWORD=<password> python3 launch.py
 ```
 
 Alternatively, you can create a local `.env` by copy-pasting the `sample.env` file and filling in approprivate credentials and run:
+
 ```bash
 python3 launch.py
 ```
 
-In Stager, Locust is set up to automatically run in distributed mode with one master node and multiple workers on a single machine. The number of workers equal the number of cores on your machine minus 2. One of the remaining two cores is dedicated for the master node, and the other one is left empty to avoid system freezes. 
+In Stager, Locust is set up to automatically run in distributed mode with one master node and multiple workers on a single machine. The number of workers equal the number of cores on your machine minus 2. One of the remaining two cores is dedicated for the master node, and the other one is left empty to avoid system freezes.
 
 To run Locust in non-distributed mode, you can pass in the `workers` argument in your launch command:
+
 ```
 python3 launch.py --workers=0
 ```
 
 ## Simulating users and viewing statistics
+
 The master instance runs Locust’s web interface, and tells the workers when to spawn/stop Users. The workers run your Users and send back statistics to the master. The master instance doesn’t run any Users itself.
 
-To view the statistics retrieved by the master instance, you can visit `http://localhost:8089`. The web interface will require you to enter the host domain for load testing, the number users you want to simulate, and the hatch rate of users. 
+To view the statistics retrieved by the master instance, you can visit `http://localhost:8089`. The web interface will require you to enter the host domain for load testing, the number users you want to simulate, and the hatch rate of users.

--- a/flask/Dockerfile
+++ b/flask/Dockerfile
@@ -1,6 +1,6 @@
 # Development image only. Runs a Flask development server.
 FROM minio/mc:RELEASE.2021-12-10T00-14-28Z AS mc
-FROM python:3.8-slim
+FROM python:3.9-slim
 LABEL org.opencontainers.image.title Stager development
 LABEL org.opencontainers.image.authors https://ccm.sickkids.ca/
 LABEL org.opencontainers.image.source https://github.com/ccmbioinfo/stager


### PR DESCRIPTION
Here are some main new features and security improvements in Python 3.9: [Link](https://towardsdatascience.com/10-awesome-python-3-9-features-b8c27f5eba5c).  

Python 3.9 is in the Ubuntu Focal distro's repos:[ link](https://packages.ubuntu.com/focal/python3.9). However, Python 3.8 is still the default system choice for Ubuntu. 