### PR TITLE
Flask: package upgrade

### DIFF
--- a/flask/requirements-dev.txt
+++ b/flask/requirements-dev.txt
@@ -4,11 +4,11 @@
 #
 #    pip-compile requirements-dev.in
 #
-alembic==1.7.7
+alembic==1.8.0
     # via flask-migrate
 apscheduler==3.9.1
     # via -r requirements.in
-astroid==2.11.3
+astroid==2.11.5
     # via pylint
 attrs==21.4.0
     # via pytest
@@ -16,7 +16,7 @@ authlib==1.0.1
     # via -r requirements.in
 black==22.3.0
     # via -r requirements-dev.in
-certifi==2021.10.8
+certifi==2022.5.18.1
     # via
     #   minio
     #   requests
@@ -24,21 +24,21 @@ cffi==1.15.0
     # via cryptography
 charset-normalizer==2.0.12
     # via requests
-click==8.1.2
+click==8.1.3
     # via
     #   black
     #   flask
-coverage[toml]==6.3.2
+coverage[toml]==6.4.1
     # via pytest-cov
-cryptography==36.0.2
+cryptography==37.0.2
     # via
     #   authlib
     #   pymysql
 debugpy==1.6.0
     # via -r requirements-dev.in
-dill==0.3.4
+dill==0.3.5.1
     # via pylint
-flask==2.1.1
+flask==2.1.2
     # via
     #   -r requirements.in
     #   flask-login
@@ -46,7 +46,7 @@ flask==2.1.1
     #   flask-migrate
     #   flask-sqlalchemy
     #   prometheus-flask-exporter
-flask-login==0.6.0
+flask-login==0.6.1
     # via -r requirements.in
 flask-marshmallow==0.14.0
     # via -r requirements.in
@@ -62,7 +62,7 @@ gunicorn==20.1.0
     # via -r requirements.in
 idna==3.3
     # via requests
-importlib-metadata==4.11.3
+importlib-metadata==4.11.4
     # via flask
 iniconfig==1.1.1
     # via pytest
@@ -70,7 +70,7 @@ isort==5.10.1
     # via pylint
 itsdangerous==2.1.2
     # via flask
-jinja2==3.1.1
+jinja2==3.1.2
     # via flask
 lazy-object-proxy==1.7.1
     # via astroid
@@ -80,7 +80,7 @@ markupsafe==2.1.1
     # via
     #   jinja2
     #   mako
-marshmallow==3.15.0
+marshmallow==3.16.0
     # via
     #   flask-marshmallow
     #   marshmallow-sqlalchemy
@@ -88,11 +88,11 @@ marshmallow-sqlalchemy==0.28.0
     # via -r requirements.in
 mccabe==0.7.0
     # via pylint
-minio==7.1.7
+minio==7.1.8
     # via -r requirements.in
 mypy-extensions==0.4.3
     # via black
-numpy==1.22.3
+numpy==1.22.4
     # via pandas
 packaging==21.3
     # via
@@ -110,19 +110,19 @@ pluggy==1.0.0
     # via pytest
 prometheus-client==0.14.1
     # via prometheus-flask-exporter
-prometheus-flask-exporter==0.20.1
+prometheus-flask-exporter==0.20.2
     # via -r requirements.in
 py==1.11.0
     # via pytest
 pycparser==2.21
     # via cffi
-pylint==2.13.7
+pylint==2.14.1
     # via -r requirements-dev.in
 pymysql[rsa]==1.0.2
     # via -r requirements.in
-pyparsing==3.0.8
+pyparsing==3.0.9
     # via packaging
-pytest==7.1.1
+pytest==7.1.2
     # via
     #   -r requirements-dev.in
     #   pytest-cov
@@ -144,6 +144,8 @@ requests==2.27.1
     # via -r requirements.in
 sendgrid==6.9.7
     # via -r requirements.in
+setproctitle==1.2.3
+    # via -r requirements.in
 six==1.16.0
     # via
     #   apscheduler
@@ -151,7 +153,7 @@ six==1.16.0
     #   python-dateutil
 slurm-rest==0.0.37.1
     # via -r requirements.in
-sqlalchemy==1.4.35
+sqlalchemy==1.4.37
     # via
     #   -r requirements.in
     #   alembic
@@ -165,6 +167,8 @@ tomli==2.0.1
     #   coverage
     #   pylint
     #   pytest
