### PR TITLE
Flask: use a tmpfs for Prometheus metrics

### DIFF
--- a/docker-compose.ccm.yaml
+++ b/docker-compose.ccm.yaml
@@ -9,6 +9,8 @@ x-app: &app
   image: "ghcr.io/ccmbioinfo/stager:${ST_VERSION}"
   user: www-data
   command: --preload --workers ${GUNICORN_WORKERS:-1}
+  tmpfs:
+    - /tmp
   healthcheck:
     test: ["CMD", "./healthcheck.py"]
   <<: *common

--- a/docker-compose.cheo.yaml
+++ b/docker-compose.cheo.yaml
@@ -21,6 +21,8 @@ services:
       - "5000:5000"
       - "9121:8080"
     command: --preload --workers ${GUNICORN_WORKERS:-1}
+    tmpfs:
+      - /tmp
     volumes:
       - log-fifo:/var/tmp
     healthcheck:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -84,6 +84,8 @@ services:
     environment:
       <<: *env
       SQLALCHEMY_SIDECAR: /var/tmp/sqlalchemy.fifo
+    tmpfs:
+      - /tmp
     volumes:
       - log-fifo:/var/tmp
     ports:


### PR DESCRIPTION
Don't use the container overlayfs for ephemeral storage