### PR TITLE
Traefik: switch internal API, metrics to HTTPS/8443, enable HSTS

### DIFF
--- a/docker-compose.ccm.yaml
+++ b/docker-compose.ccm.yaml
@@ -107,7 +107,7 @@ services:
       - --providers.docker
       - --providers.docker.exposedbydefault=false
       - --providers.file.directory=/etc/traefik
-      # - --providers.file.watch=false
+      - --providers.file.watch=false
       - --accesslog
       - --log
       - --metrics.prometheus

--- a/docker-compose.ccm.yaml
+++ b/docker-compose.ccm.yaml
@@ -106,4 +106,4 @@ services:
       - --entrypoints.https.http.tls
       - --entrypoints.traefik.address=:8443
       - --entrypoints.traefik.http.tls
-    #<<: *common
+    <<: *common

--- a/docker-compose.ccm.yaml
+++ b/docker-compose.ccm.yaml
@@ -6,7 +6,7 @@ x-common: &common
     driver: journald
 
 x-app: &app
-  image: "ghcr.io/ccmbioinfo/stager:${ST_VERSION}"
+  image: "ghcr.io/ccmbioinfo/stager"
   user: www-data
   command: --preload --workers ${GUNICORN_WORKERS:-1}
   healthcheck:
@@ -23,27 +23,30 @@ services:
     <<: *app
     environment:
       <<: *env
-      ST_SECRET_KEY: "${HIRAKI_ST_SECRET_KEY}"
-      ST_DATABASE_URI: "mysql+pymysql://${HIRAKI_MYSQL_CONNECTION_STRING}"
-      MINIO_ENDPOINT: "${HIRAKI_MINIO_ENDPOINT}"
-      MINIO_ACCESS_KEY: "${HIRAKI_MINIO_ACCESS_KEY}"
-      MINIO_SECRET_KEY: "${HIRAKI_MINIO_SECRET_KEY}"
+      ST_SECRET_KEY:
+      ST_DATABASE_URI: "mysql+pymysql://${MYSQL_USER}:${MYSQL_PASSWORD}@mysql/${MYSQL_DATABASE}"
+      MINIO_ENDPOINT: minio:9000
+      MINIO_ACCESS_KEY:
+      MINIO_SECRET_KEY:
     labels:
-      - traefik.enable=true
-      - traefik.http.routers.app-hiraki.rule=Host(`stager-hiraki.ccm.sickkids.ca`) # && PathPrefix(`/api`)
-      - traefik.http.routers.app-hiraki.entrypoints=https
-      - traefik.http.routers.app-hiraki.middlewares=app,security@file
-      - traefik.http.routers.app-hiraki.service=app-hiraki
-      - traefik.http.services.app-hiraki.loadbalancer.server.port=5000
-      - traefik.http.routers.metrics-hiraki.rule=Host(`stager-hiraki.ccm.sickkids.ca`) # && PathPrefix(`/metrics`)
-      - traefik.http.routers.metrics-hiraki.entrypoints=traefik
-      - traefik.http.routers.metrics-hiraki.middlewares=security@file
-      - traefik.http.routers.metrics-hiraki.service=metrics-hiraki
-      - traefik.http.services.metrics-hiraki.loadbalancer.server.port=8080
-      - traefik.http.middlewares.app.headers.accessControlAllowOriginList=https://stager.ccm.sickkids.ca
-      - traefik.http.middlewares.app.headers.accessControlAllowMethods=GET,HEAD,POST,PUT,DELETE,OPTIONS,PATCH
-      - traefik.http.middlewares.app.headers.accessControlAllowHeaders=Accept,Content-Type
-      - traefik.http.middlewares.app.headers.accessControlAllowCredentials=true
+      traefik.enable: true
+      # Routing for the main application server
+      traefik.http.routers.app-hiraki.rule: Host(`stager-hiraki.ccm.sickkids.ca`) # && PathPrefix(`/api`)
+      traefik.http.routers.app-hiraki.entrypoints: https
+      traefik.http.routers.app-hiraki.middlewares: app,security@file
+      traefik.http.routers.app-hiraki.service: app-hiraki
+      traefik.http.services.app-hiraki.loadbalancer.server.port: 5000
+      # Routing for the Prometheus metrics endpoint
+      traefik.http.routers.metrics-hiraki.rule: Host(`stager-hiraki.ccm.sickkids.ca`) # && PathPrefix(`/metrics`)
+      traefik.http.routers.metrics-hiraki.entrypoints: traefik
+      traefik.http.routers.metrics-hiraki.middlewares: security@file
+      traefik.http.routers.metrics-hiraki.service: metrics-hiraki
+      traefik.http.services.metrics-hiraki.loadbalancer.server.port: 8080
+      # Shared CORS middleware between services
+      traefik.http.middlewares.app.headers.accessControlAllowOriginList: https://stager.ccm.sickkids.ca
+      traefik.http.middlewares.app.headers.accessControlAllowMethods: GET,HEAD,POST,PUT,DELETE,OPTIONS,PATCH
+      traefik.http.middlewares.app.headers.accessControlAllowHeaders: Accept,Content-Type
+      traefik.http.middlewares.app.headers.accessControlAllowCredentials: true
   app-muise:
     <<: *app
     environment:
