### PR TITLE
Docker: fix sidecar volume permissions

### DIFF
--- a/docker-compose.ccm.yaml
+++ b/docker-compose.ccm.yaml
@@ -22,6 +22,7 @@ x-env: &env
 x-sidecar: &sidecar
   image: busybox
   init: true
+  user: www-data
   command: tail -f -n +1 /var/log/stager/sqlalchemy.fifo
   <<: *common
 

--- a/docker-compose.cheo.yaml
+++ b/docker-compose.cheo.yaml
@@ -31,6 +31,7 @@ services:
   sidecar-sqlalchemy:
     image: busybox
     init: true
+    user: www-data
     command: tail -f -n +1 /var/log/stager/sqlalchemy.fifo
     volumes:
       - log-fifo:/var/log/stager:ro

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -78,13 +78,14 @@ services:
       args:
         GIT_SHA:
     image: ghcr.io/ccmbioinfo/stager:latest
+    user: www-data
     profiles:
       - gunicorn
     environment:
       <<: *env
-      SQLALCHEMY_SIDECAR: /var/log/stager/sqlalchemy.fifo
+      SQLALCHEMY_SIDECAR: /var/tmp/sqlalchemy.fifo
     volumes:
-      - log-fifo:/var/log/stager
+      - log-fifo:/var/tmp
     ports:
       - "${FLASK_HOST_PORT:-127.0.0.1:5000}:5000"
       - "${METRICS_HOST_PORT:-127.0.0.1:8080}:8080"
@@ -94,6 +95,7 @@ services:
   # See __init__.py::config_logger for an explainer
   sidecar-sqlalchemy:
     image: busybox
+    user: www-data
     profiles:
       - gunicorn
     init: true


### PR DESCRIPTION
Volumes behave like the `mount` command, with the local filesystem permissions at the mount path by default. If the path does not already exist, then it gets created inside the container owned by root:root. Switch to /var/tmp, which is writable by www-data. Alternatively, we could mkdir and chown an appropriate path in the Dockerfile. Also switch busybox to the same UID rather than root.