+tomlkit==0.11.0
+    # via pylint
 typing-extensions==4.2.0
     # via
     #   astroid
@@ -179,11 +183,11 @@ urllib3==1.26.9
     #   minio
     #   requests
     #   slurm-rest
-werkzeug==2.1.1
+werkzeug==2.1.2
     # via
     #   flask
     #   flask-login
-wrapt==1.14.0
+wrapt==1.14.1
     # via astroid
 zipp==3.8.0
     # via importlib-metadata

--- a/flask/requirements.in
+++ b/flask/requirements.in
@@ -13,5 +13,6 @@ prometheus-flask-exporter
 pymysql[rsa]
 requests
 sendgrid
+setproctitle
 slurm-rest
 sqlalchemy

--- a/flask/requirements.txt
+++ b/flask/requirements.txt
@@ -4,13 +4,13 @@
 #
 #    pip-compile
 #
-alembic==1.7.7
+alembic==1.8.0
     # via flask-migrate
 apscheduler==3.9.1
     # via -r requirements.in
 authlib==1.0.1
     # via -r requirements.in
-certifi==2021.10.8
+certifi==2022.5.18.1
     # via
     #   minio
     #   requests
@@ -18,13 +18,13 @@ cffi==1.15.0
     # via cryptography
 charset-normalizer==2.0.12
     # via requests
-click==8.1.2
+click==8.1.3
     # via flask
-cryptography==36.0.2
+cryptography==37.0.2
     # via
     #   authlib
     #   pymysql
-flask==2.1.1
+flask==2.1.2
     # via
     #   -r requirements.in
     #   flask-login
@@ -32,7 +32,7 @@ flask==2.1.1
     #   flask-migrate
     #   flask-sqlalchemy
     #   prometheus-flask-exporter
-flask-login==0.6.0
+flask-login==0.6.1
     # via -r requirements.in
 flask-marshmallow==0.14.0
     # via -r requirements.in
@@ -48,11 +48,11 @@ gunicorn==20.1.0
     # via -r requirements.in
 idna==3.3
     # via requests
-importlib-metadata==4.11.3
+importlib-metadata==4.11.4
     # via flask
 itsdangerous==2.1.2
     # via flask
-jinja2==3.1.1
+jinja2==3.1.2
     # via flask
 mako==1.2.0
     # via alembic
@@ -60,15 +60,15 @@ markupsafe==2.1.1
     # via
     #   jinja2
     #   mako
-marshmallow==3.15.0
+marshmallow==3.16.0
     # via
     #   flask-marshmallow
     #   marshmallow-sqlalchemy
 marshmallow-sqlalchemy==0.28.0
     # via -r requirements.in
-minio==7.1.7
+minio==7.1.8
     # via -r requirements.in
-numpy==1.22.3
+numpy==1.22.4
     # via pandas
 packaging==21.3
     # via marshmallow
@@ -76,13 +76,13 @@ pandas==1.4.2
     # via -r requirements.in
 prometheus-client==0.14.1
     # via prometheus-flask-exporter
-prometheus-flask-exporter==0.20.1
+prometheus-flask-exporter==0.20.2
     # via -r requirements.in
 pycparser==2.21
     # via cffi
 pymysql[rsa]==1.0.2
     # via -r requirements.in
-pyparsing==3.0.8
+pyparsing==3.0.9
     # via packaging
 python-dateutil==2.8.2
     # via
@@ -100,6 +100,8 @@ requests==2.27.1
     # via -r requirements.in
 sendgrid==6.9.7
     # via -r requirements.in
+setproctitle==1.2.3
+    # via -r requirements.in
 six==1.16.0
     # via
     #   apscheduler
@@ -107,7 +109,7 @@ six==1.16.0
     #   python-dateutil
 slurm-rest==0.0.37.1
     # via -r requirements.in
-sqlalchemy==1.4.35
+sqlalchemy==1.4.37
     # via
     #   -r requirements.in
     #   alembic
@@ -124,7 +126,7 @@ urllib3==1.26.9
     #   minio
     #   requests
     #   slurm-rest
-werkzeug==2.1.1
+werkzeug==2.1.2
     # via
     #   flask
     #   flask-login


### PR DESCRIPTION
There's a lot, so I rolled them up into one

New:
- setproctitle: https://docs.gunicorn.org/en/latest/faq.html#how-can-i-name-processes

Primary dependencies:
- flask
- flask-login
- minio
- prometheus-flask-exporter
- sqlalchemy