@@ -54,15 +57,19 @@ services:
       MINIO_ACCESS_KEY: "${MUISE_MINIO_ACCESS_KEY}"
       MINIO_SECRET_KEY: "${MUISE_MINIO_SECRET_KEY}"
     labels:
-      - traefik.enable=true
-      - traefik.http.routers.app-muise.rule=Host(`stager-muise.ccm.sickkids.ca`) # && PathPrefix(`/api`)
-      - traefik.http.routers.app-muise.entrypoints=https
-      - traefik.http.routers.app-muise.middlewares=app,security@file
-      - traefik.http.services.app-muise.loadbalancer.server.port=5000
-      - traefik.http.routers.metrics-muise.rule=Host(`stager-muise.ccm.sickkids.ca`)
-      - traefik.http.routers.metrics-muise.entrypoints=traefik
-      - traefik.http.routers.metrics-muise.middlewares=security@file
-      - traefik.http.services.metrics-muise.loadbalancer.server.port=8080
+      traefik.enable: true
+      # Routing for the main application server
+      traefik.http.routers.app-muise.rule: Host(`stager-muise.ccm.sickkids.ca`) # && PathPrefix(`/api`)
+      traefik.http.routers.app-muise.entrypoints: https
+      traefik.http.routers.app-muise.middlewares: app,security@file
+      traefik.http.routers.app-muise.service: app-muise
+      traefik.http.services.app-muise.loadbalancer.server.port: 5000
+      # Routing for the Prometheus metrics endpoint
+      traefik.http.routers.metrics-muise.rule: Host(`stager-muise.ccm.sickkids.ca`) # && PathPrefix(`/metrics`)
+      traefik.http.routers.metrics-muise.entrypoints: traefik
+      traefik.http.routers.metrics-muise.middlewares: security@file
+      traefik.http.routers.metrics-muise.service: metrics-muise
+      traefik.http.services.metrics-muise.loadbalancer.server.port: 8080
   # app-hawkins:
   #   <<: *app
   #   environment:
@@ -73,15 +80,19 @@ services:
   #     MINIO_ACCESS_KEY: "${HAWKINS_MINIO_ACCESS_KEY}"
   #     MINIO_SECRET_KEY: "${HAWKINS_MINIO_SECRET_KEY}"
   #   labels:
