### PR TITLE
CI: add backend rollback workflow

### DIFF
--- a/.github/workflows/flask-rollback.yml
+++ b/.github/workflows/flask-rollback.yml
@@ -1,0 +1,102 @@
+name: Rollback backend
+on:
+  workflow_dispatch:
+    inputs:
+      revision: GitHub commit SHA
+      required: true
+jobs:
+  # Largely identical to deploy step in flask.yml except prerequisites
+  deploy:
+    strategy:
+      matrix:
+        include:
+          - runner: cheo-ri
+            environment: CHEO-RI_backend
+          - runner: ccm
+            environment: CCM_backend
+    runs-on: [self-hosted, "${{ matrix.runner }}"]
+    environment: ${{ matrix.environment }}
+    concurrency: ${{ matrix.environment }}
+    steps:
+      - uses: actions/checkout@v2
+        # Modified from regular deploy step
+        with:
+          ref: ${{ github.event.inputs.revision }}
+        # end
+      - uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Configure SSH
+        id: configure
+        # The self-hosted runner is not ephemeral, so we load the secret key into
+        # an agent instead in memory. Keep track of it for further workflow steps
+        # and so we can clean it up and not leave orphaned processes hanging around.
+        #
+        # https://docs.docker.com/engine/context/working-with-contexts/
+        # This avoids passing an -H parameter to every Docker CLI call.
+        run: |
+          SSH_AGENT_EVAL=$(ssh-agent -s)
+          eval "$SSH_AGENT_EVAL"
+          ssh-add - <<< "${{ secrets.DEPLOY_PRIVATE_KEY }}"
+          echo "::set-output name=ssh-agent-eval::$SSH_AGENT_EVAL"
+          echo "::set-output name=ssh-agent-pid::$SSH_AGENT_PID"
+          mkdir -p ~/.ssh
+          echo "${{ secrets.DEPLOY_HOST_KEY }}" > ~/.ssh/known_hosts
+          chmod -R g-rwx,o-rwx ~/.ssh
+          docker context create deploy-target --docker host=ssh://${{ secrets.DEPLOY_SSH_HOST }}
+          docker context use deploy-target
+      # The secret mapping to environment variables is different, but the script is the same
+      - name: Deploy (CHEO-RI)
+        if: matrix.runner == 'cheo-ri'
+        # Even though this is deploying to a remote Docker Engine,
+        # Compose uses the registry credentials of the client
+        env:
+          COMPOSE_FILE: docker-compose.cheo.yaml
+          ST_VERSION: sha-${{ github.event.inputs.revision }} # Modified from regular deploy step
+          ST_SECRET_KEY: ${{ secrets.ST_SECRET_KEY }}
+          MYSQL_CONNECTION_STRING: ${{ secrets.MYSQL_CONNECTION_STRING }}
+          MINIO_ENDPOINT: ${{ secrets.MINIO_ENDPOINT }}
+          MINIO_ACCESS_KEY: ${{ secrets.MINIO_ACCESS_KEY }}
+          MINIO_SECRET_KEY: ${{ secrets.MINIO_SECRET_KEY }}
+          MSTEAMS_WEBHOOK_URL: ${{ secrets.MSTEAMS_WEBHOOK }}
+          SENDGRID_API_KEY: ${{ secrets.SENDGRID_API_KEY }}
+          SENDGRID_EMAIL_TEMPLATE_ID: ${{ secrets.SENDGRID_EMAIL_TEMPLATE_ID }}
+          SENDGRID_TO_EMAIL: ${{ secrets.SENDGRID_TO_EMAIL }}
+          SENDGRID_FROM_EMAIL: ${{ secrets.SENDGRID_FROM_EMAIL }}
+        run: |
+          eval "${{ steps.configure.outputs.ssh-agent-eval }}"
+          export GUNICORN_WORKERS=$( ssh ${{ secrets.DEPLOY_SSH_HOST }} 'echo $(( $(nproc) * 2 + 1 ))' )
+          docker-compose pull
+          docker-compose up -d --remove-orphans
+      - name: Deploy (CCM)
+        if: matrix.runner == 'ccm'
+        # Even though this is deploying to a remote Docker Engine,
+        # Compose uses the registry credentials of the client
+        env:
+          COMPOSE_FILE: docker-compose.ccm.yaml
+          ST_VERSION: sha-${{ github.event.inputs.revision }} # Modified from regular deploy step
+          MSTEAMS_WEBHOOK_URL: ${{ secrets.MSTEAMS_WEBHOOK }}
+          PROJECT_ROOT: /opt/stager
+          HIRAKI_ST_SECRET_KEY: ${{ secrets.HIRAKI_ST_SECRET_KEY }}
+          HIRAKI_MYSQL_CONNECTION_STRING: ${{ secrets.HIRAKI_MYSQL_CONNECTION_STRING }}
+          HIRAKI_MINIO_ENDPOINT: ${{ secrets.HIRAKI_MINIO_ENDPOINT }}
+          HIRAKI_MINIO_ACCESS_KEY: ${{ secrets.HIRAKI_MINIO_ACCESS_KEY }}
+          HIRAKI_MINIO_SECRET_KEY: ${{ secrets.HIRAKI_MINIO_SECRET_KEY }}
+          MUISE_ST_SECRET_KEY: ${{ secrets.MUISE_ST_SECRET_KEY }}
+          MUISE_MYSQL_CONNECTION_STRING: ${{ secrets.MUISE_MYSQL_CONNECTION_STRING }}
+          MUISE_MINIO_ENDPOINT: ${{ secrets.MUISE_MINIO_ENDPOINT }}
+          MUISE_MINIO_ACCESS_KEY: ${{ secrets.MUISE_MINIO_ACCESS_KEY }}
+          MUISE_MINIO_SECRET_KEY: ${{ secrets.MUISE_MINIO_SECRET_KEY }}
+        run: |
+          eval "${{ steps.configure.outputs.ssh-agent-eval }}"
+          export GUNICORN_WORKERS=$( ssh ${{ secrets.DEPLOY_SSH_HOST }} 'echo $(( $(nproc) + 1 ))' )
+          docker-compose pull
+          docker-compose up -d --remove-orphans
+      - name: Clean up
+        if: always()
+        run: |
+          docker context rm -f deploy-target
+          eval "${{ steps.configure.outputs.ssh-agent-eval }}"
+          SSH_AGENT_PID="${{ steps.configure.outputs.ssh-agent-pid }}" ssh-agent -k

--- a/.github/workflows/flask-rollback.yml
+++ b/.github/workflows/flask-rollback.yml
@@ -2,8 +2,9 @@ name: Rollback backend
 on:
   workflow_dispatch:
     inputs:
-      revision: GitHub commit SHA
-      required: true
+      revision:
+        description: GitHub commit SHA
+        required: true
 jobs:
   # Largely identical to deploy step in flask.yml except prerequisites
   deploy:

--- a/.github/workflows/flask-rollback.yml
+++ b/.github/workflows/flask-rollback.yml
@@ -1,4 +1,4 @@
-name: Rollback backend
+name: Roll back backend
 on:
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
This adds a manually-triggered workflow in the Actions tab that will allow us to roll back the backend quickly without having to rebuild and retest a prior commit.