### PR TITLE
React: Display human-readable names for dataset types

### DIFF
--- a/react/src/AddDatasets/components/TableCells.tsx
+++ b/react/src/AddDatasets/components/TableCells.tsx
@@ -15,6 +15,7 @@ import { Autocomplete, createFilterOptions } from "@material-ui/lab";
 import { Resizable } from "re-resizable";
 import { AutocompleteMultiselect } from "../../components";
 import FileLinkingComponent from "../../components/FileLinkingComponent";
+import { useAPIInfoContext } from "../../contexts";
 import { strIsEmpty } from "../../functions";
 import { useGenesQuery } from "../../hooks/genes";
 import {
@@ -144,6 +145,7 @@ export function AutocompleteCell(
     // We control the inputValue so that we can query with it
     // with this pattern, we have to be careful that search state and selection state stay in sync
     const [search, setSearch] = useState(props.value.inputValue);
+    const apiInfo = useAPIInfoContext() ?? undefined;
 
     //selected value might change via autopopulate
     useEffect(() => {
@@ -242,7 +244,15 @@ export function AutocompleteCell(
                 getOptionDisabled={option => !!option.disabled}
                 getOptionLabel={option => option.title}
                 getOptionSelected={(option, value) => option.inputValue === value.inputValue}
-                renderOption={option => option.title}
+                renderOption={option => {
+                    return apiInfo && props.column.field === "dataset_type" ? (
+                        <Tooltip title={apiInfo.dataset_types[option.title].name}>
+                            <div>{option.title}</div>
+                        </Tooltip>
+                    ) : (
+                        option.title
+                    );
+                }}
             />
         </TableCell>
     );

--- a/react/src/AddDatasets/components/TableCells.tsx
+++ b/react/src/AddDatasets/components/TableCells.tsx
@@ -227,14 +227,25 @@ export function AutocompleteCell(
                 }}
                 options={props.options}
                 value={props.value}
-                renderInput={params => (
-                    <TextField
-                        {...params}
-                        variant="standard"
-                        error={isError}
-                        helperText={isError && "Field is required."}
-                    />
-                )}
+                renderInput={params => {
+                    return props.column.field === "dataset_type" && apiInfo && props.value.title ? (
+                        <Tooltip title={apiInfo.dataset_types[props.value.title].name}>
+                            <TextField
+                                {...params}
+                                variant="standard"
+                                error={isError}
+                                helperText={isError && "Field is required."}
+                            />
+                        </Tooltip>
+                    ) : (
+                        <TextField
+                            {...params}
+                            variant="standard"
+                            error={isError}
+                            helperText={isError && "Field is required."}
+                        />
+                    );
+                }}
                 groupBy={option => (option.origin ? option.origin : "Unknown")}
                 filterOptions={(options, params) =>
                     createFilterOptions<Option>({

--- a/react/src/AddDatasets/components/TableCells.tsx
+++ b/react/src/AddDatasets/components/TableCells.tsx
@@ -228,16 +228,18 @@ export function AutocompleteCell(
                 options={props.options}
                 value={props.value}
                 renderInput={params => {
-                    return props.column.field === "dataset_type" && apiInfo && props.value.title ? (
-                        <Tooltip title={apiInfo.dataset_types[props.value.title].name}>
-                            <TextField
-                                {...params}
-                                variant="standard"
-                                error={isError}
-                                helperText={isError && "Field is required."}
-                            />
-                        </Tooltip>
-                    ) : (
+                    if (props.column.field === "dataset_type" && apiInfo && props.value.title)
+                        return (
+                            <Tooltip title={apiInfo.dataset_types[props.value.title].name}>
+                                <TextField
+                                    {...params}
+                                    variant="standard"
+                                    error={isError}
+                                    helperText={isError && "Field is required."}
+                                />
+                            </Tooltip>
+                        );
+                    return (
                         <TextField
                             {...params}
                             variant="standard"
@@ -256,13 +258,13 @@ export function AutocompleteCell(
                 getOptionLabel={option => option.title}
                 getOptionSelected={(option, value) => option.inputValue === value.inputValue}
                 renderOption={option => {
-                    return apiInfo && props.column.field === "dataset_type" ? (
-                        <Tooltip title={apiInfo.dataset_types[option.title].name}>
-                            <div>{option.title}</div>
-                        </Tooltip>
-                    ) : (
-                        option.title
-                    );
+                    if (apiInfo && props.column.field === "dataset_type")
+                        return (
+                            <Tooltip title={apiInfo.dataset_types[option.title].name}>
+                                <div>{option.title}</div>
+                            </Tooltip>
+                        );
+                    return option.title;
                 }}
             />
         </TableCell>

--- a/react/src/AddDatasets/components/TableCells.tsx
+++ b/react/src/AddDatasets/components/TableCells.tsx
@@ -13,9 +13,8 @@ import {
 } from "@material-ui/core";
 import { Autocomplete, createFilterOptions } from "@material-ui/lab";
 import { Resizable } from "re-resizable";
-import { AutocompleteMultiselect } from "../../components";
+import { AutocompleteMultiselect, TooltipDatasetType } from "../../components";
 import FileLinkingComponent from "../../components/FileLinkingComponent";
-import { useAPIInfoContext } from "../../contexts";
 import { strIsEmpty } from "../../functions";
 import { useGenesQuery } from "../../hooks/genes";
 import {
@@ -145,7 +144,6 @@ export function AutocompleteCell(
     // We control the inputValue so that we can query with it
     // with this pattern, we have to be careful that search state and selection state stay in sync
     const [search, setSearch] = useState(props.value.inputValue);
-    const apiInfo = useAPIInfoContext() ?? undefined;
 
     //selected value might change via autopopulate
     useEffect(() => {
@@ -228,16 +226,16 @@ export function AutocompleteCell(
                 options={props.options}
                 value={props.value}
                 renderInput={params => {
-                    if (props.column.field === "dataset_type" && apiInfo && props.value.title)
+                    if (props.column.field === "dataset_type" && props.value.title)
                         return (
-                            <Tooltip title={apiInfo.dataset_types[props.value.title].name}>
+                            <TooltipDatasetType dataset_type={props.value.title}>
                                 <TextField
                                     {...params}
                                     variant="standard"
                                     error={isError}
                                     helperText={isError && "Field is required."}
                                 />
-                            </Tooltip>
+                            </TooltipDatasetType>
                         );
                     return (
                         <TextField
@@ -258,11 +256,11 @@ export function AutocompleteCell(
                 getOptionLabel={option => option.title}
                 getOptionSelected={(option, value) => option.inputValue === value.inputValue}
                 renderOption={option => {
-                    if (apiInfo && props.column.field === "dataset_type")
+                    if (props.column.field === "dataset_type")
                         return (
-                            <Tooltip title={apiInfo.dataset_types[option.title].name}>
+                            <TooltipDatasetType dataset_type={option.title}>
                                 <div>{option.title}</div>
-                            </Tooltip>
+                            </TooltipDatasetType>
                         );
                     return option.title;
                 }}

--- a/react/src/Datasets/components/DatasetTable.tsx
+++ b/react/src/Datasets/components/DatasetTable.tsx
@@ -1,6 +1,6 @@
 import { useMemo, useRef, useState } from "react";
 import { Column, EditComponentProps, MTableToolbar } from "@material-table/core";
-import { Chip, IconButton, makeStyles } from "@material-ui/core";
+import { Chip, IconButton, makeStyles, Tooltip } from "@material-ui/core";
 import { Cancel, Delete, PlayArrow, Refresh, Visibility } from "@material-ui/icons";
 import { useSnackbar } from "notistack";
 import { useParams } from "react-router-dom";
@@ -167,6 +167,13 @@ export default function DatasetTable() {
                 field: "dataset_type",
                 lookup: datasetTypes,
                 editable: (columnDef, row) => !row.analyses.length,
+                render: rowData => (
+                    <>
+                        <Tooltip title={apiInfo?.dataset_types[rowData.dataset_type].name || " "}>
+                            <div>{rowData.dataset_type}</div>
+                        </Tooltip>
+                    </>
+                ),
             },
             {
                 title: "Condition",
@@ -245,6 +252,7 @@ export default function DatasetTable() {
         setHiddenColumns(columns);
         return columns;
     }, [
+        apiInfo?.dataset_types,
         conditions,
         currentUser,
         datasetTypes,

--- a/react/src/Datasets/components/DatasetTable.tsx
+++ b/react/src/Datasets/components/DatasetTable.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useRef, useState } from "react";
+import { useCallback, useMemo, useRef, useState } from "react";
 import { Column, EditComponentProps, MTableToolbar } from "@material-table/core";
 import { Chip, IconButton, makeStyles, Tooltip } from "@material-ui/core";
 import { Cancel, Delete, PlayArrow, Refresh, Visibility } from "@material-ui/icons";
@@ -114,6 +114,15 @@ export default function DatasetTable() {
         }
     }, [apiInfo]);
 
+    const RenderDatasetType = useCallback(
+        (rowData: Dataset) => (
+            <Tooltip title={apiInfo?.dataset_types[rowData.dataset_type].name || " "}>
+                <div>{rowData.dataset_type}</div>
+            </Tooltip>
+        ),
+        [apiInfo]
+    );
+
     const [showInfo, setShowInfo] = useState(false);
     const [infoDataset, setInfoDataset] = useState<Dataset>();
 
@@ -167,13 +176,7 @@ export default function DatasetTable() {
                 field: "dataset_type",
                 lookup: datasetTypes,
                 editable: (columnDef, row) => !row.analyses.length,
-                render: rowData => (
-                    <>
-                        <Tooltip title={apiInfo?.dataset_types[rowData.dataset_type].name || " "}>
-                            <div>{rowData.dataset_type}</div>
-                        </Tooltip>
-                    </>
-                ),
+                render: RenderDatasetType,
             },
             {
                 title: "Condition",
@@ -252,11 +255,11 @@ export default function DatasetTable() {
         setHiddenColumns(columns);
         return columns;
     }, [
-        apiInfo?.dataset_types,
         conditions,
         currentUser,
         datasetTypes,
         paramID,
+        RenderDatasetType,
         tissueSampleTypes,
         setInitialSorting,
         setHiddenColumns,

--- a/react/src/Datasets/components/DatasetTable.tsx
+++ b/react/src/Datasets/components/DatasetTable.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useRef, useState } from "react";
+import { useMemo, useRef, useState } from "react";
 import { Column, EditComponentProps, MTableToolbar } from "@material-table/core";
 import { Chip, IconButton, makeStyles } from "@material-ui/core";
 import { Cancel, Delete, PlayArrow, Refresh, Visibility } from "@material-ui/icons";
@@ -115,16 +115,6 @@ export default function DatasetTable() {
         }
     }, [apiInfo]);
 
-    const RenderDatasetType = useCallback(
-        (rowData: Dataset) =>
-            apiInfo && (
-                <TooltipDatasetType dataset_type={rowData.dataset_type}>
-                    <div>{rowData.dataset_type}</div>
-                </TooltipDatasetType>
-            ),
-        [apiInfo]
-    );
-
     const [showInfo, setShowInfo] = useState(false);
     const [infoDataset, setInfoDataset] = useState<Dataset>();
 
@@ -178,7 +168,11 @@ export default function DatasetTable() {
                 field: "dataset_type",
                 lookup: datasetTypes,
                 editable: (columnDef, row) => !row.analyses.length,
-                render: RenderDatasetType,
+                render: rowData => (
+                    <TooltipDatasetType dataset_type={rowData.dataset_type}>
+                        <div>{rowData.dataset_type}</div>
+                    </TooltipDatasetType>
+                ),
             },
             {
                 title: "Condition",
@@ -261,7 +255,6 @@ export default function DatasetTable() {
         currentUser,
         datasetTypes,
         paramID,
-        RenderDatasetType,
         tissueSampleTypes,
         setInitialSorting,
         setHiddenColumns,

--- a/react/src/Datasets/components/DatasetTable.tsx
+++ b/react/src/Datasets/components/DatasetTable.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useMemo, useRef, useState } from "react";
 import { Column, EditComponentProps, MTableToolbar } from "@material-table/core";
-import { Chip, IconButton, makeStyles, Tooltip } from "@material-ui/core";
+import { Chip, IconButton, makeStyles } from "@material-ui/core";
 import { Cancel, Delete, PlayArrow, Refresh, Visibility } from "@material-ui/icons";
 import { useSnackbar } from "notistack";
 import { useParams } from "react-router-dom";
@@ -14,6 +14,7 @@ import {
     FileLinkingComponent,
     MaterialTablePrimary,
     Note,
+    TooltipDatasetType,
 } from "../../components";
 import { useAPIInfoContext, useUserContext } from "../../contexts";
 import { resetAllTableFilters, rowDiff, toKeyValue, updateTableFilter } from "../../functions";
@@ -115,11 +116,12 @@ export default function DatasetTable() {
     }, [apiInfo]);
 
     const RenderDatasetType = useCallback(
-        (rowData: Dataset) => (
-            <Tooltip title={apiInfo?.dataset_types[rowData.dataset_type].name || " "}>
-                <div>{rowData.dataset_type}</div>
-            </Tooltip>
-        ),
+        (rowData: Dataset) =>
+            apiInfo && (
+                <TooltipDatasetType dataset_type={rowData.dataset_type}>
+                    <div>{rowData.dataset_type}</div>
+                </TooltipDatasetType>
+            ),
         [apiInfo]
     );
 

--- a/react/src/components/FieldDisplay.tsx
+++ b/react/src/components/FieldDisplay.tsx
@@ -1,25 +1,21 @@
-import { Tooltip, Typography } from "@material-ui/core";
-import { useAPIInfoContext } from "../contexts";
+import { Typography } from "@material-ui/core";
+import { TooltipDatasetType } from ".";
 import { formatDisplayValue } from "../functions";
 import { Field } from "../typings";
+
 export interface FieldDisplayProps {
     field: Field;
 }
 
 /* Simple Typography component to display "title: value" */
 export default function FieldDisplay({ field }: FieldDisplayProps) {
-    const apiInfo = useAPIInfoContext() ?? undefined;
     return (
         <Typography variant="body1" gutterBottom>
             <b>{field.title}:</b>{" "}
             {field.title === "Dataset Type" && typeof field.value === "string" ? (
-                <Tooltip
-                    title={apiInfo?.dataset_types[field.value].name || " "}
-                    arrow
-                    placement="top"
-                >
-                    <span>{field.value}</span>
-                </Tooltip>
+                <TooltipDatasetType dataset_type={field.value}>
+                    <span>{formatDisplayValue(field)}</span>
+                </TooltipDatasetType>
             ) : (
                 <span>{formatDisplayValue(field)}</span>
             )}

--- a/react/src/components/FieldDisplay.tsx
+++ b/react/src/components/FieldDisplay.tsx
@@ -1,18 +1,28 @@
-import React from "react";
-import { Typography } from "@material-ui/core";
-// import { formatFieldValue } from "../functions";
+import { Tooltip, Typography } from "@material-ui/core";
+import { useAPIInfoContext } from "../contexts";
 import { formatDisplayValue } from "../functions";
 import { Field } from "../typings";
-
 export interface FieldDisplayProps {
     field: Field;
 }
 
 /* Simple Typography component to display "title: value" */
 export default function FieldDisplay({ field }: FieldDisplayProps) {
+    const apiInfo = useAPIInfoContext() ?? undefined;
     return (
         <Typography variant="body1" gutterBottom>
-            <b>{field.title}:</b> <span>{formatDisplayValue(field)}</span>
+            <b>{field.title}:</b>{" "}
+            {field.title === "Dataset Type" && typeof field.value === "string" ? (
+                <Tooltip
+                    title={apiInfo?.dataset_types[field.value].name || " "}
+                    arrow
+                    placement="top"
+                >
+                    <span>{field.value}</span>
+                </Tooltip>
+            ) : (
+                <span>{formatDisplayValue(field)}</span>
+            )}
         </Typography>
     );
 }

--- a/react/src/components/TooltipDatasetType.tsx
+++ b/react/src/components/TooltipDatasetType.tsx
@@ -1,0 +1,17 @@
+import React from "react";
+import { Tooltip } from "@material-ui/core";
+import { useAPIInfoContext } from "../contexts";
+
+export interface TooltipDatasetTypeProps {
+    dataset_type: string;
+    children: React.ReactElement<any, any>;
+}
+
+export default function TooltipDatasetType({ dataset_type, children }: TooltipDatasetTypeProps) {
+    const apiInfo = useAPIInfoContext() ?? undefined;
+    return (
+        <Tooltip title={apiInfo?.dataset_types[dataset_type].name || " "} arrow placement="top">
+            {children}
+        </Tooltip>
+    );
+}

--- a/react/src/components/index.tsx
+++ b/react/src/components/index.tsx
@@ -38,3 +38,4 @@ export { default as Note } from "./Note";
 export { default as Notification } from "./Notification";
 export { default as NotificationPopover } from "./NotificationPopover";
 export { default as SecretDisplay } from "./SecretDisplay";
+export { default as TooltipDatasetType } from "./TooltipDatasetType";


### PR DESCRIPTION
Closes #1074 

Human-readable names for dataset types are added at the following places: 
![Screen Shot 2022-04-08 at 3 51 40 PM](https://user-images.githubusercontent.com/56279639/163259551-c450dfb4-6f86-46dd-b448-6de3e1fe1f85.png)
![Screen Shot 2022-04-08 at 3 52 02 PM](https://user-images.githubusercontent.com/56279639/163259557-8b778c54-9555-45f3-8104-7fc97a3e0796.png)
![Screen Shot 2022-04-08 at 3 52 18 PM](https://user-images.githubusercontent.com/56279639/163259560-4d971170-5d46-4406-a44b-0ffe61925255.png)
![Screen Shot 2022-04-08 at 3 51 25 PM](https://user-images.githubusercontent.com/56279639/163259622-06d12351-ddd9-4576-81ec-c1afa40cb25c.png)
![Screen Shot 2022-04-08 at 4 38 49 PM](https://user-images.githubusercontent.com/56279639/163259728-2a8cce3e-f3ac-4d34-841b-7975d048571b.png)