-  #     - traefik.enable=true
-  #     - traefik.http.routers.app-hawkins.rule=Host(`stager-hawkins.ccm.sickkids.ca`) # && PathPrefix(`/api`)
-  #     - traefik.http.routers.app-hawkins.entrypoints=https
-  #     - traefik.http.routers.app-hawkins.middlewares=app,security
-  #     - traefik.http.routers.app-hawkins.middlewares=app,security
-  #     - traefik.http.routers.metrics-hawkins.rule=Host(`stager-hawkins.ccm.sickkids.ca`)
-  #     - traefik.http.routers.metrics-hawkins.entrypoints=traefik
-  #     - traefik.http.routers.metrics-hawkins.middlewares=security
-  #     - traefik.http.services.metrics-hawkins.loadbalancer.server.port=8080
+  #     traefik.enable: true
+  #     # Routing for the main application server
+  #     traefik.http.routers.app-hawkins.rule: Host(`stager-hawkins.ccm.sickkids.ca`) # && PathPrefix(`/api`)
+  #     traefik.http.routers.app-hawkins.entrypoints: https
+  #     traefik.http.routers.app-hawkins.middlewares: app,security@file
+  #     traefik.http.routers.app-hawkins.service: app-hawkins
+  #     traefik.http.services.app-hawkins.loadbalancer.server.port: 5000
+  #     # Routing for the Prometheus metrics endpoint
+  #     traefik.http.routers.metrics-hawkins.rule: Host(`stager-hawkins.ccm.sickkids.ca`) # && PathPrefix(`/metrics`)
+  #     traefik.http.routers.metrics-hawkins.entrypoints: traefik
+  #     traefik.http.routers.metrics-hawkins.middlewares: security@file
+  #     traefik.http.routers.metrics-hawkins.service: metrics-hawkins
+  #     traefik.http.services.metrics-hawkins.loadbalancer.server.port: 8080
   proxy:
     image: traefik:2.6
     volumes:
@@ -96,7 +107,7 @@ services:
       - --providers.docker
       - --providers.docker.exposedbydefault=false
       - --providers.file.directory=/etc/traefik
-      - --providers.file.watch=false
+      # - --providers.file.watch=false
       - --accesslog
       - --log
       - --metrics.prometheus

--- a/docker-compose.ccm.yaml
+++ b/docker-compose.ccm.yaml
@@ -6,7 +6,7 @@ x-common: &common
     driver: journald
 
 x-app: &app
-  image: "ghcr.io/ccmbioinfo/stager"
+  image: "ghcr.io/ccmbioinfo/stager:${ST_VERSION}"
   user: www-data
   command: --preload --workers ${GUNICORN_WORKERS:-1}
   healthcheck:
@@ -23,11 +23,11 @@ services:
     <<: *app
     environment:
       <<: *env
-      ST_SECRET_KEY:
-      ST_DATABASE_URI: "mysql+pymysql://${MYSQL_USER}:${MYSQL_PASSWORD}@mysql/${MYSQL_DATABASE}"
-      MINIO_ENDPOINT: minio:9000
-      MINIO_ACCESS_KEY:
-      MINIO_SECRET_KEY:
+      ST_SECRET_KEY: "${HIRAKI_ST_SECRET_KEY}"
+      ST_DATABASE_URI: "mysql+pymysql://${HIRAKI_MYSQL_CONNECTION_STRING}"
+      MINIO_ENDPOINT: "${HIRAKI_MINIO_ENDPOINT}"
+      MINIO_ACCESS_KEY: "${HIRAKI_MINIO_ACCESS_KEY}"
+      MINIO_SECRET_KEY: "${HIRAKI_MINIO_SECRET_KEY}"
     labels:
       traefik.enable: true
       # Routing for the main application server

--- a/docker-compose.ccm.yaml
+++ b/docker-compose.ccm.yaml
@@ -32,11 +32,13 @@ services:
       - traefik.enable=true
       - traefik.http.routers.app-hiraki.rule=Host(`stager-hiraki.ccm.sickkids.ca`) # && PathPrefix(`/api`)
       - traefik.http.routers.app-hiraki.entrypoints=https
-      - traefik.http.routers.app-hiraki.middlewares=app,security
+      - traefik.http.routers.app-hiraki.middlewares=app,security@file
+      - traefik.http.routers.app-hiraki.service=app-hiraki
       - traefik.http.services.app-hiraki.loadbalancer.server.port=5000
