### PR TITLE
React: Automatically display candidate genes 

### DIFF
--- a/react/src/AddDatasets/index.tsx
+++ b/react/src/AddDatasets/index.tsx
@@ -344,7 +344,9 @@ export default function AddDatasets() {
             currCols,
             RNA_ONLY_FIELDS.map(field => ({
                 field,
-                hidden: OPTIONAL_RNA_FIELDS.includes(field) && field !== "vcf_available",
+                hidden:
+                    OPTIONAL_RNA_FIELDS.includes(field) &&
+                    !["vcf_available", "candidate_genes"].includes(field),
                 required: REQUIRED_RNA_FIELDS.includes(field),
                 title: snakeCaseToTitle(field),
             }))


### PR DESCRIPTION
When uploading an RNAseq dataset to Stager (i.e. datasets type 'RRS'), an additional field 'Vcf available appears'. 

However, to see the 'Candidate genes' field you have to click on the show/hide fields icon and select that field. 

This PR makes it it possible to have this field shown automatically when the RRS dataset type is selected, just like the 'Vcf available' field.