-      - traefik.http.routers.metrics-hiraki.rule=Host(`stager-hiraki.ccm.sickkids.ca`)
+      - traefik.http.routers.metrics-hiraki.rule=Host(`stager-hiraki.ccm.sickkids.ca`) # && PathPrefix(`/metrics`)
       - traefik.http.routers.metrics-hiraki.entrypoints=traefik
-      - traefik.http.routers.metrics-hiraki.middlewares=security
+      - traefik.http.routers.metrics-hiraki.middlewares=security@file
+      - traefik.http.routers.metrics-hiraki.service=metrics-hiraki
       - traefik.http.services.metrics-hiraki.loadbalancer.server.port=8080
       - traefik.http.middlewares.app.headers.accessControlAllowOriginList=https://stager.ccm.sickkids.ca
       - traefik.http.middlewares.app.headers.accessControlAllowMethods=GET,HEAD,POST,PUT,DELETE,OPTIONS,PATCH
@@ -55,11 +57,11 @@ services:
       - traefik.enable=true
       - traefik.http.routers.app-muise.rule=Host(`stager-muise.ccm.sickkids.ca`) # && PathPrefix(`/api`)
       - traefik.http.routers.app-muise.entrypoints=https
-      - traefik.http.routers.app-muise.middlewares=app,security
+      - traefik.http.routers.app-muise.middlewares=app,security@file
       - traefik.http.services.app-muise.loadbalancer.server.port=5000
       - traefik.http.routers.metrics-muise.rule=Host(`stager-muise.ccm.sickkids.ca`)
       - traefik.http.routers.metrics-muise.entrypoints=traefik
-      - traefik.http.routers.metrics-muise.middlewares=security
+      - traefik.http.routers.metrics-muise.middlewares=security@file
       - traefik.http.services.metrics-muise.loadbalancer.server.port=8080
   # app-hawkins:
   #   <<: *app
@@ -81,7 +83,7 @@ services:
   #     - traefik.http.routers.metrics-hawkins.middlewares=security
   #     - traefik.http.services.metrics-hawkins.loadbalancer.server.port=8080
   proxy:
-    image: traefik:2.5
+    image: traefik:2.6
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - "${PROJECT_ROOT:-.}/traefik:/etc/traefik"
@@ -98,6 +100,7 @@ services:
       - --accesslog
       - --log
       - --metrics.prometheus
+      - --metrics.prometheus.manualrouting
       - --global.checknewversion=false
       - --global.sendanonymoususage=false
       - --entrypoints.http.address=:80

--- a/docker-compose.ccm.yaml
+++ b/docker-compose.ccm.yaml
@@ -32,13 +32,16 @@ services:
       - traefik.enable=true
       - traefik.http.routers.app-hiraki.rule=Host(`stager-hiraki.ccm.sickkids.ca`) # && PathPrefix(`/api`)
       - traefik.http.routers.app-hiraki.entrypoints=https
-      - traefik.http.routers.app-hiraki.middlewares=app
+      - traefik.http.routers.app-hiraki.middlewares=app,security
+      - traefik.http.services.app-hiraki.loadbalancer.server.port=5000
+      - traefik.http.routers.metrics-hiraki.rule=Host(`stager-hiraki.ccm.sickkids.ca`)
+      - traefik.http.routers.metrics-hiraki.entrypoints=traefik
+      - traefik.http.routers.metrics-hiraki.middlewares=security
+      - traefik.http.services.metrics-hiraki.loadbalancer.server.port=8080
       - traefik.http.middlewares.app.headers.accessControlAllowOriginList=https://stager.ccm.sickkids.ca
       - traefik.http.middlewares.app.headers.accessControlAllowMethods=GET,HEAD,POST,PUT,DELETE,OPTIONS,PATCH
       - traefik.http.middlewares.app.headers.accessControlAllowHeaders=Accept,Content-Type
       - traefik.http.middlewares.app.headers.accessControlAllowCredentials=true
-      - traefik.http.middlewares.app.headers.frameDeny=true
-      - traefik.http.middlewares.app.headers.browserXssFilter=true
   app-muise:
     <<: *app
     environment:
@@ -52,7 +55,12 @@ services:
       - traefik.enable=true
       - traefik.http.routers.app-muise.rule=Host(`stager-muise.ccm.sickkids.ca`) # && PathPrefix(`/api`)
       - traefik.http.routers.app-muise.entrypoints=https
-      - traefik.http.routers.app-muise.middlewares=app
+      - traefik.http.routers.app-muise.middlewares=app,security
+      - traefik.http.services.app-muise.loadbalancer.server.port=5000
+      - traefik.http.routers.metrics-muise.rule=Host(`stager-muise.ccm.sickkids.ca`)
+      - traefik.http.routers.metrics-muise.entrypoints=traefik
+      - traefik.http.routers.metrics-muise.middlewares=security
+      - traefik.http.services.metrics-muise.loadbalancer.server.port=8080
   # app-hawkins:
   #   <<: *app
   #   environment:
@@ -66,14 +74,23 @@ services:
   #     - traefik.enable=true
   #     - traefik.http.routers.app-hawkins.rule=Host(`stager-hawkins.ccm.sickkids.ca`) # && PathPrefix(`/api`)
   #     - traefik.http.routers.app-hawkins.entrypoints=https
-  #     - traefik.http.routers.app-hawkins.middlewares=app
+  #     - traefik.http.routers.app-hawkins.middlewares=app,security
+  #     - traefik.http.routers.app-hawkins.middlewares=app,security
+  #     - traefik.http.routers.metrics-hawkins.rule=Host(`stager-hawkins.ccm.sickkids.ca`)
+  #     - traefik.http.routers.metrics-hawkins.entrypoints=traefik
+  #     - traefik.http.routers.metrics-hawkins.middlewares=security
+  #     - traefik.http.services.metrics-hawkins.loadbalancer.server.port=8080
   proxy:
     image: traefik:2.5
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - "${PROJECT_ROOT:-.}/traefik:/etc/traefik"
+    ports:
+      - "80:80"
+      - "443:443"
+      - "8443:8443" # Traefik and Prometheus endpoint
     command:
-      - --api.insecure
+      - --api
       - --providers.docker
       - --providers.docker.exposedbydefault=false
       - --providers.file.directory=/etc/traefik
@@ -85,10 +102,8 @@ services:
       - --global.sendanonymoususage=false
       - --entrypoints.http.address=:80
       - --entrypoints.http.http.redirections.entrypoint.to=https
-      - --entrypoints.https.http.tls
       - --entrypoints.https.address=:443
-    ports:
-      - "80:80"
-      - "443:443"
-      - "8080:8080" # Traefik and Prometheus endpoint
-    <<: *common
+      - --entrypoints.https.http.tls
+      - --entrypoints.traefik.address=:8443
+      - --entrypoints.traefik.http.tls
+    #<<: *common

--- a/docs/production.md
+++ b/docs/production.md
@@ -1,13 +1,12 @@
 # Production
 
-Stager is deployed at https://sampletrackerdev.ccm.sickkids.ca via Compose.
+Stager is deployed via Compose at https://stager.genomics4rd.ca to serve Care4Rare as part of Genomics4RD.
+A separate multitenant deployment serves other collaborators at SickKids at https://stager.ccm.sickkids.ca.
 
-## [nginx](https://hub.docker.com/_/nginx)
-
-An nginx container is used to serve the static frontend files and as a reverse proxy to the
-application server and MinIO. It is also solely responsible for HTTPS/TLS. Before starting up,
-create an `nginx/certs` directory and copy the public certificate chain `bundle.crt` and the private
-key `star_ccm_sickkids_ca.key` here.
+The key differences between the development stack and production are that Gunicorn is used as the backend
+server rather than the Flask development server and the frontend is served as built static bundles by a
+reverse proxy, rather than by the Create React App/Webpack development server. Transport Layer Security
+(HTTPS) is also enabled at the reverse proxy.
 
 ## [WSGI and Gunicorn](https://gunicorn.org/#docs)
 
@@ -19,32 +18,49 @@ source code is no longer mounted but baked into the image.
 
 There is no specific reason Gunicorn is being used over other WSGI implementations.
 
-## Building the frontend
+## Static frontend
 
-The frontend is currently served out of the same directory webpack uses to build, which means that
-rebuilding will result in some downtime. To build the static bundles:
+You can build the static bundles for production by running `yarn build` in the `react/` directory.
+The server must be aware of the frontend single-page application routing, i.e. `/` and most paths
+without an extension should be served by `index.html`, and that `/api` should route to the backend
+server, since this isn't handled by the React development server anymore. This is handled by the
+reverse proxy for each deployment.
 
-```bash
-cd react
-yarn
-yarn build
-```
+## Continuous deployment through GitHub Actions
 
-## Running
+On each commit to master, a [GitHub Actions workflow](/.github/workflows/flask.yml) is run if anything
+affecting the backend was changed. After the Docker image build and test stages pass, we move to the
+deployment stage. This unlocks an environment that contains secrets specific to each deployment and
+causes Actions to label this as a deployment. This stage runs on a self-hosted Actions runner that is
+networked with the production host, and environment-specific secrets are used to access it to deploy.
+Because of this, Actions workflows are disabled for forks for security.
 
-We use an alternate Compose configuration to add nginx, run Gunicorn, and stop forwarding container
-ports to the host unless explicitly required outside of development. The specific secret credentials
-for this deployment must be in `.env` as in development.
+At the same time, a different workflow [builds the frontend](/.github/workflows/react.yml),
+incorporating environment-specific configurations as needed, and uploads the compiled static bundles
+to a designated S3 (MinIO) bucket.
 
-```bash
-docker-compose -f docker-compose.prod.yaml up -d
-```
+## [CHEO-RI deployment](https://stager.genomics4rd.ca)
 
-Assess the status of the containers:
+This deployment serves [Care4Rare](http://care4rare.ca/) as part of [Genomics4RD](https://www.genomics4rd.ca/).
+It runs on [HPC4Health](http://hpc4health.ca/) infrastructure in a dedicated tenancy referred to as
+the CHEO-RI tenancy, or CHEO_G4RD.
 
-```bash
-docker-compose -f docker-compose.prod.yaml ps
-```
+Stager is deployed as a Docker container running Gunicorn per [docker-compose.cheo.yaml](/docker-compose.cheo.yaml).
+Other needed services like MySQL and MinIO are separately already running in the tenancy. A reverse proxy for the entire
+tenancy serves the uploaded frontend and routes `/api` on the same domain to the backend container.
 
-Currently, a typical redeployment scenario involves manually performing these steps with some
-downtime. Updated images may need to be pulled and the stale database bind mount reset.
+More information on the deployments in this tenancy are at https://github.com/ccmbioinfo/cheo-ri-infrastructure.
+
+## [CCM multitenant deployment](https://stager.ccm.sickkids.ca)
+
+This deployment serves our other collaborators at SickKids. This is a multitenant deployment to keep
+each lab's data separated. This is achieved by running one backend container per lab, each configured
+to use a different database and MinIO server. The frontend is shared because the code for that stays
+largely the same, but it is configured to be aware of multiple backend domains and route the API calls
+appropriately. At the login page, the user selects their lab first, which configures the backend domain
+for the app. A Traefik reverse proxy handles all the domains and is responsible for serving the uploaded
+frontend and routing to each backend, including enabling Cross-Origin Resource Sharing.
+
+The Compose configuration is at [docker-compose.ccm.yaml](/docker-compose.ccm.yaml). For the time being,
+we must clone the repository to the production host in order to have the Traefik configuration and
+TLS certificates mounted in `traefik/certs`.

--- a/docs/production.md
+++ b/docs/production.md
@@ -76,5 +76,5 @@ The Compose configuration is at [docker-compose.ccm.yaml](/docker-compose.ccm.ya
 we must clone the repository to the production host in order to have the Traefik dynamic configuration and
 TLS certificates mounted in `traefik/certs`.
 
-Traefik is also serves a separate dashboard and its own metrics on a custom port. It is configured
+Traefik also serves a separate dashboard and its own metrics on a custom port. It is configured
 to use this same port to reverse proxy the Prometheus metrics for the backend domains.

--- a/traefik/frontend.yml
+++ b/traefik/frontend.yml
@@ -1,8 +1,7 @@
 http:
   routers:
     frontend:
-      entryPoints:
-        - https
+      entrypoints: https
       middlewares:
         - security
         - singlePageApplication

--- a/traefik/frontend.yml
+++ b/traefik/frontend.yml
@@ -26,5 +26,8 @@ http:
         replacement: /index.html
     security:
       headers:
+        stsSeconds: 31536000
+        stsIncludeSubdomains: true
+        contentSecurityPolicy: block-all-mixed-content
         frameDeny: true
         browserXssFilter: true

--- a/traefik/https.yml
+++ b/traefik/https.yml
@@ -15,14 +15,13 @@ tls:
         keyFile: /etc/traefik/certs/star_ccm_sickkids_ca.key
 http:
   routers:
-    redirect:
-      entryPoints:
-        - https
-      middlewares:
-        - redirect
+    # Redirect HTTPS requests on port 80 to the correct port
+    redirect-invalid-http:
+      entrypoints: http
+      middlewares: redirect
       rule: HostRegexp(`{host:.+}`)
       service: noop@internal
-      tls: false
+      tls: {}
   middlewares:
     redirect:
       redirectScheme:

--- a/traefik/traefik-api.yml
+++ b/traefik/traefik-api.yml
@@ -1,0 +1,10 @@
+http:
+  routers:
+    api:
+      entrypoints:
+        - traefik
+      middlewares:
+        - security
+      service: api@internal
+      rule: Host(`stager.ccm.sickkids.ca`)
+      tls: {}

--- a/traefik/traefik-api.yml
+++ b/traefik/traefik-api.yml
@@ -1,20 +1,16 @@
 http:
   routers:
     api:
-      entrypoints:
-        - traefik
-      middlewares:
-        - security
+      entrypoints: traefik
+      middlewares: security
       service: api@internal
       rule: PathPrefix(`/`)
       tls: {}
     # This is essentially identical to the automatic router, but the default one
     # has higher priority than the other routers we want to bind for some reason
     prometheus:
-      entrypoints:
-        - traefik
-      middlewares:
-        - security
+      entrypoints: traefik
+      middlewares: security
       service: prometheus@internal
       rule: PathPrefix(`/metrics`)
       tls: {}

--- a/traefik/traefik-api.yml
+++ b/traefik/traefik-api.yml
@@ -6,5 +6,15 @@ http:
       middlewares:
         - security
       service: api@internal
-      rule: Host(`stager.ccm.sickkids.ca`)
+      rule: PathPrefix(`/`)
+      tls: {}
+    # This is essentially identical to the automatic router, but the default one
+    # has higher priority than the other routers we want to bind for some reason
+    prometheus:
+      entrypoints:
+        - traefik
+      middlewares:
+        - security
+      service: prometheus@internal
+      rule: PathPrefix(`/metrics`)
       tls: {}


### PR DESCRIPTION
Reverse proxying to MinIO forwarded HSTS headers, so we'll implement HTTPS and HSTS for every service as it affects the entire primary domain already.

Refactor all HTTP security-related headers into the `security` middleware to reuse across all routers.

Configure the Traefik entrypoint to use port 8443 instead of 8080 and enable TLS. This will serve the main Traefik API and dashboard on the main domain, and proxy to the Prometheus endpoint of each backend on the corresponding backend domains. To implement this, an additional router is configured per service for the 8080 Gunicorn metrics port, since Traefik only automatically configures one service (port) per container.